### PR TITLE
Fix links to formalized sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,26 +9,27 @@ While the arrangement of definitions, theorems, and proofs here are closely para
 Much of the material in this text is duplicated in Lean's standard math library [Mathlib](https://leanprover-community.github.io/mathlib4_docs/), though with slightly different definitions.  To reconcile these discrepancies, this formalization will gradually transition from the textbook-provided definitions to the Mathlib-provided definitions as one progresses further into the text, thus sacrificing the self-containedness of the formalization in favor of compatibility with Mathlib.  For instance, Chapter 2 develops a theory of the natural numbers independent of Mathlib, but all subsequent chapters will use the Mathlib natural numbers instead.  (An epilogue to Chapter 2 is provided to show that the two notions of the natural numbers are isomorphic.)  As such, this formalization can also be used as an introduction to various portions of Mathlib.
 
 In order to align the formalization with Mathlib conventions, a small number of technical changes have been made to some of the definitions as compared with the textbook version.  Most notably:
+
 - Sequences are indexed to start from zero rather than from one, as Mathlib has much more support for the 0-based natural numbers `ℕ` than the 1-based natural numbers.
 - Many operations that are left undefined in the text, such as division by zero, or taking the formal limit of a non-Cauchy sequence, are instead assigned a "junk" value (e.g., `0`) to make the operation totally defined.  This is because Lean has better support for total functions than partial functions (indiscriminate use of the latter can lead into "dependent type hell" in which even very basic manipulations require quite subtle and delicate proofs).  See for instance [this blog post](https://xenaproject.wordpress.com/2020/07/05/division-by-zero-in-type-theory-a-faq/) by Kevin Buzzard for more discussion.
 
 Currently formalized sections:
 
-- [Section 2.1: The Peano axioms](https://teorth.github.io/analysis/sec21/)
-- [Section 2.2: Addition](https://teorth.github.io/analysis/sec22/)
-- [Section 2.3: Multiplication](https://teorth.github.io/analysis/sec23/)
-- [Chapter 2 epilogue: Isomorphism with the Mathlib natural numbers](https://teorth.github.io/analysis/sec2e/)
-- [Section 3.1: Set theory fundamentals](https://teorth.github.io/analysis/sec31/)
-- [Section 4.1: The integers](https://teorth.github.io/analysis/sec41/)
-- [Section 4.2: The rationals](https://teorth.github.io/analysis/sec42/)
-- [Section 4.3: Absolute value and exponentiation](https://teorth.github.io/analysis/sec43/)
-- [Section 5.1: Cauchy sequences of rationals](https://teorth.github.io/analysis/sec51/)
-- [Section 5.2: Equivalent Cauchy sequences](https://teorth.github.io/analysis/sec52/)
-- [Section 5.3: Construction of the real numbers](https://teorth.github.io/analysis/sec53/)
-- [Section 5.4: Ordering the reals](https://teorth.github.io/analysis/sec54/)
-
+- [Section 2.1: The Peano axioms](https://teorth.github.io/analysis/docs/Analysis/Section_2_1.html)
+- [Section 2.2: Addition](https://teorth.github.io/analysis/docs/Analysis/Section_2_2.html)
+- [Section 2.3: Multiplication](https://teorth.github.io/analysis/docs/Analysis/Section_2_3.html)
+- [Chapter 2 epilogue: Isomorphism with the Mathlib natural numbers](https://teorth.github.io/analysis/docs/Analysis/Section_2_analysis/docs/.html)
+- [Section 3.1: Set theory fundamentals](https://teorth.github.io/analysis/docs/Analysis/Section_3_1.html)
+- [Section 4.1: The integers](https://teorth.github.io/analysis/docs/Analysis/Section_4_1.html)
+- [Section 4.2: The rationals](https://teorth.github.io/analysis/docs/Analysis/Section_4_2.html)
+- [Section 4.3: Absolute value and exponentiation](https://teorth.github.io/analysis/docs/Analysis/Section_4_3.html)
+- [Section 5.1: Cauchy sequences of rationals](https://teorth.github.io/analysis/docs/Analysis/Section_5_1.html)
+- [Section 5.2: Equivalent Cauchy sequences](https://teorth.github.io/analysis/docs/Analysis/Section_5_2.html)
+- [Section 5.3: Construction of the real numbers](https://teorth.github.io/analysis/docs/Analysis/Section_5_3.html)
+- [Section 5.4: Ordering the reals](https://teorth.github.io/analysis/docs/Analysis/Section_5_4.html)
 
 Other resources:
+
 - [Web page for this project](https://teorth.github.io/analysis/)
 - [Web page for the book](https://terrytao.wordpress.com/books/analysis-i/)
   - [Springer edition](https://link.springer.com/book/10.1007/978-981-19-7261-4)
@@ -37,6 +38,7 @@ Other resources:
 - [Notes for contributors](./CONTRIBUTING.md)
 
 General Lean resources:
+
 - [The Lean community](https://leanprover-community.github.io/)
   - [Lean4 web playground](https://live.lean-lang.org/)
   - [How to run a project in Lean locally](https://leanprover-community.github.io/install/project.html)
@@ -56,8 +58,7 @@ General Lean resources:
 - [Common Lean pitfalls](https://github.com/nielsvoss/lean-pitfalls)
 - [Lean4 questions in Proof Stack Exchange](https://proofassistants.stackexchange.com/questions/tagged/lean4)
 - [The mechanics of proof](https://hrmacbeth.github.io/math2001/) - introductory Lean textbook by Heather Macbeth
-- [My Youtube channel](https://www.youtube.com/@TerenceTao27) has some demonstrations of various Lean formalization, using a variety of tools. 
+- [My Youtube channel](https://www.youtube.com/@TerenceTao27) has some demonstrations of various Lean formalization, using a variety of tools.
 - A [broader list](https://docs.google.com/document/d/1kD7H4E28656ua8jOGZ934nbH2HcBLyxcRgFDduH5iQ0) of AI and formal mathematics resources.
-
 
 More resource suggestions welcome!


### PR DESCRIPTION
The current links to the formalized sections are broken. This PR fixes that, along with some minor formatting fixes (using a Github markdown formatter).