### PR TITLE
Fix 404 for the homepage link

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Currently formalized sections:
 
 
 Other resources:
-- [Web page for this project](https://teorth.github.io/Analysis/)
+- [Web page for this project](https://teorth.github.io/analysis/)
 - [Web page for the book](https://terrytao.wordpress.com/books/analysis-i/)
   - [Springer edition](https://link.springer.com/book/10.1007/978-981-19-7261-4)
 - [How to run a project in Lean locally](https://leanprover-community.github.io/install/project.html)


### PR DESCRIPTION
It appears that the uppercased link may result in 404 on the GitHub page for some browsers.