### PR TITLE
Workaround for crash in converting section 7.1 to Verso

### DIFF
--- a/analysis/Analysis/Section_7_1.lean
+++ b/analysis/Analysis/Section_7_1.lean
@@ -249,7 +249,8 @@ theorem finite_series_of_finite_series {XX YY:Type*} (X: Finset XX) (Y: Finset Y
         intro ⟨ y, hy ⟩
         use ⟨ (x₀, y), by simp [hy] ⟩
       convert map_finite_series _ hπ with z
-      obtain ⟨ ⟨ x, y ⟩, hz ⟩ := z
+      obtain ⟨ xy , hz ⟩ := z
+      obtain ⟨x, y⟩ := xy
       simp at hz ⊢; tauto
     _ = _ := by
       convert (finite_series_of_disjoint_union _ _).symm

--- a/analysis/Analysis/Section_7_1.lean
+++ b/analysis/Analysis/Section_7_1.lean
@@ -100,7 +100,8 @@ theorem finite_series_of_rearrange {n:ℕ} {X':Type*} (X: Finset X') (hcard: X.c
   rw [sum_of_nonempty (by linarith) _]
   set x := g (π (n+1))
 
-  obtain ⟨ ⟨ j, hj' ⟩, hj ⟩ := Function.Bijective.surjective hh x
+  obtain ⟨j', hj⟩ := Function.Bijective.surjective hh x
+  obtain ⟨j, hj'⟩ := j'
   simp at hj'
   obtain ⟨ hj1, hj2 ⟩ := hj'
   set h' : ℤ → X := fun i ↦ if (i:ℤ) < j then h (π i) else h (π (i+1))
@@ -180,7 +181,8 @@ theorem finite_series_eq {n:ℕ} {Y:Type*} (X: Finset Y) (f: Y → ℝ) (g: Icc 
   . intro i hi j hj h
     simp [Subtype.val_inj, (Function.Bijective.injective hg).eq_iff] at h; assumption
   . intro b hb
-    obtain ⟨ ⟨ i, hi ⟩, h ⟩ := (Function.Bijective.surjective hg) ⟨ b, hb ⟩
+    obtain ⟨hi', h⟩ := (Function.Bijective.surjective hg) ⟨ b, hb ⟩
+    obtain ⟨i, hi⟩ := hi'
     use i, hi; simp [h]
   intro i hi; simp [hi]
 

--- a/book/AnalysisBook.lean
+++ b/book/AnalysisBook.lean
@@ -70,7 +70,7 @@ def demoSite : Site := site AnalysisBook.Home /
   "sec65" Book.Analysis.Section_6_5
   "sec66" Book.Analysis.Section_6_6
   "sec6e" Book.Analysis.Section_6_epilogue
---  "sec71" Book.Analysis.Section_7_1
+ "sec71" Book.Analysis.Section_7_1
 
 def baseUrl := "https://teorth.github.io/analysis/docs/"
 

--- a/book/AnalysisBook.lean
+++ b/book/AnalysisBook.lean
@@ -70,7 +70,7 @@ def demoSite : Site := site AnalysisBook.Home /
   "sec65" Book.Analysis.Section_6_5
   "sec66" Book.Analysis.Section_6_6
   "sec6e" Book.Analysis.Section_6_epilogue
- "sec71" Book.Analysis.Section_7_1
+  "sec71" Book.Analysis.Section_7_1
 
 def baseUrl := "https://teorth.github.io/analysis/docs/"
 

--- a/book/lakefile.lean
+++ b/book/lakefile.lean
@@ -49,8 +49,8 @@ def sections := #[
   (`Analysis.Section_6_4, "Limsup, Liminf, and limit points"),
   (`Analysis.Section_6_5, "Some standard limits"),
   (`Analysis.Section_6_6, "Subsequences"),
-  (`Analysis.Section_6_epilogue, "Connections with Mathlib limits")
---  (`Analysis.Section_7_1, "Finite series")
+  (`Analysis.Section_6_epilogue, "Connections with Mathlib limits"),
+ (`Analysis.Section_7_1, "Finite series")
 ]
 
 /--


### PR DESCRIPTION
Apparently the Verso conversion does not work with an obtain that's nested in the first variable. I'm not entirely sure what the scope of this bug is, and I'll try to investigate a bit further, but in theory this should fix the build for now.