### PR TITLE
Styling and lemma fixes

### DIFF
--- a/book/lake-manifest.json
+++ b/book/lake-manifest.json
@@ -5,7 +5,7 @@
    "type": "git",
    "subDir": null,
    "scope": "",
-   "rev": "a71fb6d4153ff528186aef3df20732076f71509f",
+   "rev": "56d79b34f49586d95ac0a7c3d71f1342469d025d",
    "name": "verso",
    "manifestFile": "lake-manifest.json",
    "inputRev": "analysis",

--- a/book/static_files/style.css
+++ b/book/static_files/style.css
@@ -51,3 +51,11 @@ code span {
 body {
     font-family: "Source Sans 3","Helvetica Neue","Segoe UI","Roboto",Arial,sans-serif;
 }
+
+div.declaration {
+    border-top: 1px solid #c0c0d0;
+    padding-top: 1em;
+    padding-bottom: 1em;
+    margin-top: 1em;
+    margin-bottom: 1em;
+}


### PR DESCRIPTION
This PR updates to a patched Verso which:

- Allows styling around defintions with docstrings, used to include line as visual separator
- Also parses docstrings on lemma's, which were missed before