### PR TITLE
Chore: make files mathlib line length compliant

### DIFF
--- a/analysis/Analysis/Section_2_1.lean
+++ b/analysis/Analysis/Section_2_1.lean
@@ -3,23 +3,39 @@ import Mathlib.Tactic
 /-!
 # Analysis I, Section 2.1
 
-This file is a translation of Section 2.1 of Analysis I to Lean 4.  All numbering refers to the original text.
+This file is a translation of Section 2.1 of Analysis I to Lean 4.  All numbering refers to the
+original text.
 
-I have attempted to make the translation as faithful a paraphrasing as possible of the original text.  When there is a choice between a more idiomatic Lean solution and a more faithful translation, I have generally chosen the latter.  In particular, there will be places where the Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided doing so.
+I have attempted to make the translation as faithful a paraphrasing as possible of the original
+text.  When there is a choice between a more idiomatic Lean solution and a more faithful
+translation, I have generally chosen the latter.  In particular, there will be places where the
+Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided doing
+so.
 
 Main constructions and results of this section:
 
-- Definition of the "Chapter 2" natural numbers, `Chapter2.Nat`, abbreviated as `Nat` within the `Chapter2` namespace. (In the book, the natural numbers are treated in a purely axiomatic fashion, as a type that obeys the Peano axioms; but here we take advantage of Lean's native inductive types to explicitly construct a version of the natural numbers that obey those axioms.  One could also proceed more axiomatically, as is done in Section 3 for set theory, but we leave this as an exercise for the reader.)
+- Definition of the "Chapter 2" natural numbers, `Chapter2.Nat`, abbreviated as `Nat` within the
+  `Chapter2` namespace. (In the book, the natural numbers are treated in a purely axiomatic
+  fashion, as a type that obeys the Peano axioms; but here we take advantage of Lean's native
+  inductive types to explicitly construct a version of the natural numbers that obey those
+  axioms.  One could also proceed more axiomatically, as is done in Section 3 for set theory, but
+  we leave this as an exercise for the reader.)
 - Establishment of the Peano axioms for `Chapter2.Nat`
 - Recursive definitions for `Chapter2.Nat`
 
-Note: at the end of this Chapter, the `Chapter2.Nat` class will be deprecated in favor of the standard Mathlib class `_root_.Nat`, or `ℕ`.  However, we will develop the properties of `Chapter2.Nat` "by hand" in the next few sections for pedagogical purposes.
+Note: at the end of this Chapter, the `Chapter2.Nat` class will be deprecated in favor of the
+standard Mathlib class `_root_.Nat`, or `ℕ`.  However, we will develop the properties of
+`Chapter2.Nat` "by hand" in the next few sections for pedagogical purposes.
 
 -/
 
 namespace Chapter2
 
-/-- Assumption 2.6 (Existence of natural numbers).  Here we use an explicit construction of the natural numbers (using an inductive type).  For a more axiomatic approach, see the epilogue to this chapter. -/
+/--
+  Assumption 2.6 (Existence of natural numbers).  Here we use an explicit construction of the
+  natural numbers (using an inductive type).  For a more axiomatic approach, see the epilogue to
+  this chapter.
+-/
 inductive Nat where
 | zero : Nat
 | succ : Nat → Nat
@@ -34,7 +50,11 @@ postfix:100 "++" => Nat.succ
 #check (fun n ↦ n++)
 
 
-/-- Definition 2.1.3 (Definition of the numerals 0, 1, 2, etc.). Note: to avoid ambiguity, one may need to use explicit casts such as (0:Nat), (1:Nat), etc. to refer to this Chapter's version of the natural numbers. -/
+/--
+  Definition 2.1.3 (Definition of the numerals 0, 1, 2, etc.). Note: to avoid ambiguity, one may
+  need to use explicit casts such as (0:Nat), (1:Nat), etc. to refer to this Chapter's version of
+  the natural numbers.
+-/
 instance Nat.instOfNat {n:_root_.Nat} : OfNat Nat n where
   ofNat := _root_.Nat.rec 0 (fun _ n ↦ n++) n
 
@@ -49,7 +69,10 @@ lemma Nat.one_succ : 1++ = 2 := by rfl
 lemma Nat.two_succ : 2++ = 3 := by rfl
 #check (3:Nat)
 
-/-- Axiom 2.3 (0 is not the successor of any natural number).  Compare with Mathlib's `Nat.succ_ne_zero` -/
+/--
+  Axiom 2.3 (0 is not the successor of any natural number).
+  Compare with Mathlib's `Nat.succ_ne_zero`.
+-/
 theorem Nat.succ_ne (n:Nat) : n++ ≠ 0 := by
   by_contra h
   simp only [reduceCtorEq] at h
@@ -61,11 +84,17 @@ theorem Nat.four_ne : (4:Nat) ≠ 0 := by
   -- By axiom 2.3, 3++ is not zero.
   exact succ_ne _
 
-/-- Axiom 2.4 (Different natural numbers have different successors).  Compare with Mathlib's `Nat.succ_inj` -/
+/--
+  Axiom 2.4 (Different natural numbers have different successors).
+  Compare with Mathlib's `Nat.succ_inj`.
+-/
 theorem Nat.succ_cancel {n m:Nat} (hnm: n++ = m++) : n = m := by
   rwa [succ.injEq] at hnm
 
-/-- Axiom 2.4 (Different natural numbers have different successors).  Compare with Mathlib's `Nat.succ_ne_succ` -/
+/--
+  Axiom 2.4 (Different natural numbers have different successors).
+  Compare with Mathlib's `Nat.succ_ne_succ`.
+-/
 theorem Nat.succ_ne_succ (n m:Nat) : n ≠ m → n++ ≠ m++ := by
   intro h
   contrapose! h
@@ -86,14 +115,21 @@ theorem Nat.six_ne_two : (6:Nat) ≠ 2 := by
 theorem Nat.six_ne_two' : (6:Nat) ≠ 2 := by
   decide
 
-/-- Axiom 2.5 (principle of mathematical induction). The `induction` (or `induction'`) tactic in Mathlib serve as a substitute for this axiom. -/
-theorem Nat.induction (P : Nat → Prop) (hbase : P 0) (hind : ∀ n, P n → P (n++)) : ∀ n, P n := by
+/--
+  Axiom 2.5 (principle of mathematical induction). The `induction` (or `induction'`) tactic in
+  Mathlib serve as a substitute for this axiom.
+-/
+theorem Nat.induction (P : Nat → Prop) (hbase : P 0) (hind : ∀ n, P n → P (n++)) :
+    ∀ n, P n := by
   intro n
   induction n with
   | zero => exact hbase
   | succ n ih => exact hind _ ih
 
-/-- Recursion.  Analogous to the inbuilt Mathlib method `Nat.rec` associated to the Mathlib natural numbers -/
+/--
+  Recursion. Analogous to the inbuilt Mathlib method `Nat.rec` associated to
+  the Mathlib natural numbers
+-/
 abbrev Nat.recurse (f: Nat → Nat → Nat) (c: Nat) : Nat → Nat := fun n ↦ match n with
 | 0 => c
 | n++ => f n (recurse f c n)
@@ -102,10 +138,12 @@ abbrev Nat.recurse (f: Nat → Nat → Nat) (c: Nat) : Nat → Nat := fun n ↦ 
 theorem Nat.recurse_zero (f: Nat → Nat → Nat) (c: Nat) : Nat.recurse f c 0 = c := by rfl
 
 /-- Proposition 2.1.16 (recursive definitions). Compare with Mathlib's `Nat.rec_add_one`. -/
-theorem Nat.recurse_succ (f: Nat → Nat → Nat) (c: Nat) (n: Nat) : recurse f c (n++) = f n (recurse f c n) := by rfl
+theorem Nat.recurse_succ (f: Nat → Nat → Nat) (c: Nat) (n: Nat) :
+    recurse f c (n++) = f n (recurse f c n) := by rfl
 
 /-- Proposition 2.1.16 (recursive definitions). -/
-theorem Nat.eq_recurse (f: Nat → Nat → Nat) (c: Nat) (a: Nat → Nat) : (a 0 = c ∧ ∀ n, a (n++) = f n (a n)) ↔ a = recurse f c := by
+theorem Nat.eq_recurse (f: Nat → Nat → Nat) (c: Nat) (a: Nat → Nat) :
+    (a 0 = c ∧ ∀ n, a (n++) = f n (a n)) ↔ a = recurse f c := by
   constructor
   . intro ⟨ h0, hsucc ⟩
     -- this proof is written to follow the structure of the original text.
@@ -121,12 +159,13 @@ theorem Nat.eq_recurse (f: Nat → Nat → Nat) (c: Nat) (a: Nat → Nat) : (a 0
 
 
 /-- Proposition 2.1.16 (recursive definitions). -/
-theorem Nat.recurse_uniq (f: Nat → Nat → Nat) (c: Nat) : ∃! (a: Nat → Nat), a 0 = c ∧ ∀ n, a (n++) = f n (a n) := by
-apply ExistsUnique.intro (recurse f c)
-. constructor
-  . exact recurse_zero _ _
-  . exact recurse_succ _ _
-intro a
-exact (eq_recurse _ _ a).mp
+theorem Nat.recurse_uniq (f: Nat → Nat → Nat) (c: Nat) :
+    ∃! (a: Nat → Nat), a 0 = c ∧ ∀ n, a (n++) = f n (a n) := by
+  apply ExistsUnique.intro (recurse f c)
+  . constructor
+    . exact recurse_zero _ _
+    . exact recurse_succ _ _
+  intro a
+  exact (eq_recurse _ _ a).mp
 
 end Chapter2

--- a/analysis/Analysis/Section_2_2.lean
+++ b/analysis/Analysis/Section_2_2.lean
@@ -4,16 +4,23 @@ import Analysis.Section_2_1
 /-!
 # Analysis I, Section 2.2
 
-This file is a translation of Section 2.2 of Analysis I to Lean 4.  All numbering refers to the original text.
+This file is a translation of Section 2.2 of Analysis I to Lean 4.
+All numbering refers to the original text.
 
-I have attempted to make the translation as faithful a paraphrasing as possible of the original text.   When there is a choice between a more idiomatic Lean solution and a more faithful translation, I have generally chosen the latter.  In particular, there will be places where the Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided doing so.
+I have attempted to make the translation as faithful a paraphrasing as possible of the original
+text. When there is a choice between a more idiomatic Lean solution and a more faithful
+translation, I have generally chosen the latter.  In particular, there will be places where the
+Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided
+doing so.
 
 Main constructions and results of this section:
 
 - Definition of addition and order for the "Chapter 2" natural numbers, `Chapter2.Nat`
 - Establishment of basic properties of addition and order
 
-Note: at the end of this chapter, the `Chapter2.Nat` class will be deprecated in favor of the standard Mathlib class `_root_.Nat`, or `ℕ`.  However, we will develop the properties of `Chapter2.Nat` "by hand" for pedagogical purposes.
+Note: at the end of this chapter, the `Chapter2.Nat` class will be deprecated in favor of the
+standard Mathlib class `_root_.Nat`, or `ℕ`.  However, we will develop the properties of
+`Chapter2.Nat` "by hand" for pedagogical purposes.
 -/
 
 namespace Chapter2
@@ -130,7 +137,11 @@ theorem Nat.add_eq_zero (a b:Nat) (hab: a + b = 0) : a = 0 ∧ b = 0 := by
   have : (a + b).isPos := add_pos _ hb
   contradiction
 
--- The following API for ∃! may be useful for the next problem.  Also, the `obtain` tactic is useful for extracting witnesses from existential statements; for instance, `obtain ⟨ x, hx ⟩ := h` extracts a witness `x` and a proof `hx : P x` of the property from a hypothesis `h : ∃ x, P x`.
+/-
+The following API for ∃! may be useful for the next problem.  Also, the `obtain` tactic is useful
+for extracting witnesses from existential statements; for instance, `obtain ⟨ x, hx ⟩ := h`
+extracts a witness `x` and a proof `hx : P x` of the property from a hypothesis `h : ∃ x, P x`.
+-/
 
 #check existsUnique_of_exists_of_unique
 #check ExistsUnique.exists
@@ -248,7 +259,13 @@ theorem Nat.trichotomous (a b:Nat) : a < b ∨ a = b ∨ a > b := by
   have why : a++ > b := by sorry
   tauto
 
-/-- (Not from textbook) Establish the decidability of this order computably.  The portion of the proof involving decidability has been provided; the remaining sorries involve claims about the natural numbers.  One could also have established this result by the `classical` tactic followed by `exact Classical.decRel _`, but this would make this definition (as well as some instances below) noncomputable. -/
+/--
+  (Not from textbook) Establish the decidability of this order computably.  The portion of the
+  proof involving decidability has been provided; the remaining sorries involve claims about the
+  natural numbers.  One could also have established this result by the `classical` tactic
+  followed by `exact Classical.decRel _`, but this would make this definition (as well as some
+  instances below) noncomputable.
+-/
 def Nat.le_dec : (a b : Nat) → Decidable (a ≤ b)
   | 0, b => by
     apply isTrue
@@ -287,15 +304,20 @@ instance Nat.isOrderedAddMonoid : IsOrderedAddMonoid Nat where
 
 /-- Proposition 2.2.14 (Strong principle of induction) / Exercise 2.2.5
 -/
-theorem Nat.strong_induction {m₀:Nat} {P: Nat → Prop} (hind: ∀ m, m ≥ m₀ → (∀ m', m₀ ≤ m' ∧ m' < m → P m') → P m) : ∀ m, m ≥ m₀ → P m := by
+theorem Nat.strong_induction {m₀:Nat} {P: Nat → Prop}
+  (hind: ∀ m, m ≥ m₀ → (∀ m', m₀ ≤ m' ∧ m' < m → P m') → P m) :
+    ∀ m, m ≥ m₀ → P m := by
   sorry
 
 /-- Exercise 2.2.6 (backwards induction) -/
-theorem Nat.backwards_induction {n:Nat} {P: Nat → Prop}  (hind: ∀ m, P (m++) → P m) (hn: P n) : ∀ m, m ≤ n → P m := by
+theorem Nat.backwards_induction {n:Nat} {P: Nat → Prop}
+  (hind: ∀ m, P (m++) → P m) (hn: P n) :
+    ∀ m, m ≤ n → P m := by
   sorry
 
 /-- Exercise 2.2.7 (induction from a starting point) -/
-theorem Nat.induction_from {n:Nat} {P: Nat → Prop} (hind: ∀ m, P m → P (m++)) : P n → ∀ m, m ≥ n → P m := by
+theorem Nat.induction_from {n:Nat} {P: Nat → Prop} (hind: ∀ m, P m → P (m++)) :
+    P n → ∀ m, m ≥ n → P m := by
   sorry
 
 

--- a/analysis/Analysis/Section_2_3.lean
+++ b/analysis/Analysis/Section_2_3.lean
@@ -4,15 +4,23 @@ import Analysis.Section_2_2
 /-!
 # Analysis I, Section 2.3
 
-This file is a translation of Section 2.3 of Analysis I to Lean 4.  All numbering refers to the original text.
+This file is a translation of Section 2.3 of Analysis I to Lean 4.
+All numbering refers to the original text.
 
-I have attempted to make the translation as faithful a paraphrasing as possible of the original text.  When there is a choice between a more idiomatic Lean solution and a more faithful translation, I have generally chosen the latter.  In particular, there will be places where the Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided doing so.
+I have attempted to make the translation as faithful a paraphrasing as possible of the original
+text. When there is a choice between a more idiomatic Lean solution and a more faithful
+translation, I have generally chosen the latter.  In particular, there will be places where the
+Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided
+doing so.
 
 Main constructions and results of this section:
 
-- Definition of multiplication and exponentiation for the "Chapter 2" natural numbers, `Chapter2.Nat`
+- Definition of multiplication and exponentiation for the "Chapter 2" natural numbers,
+  `Chapter2.Nat`
 
-Note: at the end of this chapter, the `Chapter2.Nat` class will be deprecated in favor of the standard Mathlib class `_root_.Nat`, or `ℕ`.  However, we will develop the properties of `Chapter2.Nat` "by hand" for pedagogical purposes.
+Note: at the end of this chapter, the `Chapter2.Nat` class will be deprecated in favor of the
+standard Mathlib class `_root_.Nat`, or `ℕ`.  However, we will develop the properties of
+`Chapter2.Nat` "by hand" for pedagogical purposes.
 -/
 
 namespace Chapter2
@@ -101,7 +109,8 @@ theorem Nat.mul_lt_mul_of_pos_right {a b c: Nat} (h: a < b) (hc: c.isPos) : a * 
   use d*c
 
 /-- Proposition 2.3.6 (Multiplication preserves order) -/
-theorem Nat.mul_gt_mul_of_pos_right {a b c: Nat} (h: a > b) (hc: c.isPos) : a * c > b * c := mul_lt_mul_of_pos_right h hc
+theorem Nat.mul_gt_mul_of_pos_right {a b c: Nat} (h: a > b) (hc: c.isPos) :
+    a * c > b * c := mul_lt_mul_of_pos_right h hc
 
 /-- Proposition 2.3.6 (Multiplication preserves order) -/
 theorem Nat.mul_lt_mul_of_pos_left {a b c: Nat} (h: a < b) (hc: c.isPos) : c * a < c * b := by
@@ -109,7 +118,8 @@ theorem Nat.mul_lt_mul_of_pos_left {a b c: Nat} (h: a < b) (hc: c.isPos) : c * a
   exact mul_lt_mul_of_pos_right h hc
 
 /-- Proposition 2.3.6 (Multiplication preserves order) -/
-theorem Nat.mul_gt_mul_of_pos_left {a b c: Nat} (h: a > b) (hc: c.isPos) : c * a > c * b := mul_lt_mul_of_pos_left h hc
+theorem Nat.mul_gt_mul_of_pos_left {a b c: Nat} (h: a > b) (hc: c.isPos) :
+    c * a > c * b := mul_lt_mul_of_pos_left h hc
 
 
 
@@ -134,7 +144,8 @@ instance Nat.isOrderedRing : IsOrderedRing Nat where
 
 
 /-- Proposition 2.3.9 (Euclid's division lemma) / Exercise 2.3.5 -/
-theorem Nat.exists_div_mod (n :Nat) {q: Nat} (hq: q.isPos) : ∃ m r: Nat, 0 ≤ r ∧ r < q ∧ n = m * q + r := by
+theorem Nat.exists_div_mod (n :Nat) {q: Nat} (hq: q.isPos) :
+    ∃ m r: Nat, 0 ≤ r ∧ r < q ∧ n = m * q + r := by
   sorry
 
 /-- Definition 2.3.11 (Exponentiation for natural numbers) -/
@@ -147,13 +158,12 @@ instance Nat.instPow : HomogeneousPow Nat where
 theorem Nat.zero_pow_zero : (0:Nat) ^ 0 = 1 := recurse_zero (fun _ prod ↦ prod * 0) _
 
 /-- Definition 2.3.11 (Exponentiation for natural numbers) -/
-theorem Nat.pow_succ (m n: Nat) : (m:Nat) ^ n++ = m^n * m := recurse_succ (fun _ prod ↦ prod * m) _ _
+theorem Nat.pow_succ (m n: Nat) : (m:Nat) ^ n++ = m^n * m :=
+  recurse_succ (fun _ prod ↦ prod * m) _ _
 
 /-- Exercise 2.3.4-/
-theorem Nat.sq_add_eq (a b: Nat) : (a + b) ^ (2 : Nat) = a ^ (2 : Nat) + 2 * a * b + b ^ (2 : Nat) := by
+theorem Nat.sq_add_eq (a b: Nat) :
+    (a + b) ^ (2 : Nat) = a ^ (2 : Nat) + 2 * a * b + b ^ (2 : Nat) := by
   sorry
-
-
-
 
 end Chapter2

--- a/analysis/Analysis/Section_2_epilogue.lean
+++ b/analysis/Analysis/Section_2_epilogue.lean
@@ -4,13 +4,23 @@ import Analysis.Section_2_3
 /-!
 # Analysis I, Chapter 2 epilogue
 
-In this (technical) epilogue, we show that the "Chapter 2" natural numbers `Chapter2.Nat` are isomorphic in various standard senses to the standard natural numbers `ℕ`.
+In this (technical) epilogue, we show that the "Chapter 2" natural numbers `Chapter2.Nat` are
+isomorphic in various standard senses to the standard natural numbers `ℕ`.
 
-From this point onwards, `Chapter2.Nat` will be deprecated, and we will use the standard natural numbers `ℕ` instead.  In particular, one should use the full Mathlib API for `ℕ` for all subsequent chapters, in lieu of the `Chapter2.Nat` API.
+From this point onwards, `Chapter2.Nat` will be deprecated, and we will use the standard natural
+numbers `ℕ` instead.  In particular, one should use the full Mathlib API for `ℕ` for all
+subsequent chapters, in lieu of the `Chapter2.Nat` API.
 
-Filling the sorries here requires both the Chapter2.Nat API and the Mathlib API for the standard natural numbers `ℕ`.  As such, they are excellent exercises to prepare you for the aforementioned transition.
+Filling the sorries here requires both the Chapter2.Nat API and the Mathlib API for the standard
+natural numbers `ℕ`.  As such, they are excellent exercises to prepare you for the aforementioned
+transition.
 
-In second half of this section we also give a fully axiomatic treatment of the natural numbers via the Peano axioms.  The treatment in the preceding three sections was only partially axiomatic, because we used a specific construction `Chapter2.Nat` of the natural numbers that was an inductive type, and used that inductive type to construct a recursor.  Here, we give some exercises to show how one can accomplish the same tasks directly from the Peano axioms, without knowing the specific implementation of the natural numbers.
+In second half of this section we also give a fully axiomatic treatment of the natural numbers
+via the Peano axioms. The treatment in the preceding three sections was only partially
+axiomatic, because we used a specific construction `Chapter2.Nat` of the natural numbers that was
+an inductive type, and used that inductive type to construct a recursor.  Here, we give some
+exercises to show how one can accomplish the same tasks directly from the Peano axioms, without
+knowing the specific implementation of the natural numbers.
 -/
 
 abbrev Chapter2.Nat.toNat (n : Chapter2.Nat) : ℕ := match n with
@@ -48,7 +58,8 @@ abbrev Chapter2.Nat.equivNat_ordered_ring : Chapter2.Nat ≃+*o ℕ where
     sorry
   map_le_map_iff' := by sorry
 
-lemma Chapter2.Nat.pow_eq_pow (n m : Chapter2.Nat) : n.toNat ^ m.toNat = n^m := by
+lemma Chapter2.Nat.pow_eq_pow (n m : Chapter2.Nat) :
+    n.toNat ^ m.toNat = n^m := by
   sorry
 
 
@@ -60,7 +71,8 @@ class PeanoAxioms where
   succ : Nat → Nat -- Axiom 2.2
   succ_ne : ∀ n : Nat, succ n ≠ zero -- Axiom 2.3
   succ_cancel : ∀ {n m : Nat}, succ n = succ m → n = m -- Axiom 2.4
-  induction : ∀ (P : Nat → Prop), P zero → (∀ n : Nat, P n → P (succ n)) → ∀ n : Nat, P n -- Axiom 2.5
+  induction : ∀ (P : Nat → Prop),
+    P zero → (∀ n : Nat, P n → P (succ n)) → ∀ n : Nat, P n -- Axiom 2.5
 
 namespace PeanoAxioms
 
@@ -122,11 +134,13 @@ noncomputable abbrev Equiv.fromNat (P : PeanoAxioms) : Equiv Mathlib.Nat P where
 
 noncomputable abbrev Equiv.mk' (P Q : PeanoAxioms) : Equiv P Q := by sorry
 
-theorem Equiv.uniq {P Q : PeanoAxioms} (equiv1 equiv2 : PeanoAxioms.Equiv P Q) : equiv1 = equiv2 := by
+theorem Equiv.uniq {P Q : PeanoAxioms} (equiv1 equiv2 : PeanoAxioms.Equiv P Q) :
+    equiv1 = equiv2 := by
   sorry
 
 /-- A sample result: recursion is well-defined on any structure obeying the Peano axioms-/
-theorem Nat.recurse_uniq {P : PeanoAxioms} (f: P.Nat → P.Nat → P.Nat) (c: P.Nat) : ∃! (a: P.Nat → P.Nat), a P.zero = c ∧ ∀ n, a (P.succ n) = f n (a n) := by
+theorem Nat.recurse_uniq {P : PeanoAxioms} (f: P.Nat → P.Nat → P.Nat) (c: P.Nat) :
+    ∃! (a: P.Nat → P.Nat), a P.zero = c ∧ ∀ n, a (P.succ n) = f n (a n) := by
   sorry
 
 end PeanoAxioms

--- a/analysis/Analysis/Section_3_2.lean
+++ b/analysis/Analysis/Section_3_2.lean
@@ -4,11 +4,18 @@ import Analysis.Section_3_1
 /-!
 # Analysis I, Section 3.2
 
-In this section we set up a version of Zermelo-Frankel set theory (with atoms) that tries to be as faithful as possible to the original text of Analysis I, Section 3.1. All numbering refers to the original text.
+In this section we set up a version of Zermelo-Frankel set theory (with atoms) that tries to be
+as faithful as possible to the original text of Analysis I, Section 3.1. All numbering refers to
+the original text.
 
-I have attempted to make the translation as faithful a paraphrasing as possible of the original text.   When there is a choice between a more idiomatic Lean solution and a more faithful translation, I have generally chosen the latter.  In particular, there will be places where the Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided doing so.
+I have attempted to make the translation as faithful a paraphrasing as possible of the original
+text. When there is a choice between a more idiomatic Lean solution and a more faithful
+translation, I have generally chosen the latter.  In particular, there will be places where the
+Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided
+doing so.
 
-This section is mostly optional, though it does make explicit the axiom of foundation which is used in a minor role in an exercise in Section 3.5.
+This section is mostly optional, though it does make explicit the axiom of foundation which is
+used in a minor role in an exercise in Section 3.5.
 
 Main constructions and results of this section:
 
@@ -23,7 +30,8 @@ export SetTheory (Set Object)
 variable [SetTheory]
 
 /-- Axiom 3.8 (Universal specification) -/
-abbrev axiom_of_universal_specification : Prop := ∀ P : Object → Prop, ∃ A : Set, ∀ x : Object, x ∈ A ↔ P x
+abbrev axiom_of_universal_specification : Prop :=
+  ∀ P : Object → Prop, ∃ A : Set, ∀ x : Object, x ∈ A ↔ P x
 
 theorem Russells_paradox : ¬ axiom_of_universal_specification := by
   -- this proof is written to follow the structure of the original text.
@@ -41,7 +49,8 @@ theorem Russells_paradox : ¬ axiom_of_universal_specification := by
   contradiction
 
 /-- Axiom 3.9 (Regularity ) -/
-theorem SetTheory.Set.axiom_of_regularity {A:Set} (h: A ≠ ∅) : ∃ x:A, ∀ S:Set, x.val = S → Disjoint S A := by
+theorem SetTheory.Set.axiom_of_regularity {A:Set} (h: A ≠ ∅) :
+    ∃ x:A, ∀ S:Set, x.val = S → Disjoint S A := by
   obtain ⟨ x, h, h' ⟩ := SetTheory.regularity_axiom A (nonempty_def h)
   use ⟨x, h⟩
   intro S hS
@@ -52,28 +61,53 @@ theorem SetTheory.Set.axiom_of_regularity {A:Set} (h: A ≠ ∅) : ∃ x:A, ∀ 
   obtain ⟨ y, h1, h2 ⟩ := h'
   exact ⟨ y, h2, h1 ⟩
 
-/-- Exercise 3.2.1.  The spirit of the exercise is to establish these results without using either Russell's paradox, or the empty set.-/
-theorem SetTheory.Set.emptyset_exists (h: axiom_of_universal_specification): ∃ (X:Set), ∀ x, x ∉ X := by
+/--
+  Exercise 3.2.1.  The spirit of the exercise is to establish these results without using either
+  Russell's paradox, or the empty set.
+-/
+theorem SetTheory.Set.emptyset_exists (h: axiom_of_universal_specification):
+    ∃ (X:Set), ∀ x, x ∉ X := by
   sorry
 
-/-- Exercise 3.2.1.  The spirit of the exercise is to establish these results without using either Russell's paradox, or the singleton set.-/
-theorem SetTheory.Set.singleton_exists (h: axiom_of_universal_specification) (x:Object): ∃ (X:Set), ∀ y, y ∈ X ↔ y = x := by
+/--
+  Exercise 3.2.1.  The spirit of the exercise is to establish these results without using either
+  Russell's paradox, or the singleton set.
+-/
+theorem SetTheory.Set.singleton_exists (h: axiom_of_universal_specification) (x:Object):
+    ∃ (X:Set), ∀ y, y ∈ X ↔ y = x := by
   sorry
 
-/-- Exercise 3.2.1.  The spirit of the exercise is to establish these results without using either Russell's paradox, or the pair set.-/
-theorem SetTheory.Set.pair_exists (h: axiom_of_universal_specification) (x₁ x₂:Object): ∃ (X:Set), ∀ y, y ∈ X ↔ y = x₁ ∨ y = x₂ := by
+/--
+  Exercise 3.2.1.  The spirit of the exercise is to establish these results without using either
+  Russell's paradox, or the pair set.
+-/
+theorem SetTheory.Set.pair_exists (h: axiom_of_universal_specification) (x₁ x₂:Object):
+    ∃ (X:Set), ∀ y, y ∈ X ↔ y = x₁ ∨ y = x₂ := by
   sorry
 
-/-- Exercise 3.2.1.  The spirit of the exercise is to establish these results without using either Russell's paradox, or the union operation.-/
-theorem SetTheory.Set.union_exists (h: axiom_of_universal_specification) (A B:Set): ∃ (Z:Set), ∀ z, z ∈ Z ↔ z ∈ A ∨ z ∈ B := by
+/--
+  Exercise 3.2.1. The spirit of the exercise is to establish these results without using either
+  Russell's paradox, or the union operation.
+-/
+theorem SetTheory.Set.union_exists (h: axiom_of_universal_specification) (A B:Set):
+    ∃ (Z:Set), ∀ z, z ∈ Z ↔ z ∈ A ∨ z ∈ B := by
   sorry
 
-/-- Exercise 3.2.1.  The spirit of the exercise is to establish these results without using either Russell's paradox, or the specify operation.-/
-theorem SetTheory.Set.specify_exists (h: axiom_of_universal_specification) (A:Set) (P: A → Prop): ∃ (Z:Set), ∀ z, z ∈ Z ↔ ∃ h : z ∈ A, P ⟨ z, h ⟩ := by
+/--
+  Exercise 3.2.1. The spirit of the exercise is to establish these results without using either
+  Russell's paradox, or the specify operation.
+-/
+theorem SetTheory.Set.specify_exists (h: axiom_of_universal_specification) (A:Set) (P: A → Prop):
+    ∃ (Z:Set), ∀ z, z ∈ Z ↔ ∃ h : z ∈ A, P ⟨ z, h ⟩ := by
   sorry
 
-/-- Exercise 3.2.1.  The spirit of the exercise is to establish these results without using either Russell's paradox, or the specify operation.-/
-theorem SetTheory.Set.replace_exists (h: axiom_of_universal_specification) (A:Set) (P: A → Object → Prop) (hP: ∀ x y y', P x y ∧ P x y' → y = y') : ∃ (Z:Set), ∀ y, y ∈ Z ↔ ∃ a : A, P a y := by
+/--
+  Exercise 3.2.1. The spirit of the exercise is to establish these results without using either
+  Russell's paradox, or the specify operation.
+-/
+theorem SetTheory.Set.replace_exists (h: axiom_of_universal_specification) (A:Set)
+  (P: A → Object → Prop) (hP: ∀ x y y', P x y ∧ P x y' → y = y') :
+    ∃ (Z:Set), ∀ y, y ∈ Z ↔ ∃ a : A, P a y := by
   sorry
 
 /-- Exercise 3.2.2 -/
@@ -83,7 +117,8 @@ theorem SetTheory.Set.not_mem_self (A:Set) : (A:Object) ∉ A := by sorry
 theorem SetTheory.Set.not_mem_mem (A B:Set) : (A:Object) ∉ B ∨ (B:Object) ∉ A := by sorry
 
 /-- Exercise 3.2.3 -/
-theorem SetTheory.Set.univ_imp (U: Set) (hU: ∀ x, x ∈ U) : axiom_of_universal_specification := by sorry
+theorem SetTheory.Set.univ_imp (U: Set) (hU: ∀ x, x ∈ U) :
+    axiom_of_universal_specification := by sorry
 
 /-- Exercise 3.2.3 -/
 theorem SetTheory.Set.no_univ : ¬ ∃ (U:Set), ∀ (x:Object), x ∈ U := by sorry

--- a/analysis/Analysis/Section_3_3.lean
+++ b/analysis/Analysis/Section_3_3.lean
@@ -4,25 +4,42 @@ import Analysis.Section_3_1
 /-!
 # Analysis I, Section 3.3
 
-I have attempted to make the translation as faithful a paraphrasing as possible of the original text.   When there is a choice between a more idiomatic Lean solution and a more faithful translation, I have generally chosen the latter.  In particular, there will be places where the Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided doing so.
+I have attempted to make the translation as faithful a paraphrasing as possible of the original
+text. When there is a choice between a more idiomatic Lean solution and a more faithful
+translation, I have generally chosen the latter. In particular, there will be places where the
+Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided
+doing so.
 
 Main constructions and results of this section:
 
 - A notion of function `Function X Y` between two sets `X`, `Y` in the set theory of Section 3.1
-- Various relations with the Mathlib notion of a function `X → Y` between two types `X`, `Y`.  (Note from Section 3.1 that every `Set` `X` can also be viewed as a subtype `{ x:Object // x ∈ X }` of `Object`.)
-- Basic function properties and operations, such as composition, one-to-one and onto functions, and inverses.
+- Various relations with the Mathlib notion of a function `X → Y` between two types `X`, `Y`.
+  (Note from Section 3.1 that every `Set` `X` can also be viewed as a subtype
+  `{ x:Object // x ∈ X }` of `Object`.)
+- Basic function properties and operations, such as composition, one-to-one and onto functions,
+  and inverses.
 
-In the rest of the book we will deprecate the Chapter 3 version of a function, and work with the Mathlib notion of a function instead.  Even within this section, we will switch to the Mathlib formalism for some of the examples involving number systems such as `ℤ` or `ℝ` that have not been implemented in the Chapter 3 framework.
+In the rest of the book we will deprecate the Chapter 3 version of a function, and work with the
+Mathlib notion of a function instead.  Even within this section, we will switch to the Mathlib
+formalism for some of the examples involving number systems such as `ℤ` or `ℝ` that have not been
+implemented in the Chapter 3 framework.
 -/
 
 namespace Chapter3
 
--- We will work here with the version `nat` of the natural numbers internal to the Chapter 3 set theory, though usually we will use coercions to then immediately translate to the Mathlib natural numbers `ℕ`.
+/-
+We will work here with the version `nat` of the natural numbers internal to the Chapter 3 set
+theory, though usually we will use coercions to then immediately translate to the Mathlib
+natural numbers `ℕ`.
+-/
 export SetTheory (Set Object nat)
 
 variable [SetTheory]
 
-/-- Definition 3.3.1. `Function X Y` is the structure of functions from `X` to `Y`.   Analogous to the Mathlib type `X → Y`.-/
+/--
+  Definition 3.3.1. `Function X Y` is the structure of functions from `X` to `Y`.
+  Analogous to the Mathlib type `X → Y`.
+-/
 @[ext]
 structure Function (X Y: Set) where
   P : X → Y → Prop
@@ -30,7 +47,11 @@ structure Function (X Y: Set) where
 
 #check Function.mk
 
-/-- Converting a Chapter 3 function `f: Function X Y` to a Mathlib function `f: X → Y`. The Chapter 3 definition of a function was nonconstructive, so we have to use the axiom of choice here.  -/
+/--
+  Converting a Chapter 3 function `f: Function X Y` to a Mathlib function `f: X → Y`.
+  The Chapter 3 definition of a function was nonconstructive, so we have to use the
+  axiom of choice here.
+-/
 noncomputable instance Function.inst_coefn (X Y: Set)  : CoeFun (Function X Y) (fun _ ↦ X → Y) where
   coe := fun f x ↦ Classical.choose (f.unique x)
 
@@ -75,7 +96,8 @@ theorem SetTheory.Set.P_3_3_2a_existsUnique (x: nat) : ∃! y: nat, P_3_3_2a x y
 
 abbrev SetTheory.Set.f_3_3_2a : Function nat nat := Function.mk P_3_3_2a P_3_3_2a_existsUnique
 
-theorem SetTheory.Set.f_3_3_2a_eval (x y: nat) : y = f_3_3_2a x ↔ (y:ℕ) = (x+1:ℕ) := Function.eval _ _ _
+theorem SetTheory.Set.f_3_3_2a_eval (x y: nat) : y = f_3_3_2a x ↔ (y:ℕ) = (x+1:ℕ) :=
+  Function.eval _ _ _
 
 
 theorem SetTheory.Set.f_3_3_2a_eval' (n: ℕ) : f_3_3_2a (n:nat) = (n+1:ℕ) := by
@@ -96,10 +118,13 @@ theorem SetTheory.Set.not_P_3_3_2b_existsUnique : ¬ ∀ x, ∃! y: nat, P_3_3_2
   have : ((0:nat):ℕ) = 0 := by simp [OfNat.ofNat]
   simp [P_3_3_2b, this] at hn
 
-abbrev SetTheory.Set.P_3_3_2c : (nat \ {(0:Object)}: Set) → nat → Prop := fun x y ↦ ((y+1:ℕ):Object) = x
+abbrev SetTheory.Set.P_3_3_2c : (nat \ {(0:Object)}: Set) → nat → Prop :=
+  fun x y ↦ ((y+1:ℕ):Object) = x
 
-theorem SetTheory.Set.P_3_3_2c_existsUnique (x: (nat \ {(0:Object)}: Set)) : ∃! y: nat, P_3_3_2c x y := by
--- Some technical unpacking here due to the subtle distinctions between the `Object` type, sets converted to subtypes of `Object`, and subsets of those sets.
+theorem SetTheory.Set.P_3_3_2c_existsUnique (x: (nat \ {(0:Object)}: Set)) :
+    ∃! y: nat, P_3_3_2c x y := by
+  -- Some technical unpacking here due to the subtle distinctions between the `Object` type,
+  -- sets converted to subtypes of `Object`, and subsets of those sets.
   obtain ⟨ x, hx ⟩ := x
   simp at hx
   obtain ⟨ hx1, hx2⟩ := hx
@@ -113,21 +138,35 @@ theorem SetTheory.Set.P_3_3_2c_existsUnique (x: (nat \ {(0:Object)}: Set)) : ∃
   set m := (y:ℕ)
   simp [←hy, m]
 
-abbrev SetTheory.Set.f_3_3_2c : Function (nat \ {(0:Object)}: Set) nat := Function.mk P_3_3_2c P_3_3_2c_existsUnique
+abbrev SetTheory.Set.f_3_3_2c : Function (nat \ {(0:Object)}: Set) nat :=
+  Function.mk P_3_3_2c P_3_3_2c_existsUnique
 
-theorem SetTheory.Set.f_3_3_2c_eval (x: (nat \ {(0:Object)}: Set)) (y: nat) : y = f_3_3_2c x ↔ ((y+1:ℕ):Object) = x := Function.eval _ _ _
+theorem SetTheory.Set.f_3_3_2c_eval (x: (nat \ {(0:Object)}: Set)) (y: nat) :
+    y = f_3_3_2c x ↔ ((y+1:ℕ):Object) = x := Function.eval _ _ _
 
 /-- Create a version of a non-zero `n` inside `nat \ {0}` for any natural number n. -/
-abbrev SetTheory.Set.coe_nonzero (n:ℕ) (h: n ≠ 0): (nat \ {(0:Object)}: Set) := ⟨ ((n:ℕ):Object), by simp [SetTheory.Object.ofnat_eq',h]; rw [←SetTheory.Object.ofnat_eq]; exact Subtype.property _ ⟩
+abbrev SetTheory.Set.coe_nonzero (n:ℕ) (h: n ≠ 0): (nat \ {(0:Object)}: Set) :=
+  ⟨((n:ℕ):Object), by
+    simp [SetTheory.Object.ofnat_eq',h]
+    rw [←SetTheory.Object.ofnat_eq]
+    exact Subtype.property _
+  ⟩
 
 theorem SetTheory.Set.f_3_3_2c_eval' (n: ℕ) : f_3_3_2c (coe_nonzero (n+1) (by positivity)) = n := by
   symm; rw [f_3_3_2c_eval]; simp
 
-theorem SetTheory.Set.f_3_3_2c_eval'' : f_3_3_2c (coe_nonzero 4 (by positivity)) = 3 := by convert f_3_3_2c_eval' 3
+theorem SetTheory.Set.f_3_3_2c_eval'' : f_3_3_2c (coe_nonzero 4 (by positivity)) = 3 := by
+  convert f_3_3_2c_eval' 3
 
-theorem SetTheory.Set.f_3_3_2c_eval''' (n:ℕ) : f_3_3_2c (coe_nonzero (2*n+3) (by positivity)) = (2*n+2:ℕ) := by convert f_3_3_2c_eval' (2*n+2)
+theorem SetTheory.Set.f_3_3_2c_eval''' (n:ℕ) :
+    f_3_3_2c (coe_nonzero (2*n+3) (by positivity)) = (2*n+2:ℕ) := by convert f_3_3_2c_eval' (2*n+2)
 
-/-- Example 3.3.3 is a little tricky to replicate with the current formalism as the real numbers have not been constructed yet.  Instead, I offer some Mathlib counterparts.  Of course, filling in these sorries will require using some Mathlib API, for instance for the nonnegative real class `NNReal`, and how this class interacts with `ℝ`. -/
+/--
+  Example 3.3.3 is a little tricky to replicate with the current formalism as the real numbers
+  have not been constructed yet.  Instead, I offer some Mathlib counterparts.  Of course, filling
+  in these sorries will require using some Mathlib API, for instance for the nonnegative real
+  class `NNReal`, and how this class interacts with `ℝ`.
+-/
 example : ¬ ∃ f: ℝ → ℝ, ∀ x y, y = f x ↔ y^2 = x := by sorry
 
 example : ¬ ∃ f: NNReal → ℝ, ∀ x y, y = f x ↔ y^2 = x := by sorry
@@ -159,7 +198,10 @@ theorem Function.eq_iff {X Y: Set} (f g: Function X Y) : f = g ↔ ∀ x: X, f x
   intro hg
   rwa [←Function.eval _ _ _, h x, Function.eval _ _ _]
 
-/-- Example 3.3.8 (simplified).  The second part of the example is tricky to replicate in this formalism, so a Mathlib substitute is offered instead. -/
+/--
+  Example 3.3.8 (simplified).  The second part of the example is tricky to replicate in this
+  formalism, so a Mathlib substitute is offered instead.
+-/
 abbrev SetTheory.Set.f_3_3_8a : Function nat nat := Function.mk_fn (fun x ↦ (x^2 + 2*x + 1:ℕ))
 
 abbrev SetTheory.Set.f_3_3_8b : Function nat nat := Function.mk_fn (fun x ↦ ((x+1)^2:ℕ))
@@ -176,70 +218,93 @@ example : (fun x:NNReal ↦ (x:ℝ)) = (fun x:NNReal ↦ |(x:ℝ)|) := by sorry
 example : (fun x:ℝ ↦ (x:ℝ)) ≠ (fun x:ℝ ↦ |(x:ℝ)|) := by sorry
 
 /-- Example 3.3.9 -/
-abbrev SetTheory.Set.f_3_3_9 (X:Set) : Function (∅:Set) X := Function.mk (fun _ _ ↦ True) (by intro ⟨ x,hx ⟩; simp at hx)
+abbrev SetTheory.Set.f_3_3_9 (X:Set) : Function (∅:Set) X :=
+  Function.mk (fun _ _ ↦ True) (by intro ⟨ x,hx ⟩; simp at hx)
 
 theorem SetTheory.Set.empty_function_unique {X: Set} (f g: Function (∅:Set) X) : f = g := by sorry
 
 /-- Definition 3.3.10 (Composition) -/
-noncomputable abbrev Function.comp {X Y Z: Set} (g: Function Y Z) (f: Function X Y)  : Function X Z :=
+noncomputable abbrev Function.comp {X Y Z: Set} (g: Function Y Z) (f: Function X Y) :
+    Function X Z :=
   Function.mk_fn (fun x ↦ g (f x))
 
--- `∘` is already taken in Mathlib for the composition of Mathlib functions, so we use `○` here instead to avoid ambiguity.
+-- `∘` is already taken in Mathlib for the composition of Mathlib functions,
+-- so we use `○` here instead to avoid ambiguity.
 infix:90 "○" => Function.comp
 
-theorem Function.comp_eval {X Y Z: Set} (g: Function Y Z) (f: Function X Y) (x: X) : (g ○ f) x = g (f x) := Function.eval_of _ _
+theorem Function.comp_eval {X Y Z: Set} (g: Function Y Z) (f: Function X Y) (x: X) :
+    (g ○ f) x = g (f x) := Function.eval_of _ _
 
-/-- Compatibility with Mathlib's composition operation.  You may find the `ext` and `simp` tactics to be useful. -/
-theorem Function.comp_eq_comp {X Y Z: Set} (g: Function Y Z) (f: Function X Y) : (g ○ f).to_fn = g.to_fn ∘ f.to_fn := by sorry
+/--
+  Compatibility with Mathlib's composition operation.
+  You may find the `ext` and `simp` tactics to be useful.
+-/
+theorem Function.comp_eq_comp {X Y Z: Set} (g: Function Y Z) (f: Function X Y) :
+    (g ○ f).to_fn = g.to_fn ∘ f.to_fn := by sorry
 
 /-- Example 3.3.11 -/
 abbrev SetTheory.Set.f_3_3_11 : Function nat nat := Function.mk_fn (fun x ↦ (2*x:ℕ))
 
 abbrev SetTheory.Set.g_3_3_11 : Function nat nat := Function.mk_fn (fun x ↦ (x+3:ℕ))
 
-theorem SetTheory.Set.g_circ_f_3_3_11: g_3_3_11 ○ f_3_3_11 = Function.mk_fn (fun x ↦ ((2*(x:ℕ)+3:ℕ):nat)) := by
+theorem SetTheory.Set.g_circ_f_3_3_11 :
+    g_3_3_11 ○ f_3_3_11 = Function.mk_fn (fun x ↦ ((2*(x:ℕ)+3:ℕ):nat)) := by
   rw [Function.eq_iff]
   intro x
   rw [Function.comp_eval, Function.eval_of, Function.eval_of, Function.eval_of]
   simp
 
-theorem SetTheory.Set.f_circ_g_3_3_11: f_3_3_11 ○ g_3_3_11 = Function.mk_fn (fun x ↦ ((2*(x:ℕ)+6:ℕ):nat)) := by
+theorem SetTheory.Set.f_circ_g_3_3_11 :
+    f_3_3_11 ○ g_3_3_11 = Function.mk_fn (fun x ↦ ((2*(x:ℕ)+6:ℕ):nat)) := by
   rw [Function.eq_iff]
   intro x
   rw [Function.comp_eval, Function.eval_of, Function.eval_of, Function.eval_of]
   simp; ring
 
 /-- Lemma 3.3.12 (Composition is associative) -/
-theorem SetTheory.Set.comp_assoc {W X Y Z: Set} (h: Function Y Z) (g: Function X Y) (f: Function W X) : h ○ (g ○ f) = (h ○ g) ○ f := by
+theorem SetTheory.Set.comp_assoc {W X Y Z: Set} (h: Function Y Z) (g: Function X Y)
+  (f: Function W X) :
+    h ○ (g ○ f) = (h ○ g) ○ f := by
   rw [Function.eq_iff]
   intro x
   simp_rw [Function.comp_eval]
 
 abbrev Function.one_to_one {X Y: Set} (f: Function X Y) : Prop := ∀ x x': X, x ≠ x' → f x ≠ f x'
 
-theorem Function.one_to_one_iff {X Y: Set} (f: Function X Y) : f.one_to_one ↔ ∀ x x': X, f x = f x' → x = x' := by
+theorem Function.one_to_one_iff {X Y: Set} (f: Function X Y) :
+    f.one_to_one ↔ ∀ x x': X, f x = f x' → x = x' := by
   apply forall_congr'; intro x
   apply forall_congr'; intro x'
   tauto
 
-/-- Compatibility with Mathlib's `Function.Injective`.  You may wish to use the `unfold` tactic to understand Mathlib concepts such as `Function.Injective`. -/
-theorem Function.one_to_one_iff' {X Y: Set} (f: Function X Y) : f.one_to_one ↔ Function.Injective f.to_fn := by sorry
+/--
+  Compatibility with Mathlib's `Function.Injective`.  You may wish to use the `unfold` tactic to
+  understand Mathlib concepts such as `Function.Injective`.
+-/
+theorem Function.one_to_one_iff' {X Y: Set} (f: Function X Y) :
+    f.one_to_one ↔ Function.Injective f.to_fn := by sorry
 
-/-- Example 3.3.15.  One half of the example requires the integers, and so is expressed using Mathlib functions instead of Chapter 3 functions. -/
-theorem SetTheory.Set.f_3_3_15_one_to_one : (Function.mk_fn (fun (n:nat) ↦ ((n^2:ℕ):nat))).one_to_one := by sorry
+/--
+  Example 3.3.15.  One half of the example requires the integers, and so is expressed using
+  Mathlib functions instead of Chapter 3 functions.
+-/
+theorem SetTheory.Set.f_3_3_15_one_to_one :
+    (Function.mk_fn (fun (n:nat) ↦ ((n^2:ℕ):nat))).one_to_one := by sorry
 
 example : ¬ Function.Injective (fun (n:ℤ) ↦ n^2) := by sorry
 
 example : Function.Injective (fun (n:ℕ) ↦ n^2) := by sorry
 
 /-- Remark 3.3.16 -/
-theorem SetTheory.Set.two_to_one {X Y: Set} {f: Function X Y} (h: ¬ f.one_to_one) : ∃ x x': X, x ≠ x' ∧ f x = f x' := by sorry
+theorem SetTheory.Set.two_to_one {X Y: Set} {f: Function X Y} (h: ¬ f.one_to_one) :
+    ∃ x x': X, x ≠ x' ∧ f x = f x' := by sorry
 
 /-- Definition 3.3.17 (Onto functions) -/
 abbrev Function.onto {X Y: Set} (f: Function X Y) : Prop := ∀ y: Y, ∃ x: X, f x = y
 
 /-- Compatibility with Mathlib's Function.Surjective-/
-theorem Function.onto_iff {X Y: Set} (f: Function X Y) : f.onto ↔ Function.Surjective f.to_fn := by sorry
+theorem Function.onto_iff {X Y: Set} (f: Function X Y) : f.onto ↔ Function.Surjective f.to_fn := by
+  sorry
 
 /-- Example 3.3.18 (using Mathlib) -/
 example : ¬ Function.Surjective (fun (n:ℤ) ↦ n^2) := by sorry
@@ -252,7 +317,8 @@ example : Function.Surjective (fun (n:ℤ) ↦ ⟨ n^2, by use n ⟩ : ℤ → A
 abbrev Function.bijective {X Y: Set} (f: Function X Y) : Prop := f.one_to_one ∧ f.onto
 
 /-- Compatibility with Mathlib's Function.Bijective-/
-theorem Function.bijective_iff {X Y: Set} (f: Function X Y) : f.bijective ↔ Function.Bijective f.to_fn := by sorry
+theorem Function.bijective_iff {X Y: Set} (f: Function X Y) :
+    f.bijective ↔ Function.Bijective f.to_fn := by sorry
 
 /-- Example 3.3.21 (using Mathlib) -/
 abbrev f_3_3_21 : Fin 3 → ({3,4}:_root_.Set ℕ) := fun x ↦ match x with
@@ -277,31 +343,43 @@ abbrev h_3_3_21 : Fin 3 → ({3,4,5}:_root_.Set ℕ) := fun x ↦ match x with
 
 example : Function.Bijective h_3_3_21 := by sorry
 
-/-- Example 3.3.22 is formulated using Mathlib rather than the set theory framework here to avoid some tedious technical issues (cf. Exercise 3.3.2) -/
+/--
+  Example 3.3.22 is formulated using Mathlib rather than the set theory framework here to avoid
+  some tedious technical issues (cf. Exercise 3.3.2)
+-/
 example : Function.Bijective (fun n ↦ ⟨ n+1, by omega⟩ : ℕ → { n:ℕ // n ≠ 0 }) := by sorry
 
 example : ¬ Function.Bijective (fun n ↦ n+1) := by sorry
 
 /-- Remark 3.3.24 -/
-theorem Function.bijective_incorrect_def : ∃ X Y: Set, ∃ f: Function X Y, (∀ x: X, ∃! y: Y, y = f x) ∧ ¬ f.bijective := by sorry
+theorem Function.bijective_incorrect_def :
+    ∃ X Y: Set, ∃ f: Function X Y, (∀ x: X, ∃! y: Y, y = f x) ∧ ¬ f.bijective := by sorry
 
-/-- We cannot use the notation `f⁻¹` for the inverse because in Mathlib's `Inv` class, the inverse of `f` must be exactly of the same type of `f`, and `Function Y X` is a different type from `Function X Y`.-/
-abbrev Function.inverse {X Y: Set} (f: Function X Y) (h: f.bijective) : Function Y X := Function.mk (fun y x ↦ f x = y) (by
-  intro y
-  apply existsUnique_of_exists_of_unique
-  . obtain ⟨ x, hx ⟩ := h.2 y
-    use x
-  intro x x' hx hx'
-  simp at hx hx'
-  rw [←hx'] at hx
-  apply f.one_to_one_iff.mp h.1 _ _
-  simp [hx]
+/--
+  We cannot use the notation `f⁻¹` for the inverse because in Mathlib's `Inv` class, the inverse
+  of `f` must be exactly of the same type of `f`, and `Function Y X` is a different type from
+  `Function X Y`.
+-/
+abbrev Function.inverse {X Y: Set} (f: Function X Y) (h: f.bijective) :
+    Function Y X :=
+  Function.mk (fun y x ↦ f x = y) (by
+    intro y
+    apply existsUnique_of_exists_of_unique
+    . obtain ⟨ x, hx ⟩ := h.2 y
+      use x
+    intro x x' hx hx'
+    simp at hx hx'
+    rw [←hx'] at hx
+    apply f.one_to_one_iff.mp h.1 _ _
+    simp [hx]
   )
 
-theorem Function.inverse_eval {X Y: Set} {f: Function X Y} (h: f.bijective) (y: Y) (x: X) : x = (f.inverse h) y ↔ f x = y := Function.eval _ _ _
+theorem Function.inverse_eval {X Y: Set} {f: Function X Y} (h: f.bijective) (y: Y) (x: X) :
+    x = (f.inverse h) y ↔ f x = y := Function.eval _ _ _
 
 /-- Compatibility with Mathlib's notion of inverse -/
-theorem Function.inverse_eq {X Y: Set} [Nonempty X] {f: Function X Y} (h: f.bijective) : (f.inverse h).to_fn = Function.invFun f.to_fn := by sorry
+theorem Function.inverse_eq {X Y: Set} [Nonempty X] {f: Function X Y} (h: f.bijective) :
+    (f.inverse h).to_fn = Function.invFun f.to_fn := by sorry
 
 /-- Exercise 3.3.1 -/
 theorem Function.refl {X Y:Set} (f: Function X Y) : f = f := by sorry
@@ -310,62 +388,91 @@ theorem Function.symm {X Y:Set} (f g: Function X Y) : f = g ↔ g = f := by sorr
 
 theorem Function.trans {X Y:Set} {f g h: Function X Y} (hfg: f = g) (hgh: g = h) : f = h := by sorry
 
-theorem Function.comp_congr {X Y Z:Set} {f f': Function X Y} (hff': f = f') {g g': Function Y Z} (hgg': g = g') : g ○ f = g' ○ f' := by sorry
+theorem Function.comp_congr {X Y Z:Set} {f f': Function X Y} (hff': f = f') {g g': Function Y Z}
+  (hgg': g = g') : g ○ f = g' ○ f' := by sorry
 
 /-- Exercise 3.3.2 -/
-theorem Function.comp_of_inj {X Y Z:Set} {f: Function X Y} {g : Function Y Z} (hf: f.one_to_one) (hg: g.one_to_one) : (g ○ f).one_to_one := by sorry
+theorem Function.comp_of_inj {X Y Z:Set} {f: Function X Y} {g : Function Y Z} (hf: f.one_to_one)
+  (hg: g.one_to_one) : (g ○ f).one_to_one := by sorry
 
-theorem Function.comp_of_surj {X Y Z:Set} {f: Function X Y} {g : Function Y Z} (hf: f.onto) (hg: g.onto) : (g ○ f).onto := by sorry
+theorem Function.comp_of_surj {X Y Z:Set} {f: Function X Y} {g : Function Y Z} (hf: f.onto)
+  (hg: g.onto) : (g ○ f).onto := by sorry
 
-/-- Exercise 3.3.3 - fill in the sorrys in the statements in  a reasonable fashion. -/
+/--
+  Exercise 3.3.3 - fill in the sorrys in the statements in  a reasonable fashion.
+-/
 example (X: Set) : (SetTheory.Set.f_3_3_9 X).one_to_one ↔ sorry := by sorry
 
 example (X: Set) : (SetTheory.Set.f_3_3_9 X).onto ↔ sorry := by sorry
 
 example (X: Set) : (SetTheory.Set.f_3_3_9 X).bijective ↔ sorry := by sorry
 
-/-- Exercise 3.3.4.  State and prove theorems or counterexamples in the case that `hg` or `hf` is omitted as a hypothesis. -/
-theorem Function.comp_cancel_left {X Y Z:Set} {f f': Function X Y} {g : Function Y Z} (heq : g ○ f = g ○ f') (hg: g.one_to_one) : f = f' := by sorry
+/--
+  Exercise 3.3.4.  State and prove theorems or counterexamples in the case that `hg` or `hf` is
+  omitted as a hypothesis.
+-/
+theorem Function.comp_cancel_left {X Y Z:Set} {f f': Function X Y} {g : Function Y Z}
+  (heq : g ○ f = g ○ f') (hg: g.one_to_one) : f = f' := by sorry
 
-theorem Function.comp_cancel_right {X Y Z:Set} {f: Function X Y} {g g': Function Y Z} (heq : g ○ f = g' ○ f) (hf: g.onto) : g = g' := by sorry
+theorem Function.comp_cancel_right {X Y Z:Set} {f: Function X Y} {g g': Function Y Z}
+  (heq : g ○ f = g' ○ f) (hf: g.onto) : g = g' := by sorry
 
-/-- Exercise 3.3.5.  State or prove theorems or counterexamples in the case that `f` is replaced with `g` or vice versa in the conclusion.-/
-theorem Function.comp_injective {X Y Z:Set} {f: Function X Y} {g : Function Y Z} (hinj : (g ○ f).one_to_one) : f.one_to_one := by sorry
+/--
+  Exercise 3.3.5.  State or prove theorems or counterexamples in the case that `f` is replaced
+  with `g` or vice versa in the conclusion.
+-/
+theorem Function.comp_injective {X Y Z:Set} {f: Function X Y} {g : Function Y Z} (hinj :
+    (g ○ f).one_to_one) : f.one_to_one := by sorry
 
-theorem Function.comp_surjective {X Y Z:Set} {f: Function X Y} {g : Function Y Z} (hinj : (g ○ f).onto) : g.onto := by sorry
+theorem Function.comp_surjective {X Y Z:Set} {f: Function X Y} {g : Function Y Z}
+  (hinj : (g ○ f).onto) : g.onto := by sorry
 
 /-- Exercise 3.3.6 -/
-theorem Function.inverse_comp_self {X Y: Set} {f: Function X Y} (h: f.bijective) (x: X) : (f.inverse h) (f x) = x := by sorry
+theorem Function.inverse_comp_self {X Y: Set} {f: Function X Y} (h: f.bijective) (x: X) :
+    (f.inverse h) (f x) = x := by sorry
 
-theorem Function.self_comp_inverse {X Y: Set} {f: Function X Y} (h: f.bijective) (y: Y) : f ((f.inverse h) y) = y := by sorry
+theorem Function.self_comp_inverse {X Y: Set} {f: Function X Y} (h: f.bijective) (y: Y) :
+    f ((f.inverse h) y) = y := by sorry
 
-theorem Function.inverse_bijective {X Y: Set} {f: Function X Y} (h: f.bijective) : (f.inverse h).bijective := by sorry
+theorem Function.inverse_bijective {X Y: Set} {f: Function X Y} (h: f.bijective) :
+    (f.inverse h).bijective := by sorry
 
-theorem Function.inverse_inverse {X Y: Set} {f: Function X Y} (h: f.bijective) : (f.inverse h).inverse (f.inverse_bijective h) = f := by sorry
+theorem Function.inverse_inverse {X Y: Set} {f: Function X Y} (h: f.bijective) :
+    (f.inverse h).inverse (f.inverse_bijective h) = f := by sorry
 
-theorem Function.comp_bijective {X Y Z:Set} {f: Function X Y} {g : Function Y Z} (hf: f.bijective) (hg: g.bijective) : (g ○ f).bijective := by sorry
+theorem Function.comp_bijective {X Y Z:Set} {f: Function X Y} {g : Function Y Z} (hf: f.bijective)
+  (hg: g.bijective) : (g ○ f).bijective := by sorry
 
 /-- Exercise 3.3.7 -/
-theorem Function.inv_of_comp {X Y Z:Set} {f: Function X Y} {g : Function Y Z} (hf: f.bijective) (hg: g.bijective) : (g ○ f).inverse (Function.comp_bijective hf hg) = (f.inverse hf) ○ (g.inverse hg) := by sorry
+theorem Function.inv_of_comp {X Y Z:Set} {f: Function X Y} {g : Function Y Z}
+  (hf: f.bijective) (hg: g.bijective) :
+    (g ○ f).inverse (Function.comp_bijective hf hg) = (f.inverse hf) ○ (g.inverse hg) := by sorry
 
 /-- Exercise 3.3.8 -/
-abbrev Function.inclusion {X Y:Set} (h: X ⊆ Y) : Function X Y := Function.mk_fn (fun x ↦ ⟨ x.val, h x.val x.property ⟩ )
+abbrev Function.inclusion {X Y:Set} (h: X ⊆ Y) :
+    Function X Y := Function.mk_fn (fun x ↦ ⟨ x.val, h x.val x.property ⟩ )
 
 abbrev Function.id (X:Set) : Function X X := Function.mk_fn (fun x ↦ x)
 
-theorem Function.inclusion_id (X:Set) : Function.inclusion (SetTheory.Set.subset_self X) = Function.id X := by sorry
+theorem Function.inclusion_id (X:Set) :
+    Function.inclusion (SetTheory.Set.subset_self X) = Function.id X := by sorry
 
-theorem Function.inclusion_comp (X Y Z:Set) (hXY: X ⊆ Y) (hYZ: Y ⊆ Z) : Function.inclusion hYZ ○ Function.inclusion hXY = Function.inclusion (SetTheory.Set.subset_trans hXY hYZ) := by sorry
+theorem Function.inclusion_comp (X Y Z:Set) (hXY: X ⊆ Y) (hYZ: Y ⊆ Z) :
+    Function.inclusion hYZ ○ Function.inclusion hXY = Function.inclusion (SetTheory.Set.subset_trans hXY hYZ) := by sorry
 
 theorem Function.comp_id {A B:Set} (f: Function A B) : f ○ Function.id A = f := by sorry
 
 theorem Function.id_comp {A B:Set} (f: Function A B) : Function.id B ○ f = f := by sorry
 
-theorem Function.comp_inv {A B:Set} (f: Function A B) (hf: f.bijective) : f ○ f.inverse hf = Function.id B := by sorry
+theorem Function.comp_inv {A B:Set} (f: Function A B) (hf: f.bijective) :
+    f ○ f.inverse hf = Function.id B := by sorry
 
-theorem Function.inv_comp {A B:Set} (f: Function A B) (hf: f.bijective) : f.inverse hf ○ f = Function.id A := by sorry
+theorem Function.inv_comp {A B:Set} (f: Function A B) (hf: f.bijective) :
+    f.inverse hf ○ f = Function.id A := by sorry
 
-theorem Function.glue {X Y Z:Set} (hXY: Disjoint X Y) (f: Function X Z) (g: Function Y Z) : ∃! h: Function (X ∪ Y) Z, (h ○ Function.inclusion (SetTheory.Set.subset_union_left X Y) = f) ∧ (h ○ Function.inclusion (SetTheory.Set.subset_union_right X Y) = g) := by sorry
+theorem Function.glue {X Y Z:Set} (hXY: Disjoint X Y) (f: Function X Z) (g: Function Y Z) :
+    ∃! h: Function (X ∪ Y) Z, (h ○ Function.inclusion (SetTheory.Set.subset_union_left X Y) = f)
+    ∧ (h ○ Function.inclusion (SetTheory.Set.subset_union_right X Y) = g) := by sorry
 
 
 

--- a/analysis/Analysis/Section_3_4.lean
+++ b/analysis/Analysis/Section_3_4.lean
@@ -4,11 +4,16 @@ import Analysis.Section_3_1
 /-!
 # Analysis I, Section 3.4
 
-I have attempted to make the translation as faithful a paraphrasing as possible of the original text.   When there is a choice between a more idiomatic Lean solution and a more faithful translation, I have generally chosen the latter.  In particular, there will be places where the Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided doing so.
+I have attempted to make the translation as faithful a paraphrasing as possible of the original
+text. When there is a choice between a more idiomatic Lean solution and a more faithful
+translation, I have generally chosen the latter. In particular, there will be places where the
+Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided
+doing so.
 
 Main constructions and results of this section:
 
-- Images and inverse images of (Mathlib) functions, within the framework of Section 3.1 set theory.  (The Section 3.2 functions are now deprecated and will not be used further.)
+- Images and inverse images of (Mathlib) functions, within the framework of Section 3.1 set
+  theory. (The Section 3.2 functions are now deprecated and will not be used further.)
 - Connection with Mathlib's image `f '' S` and preimage `f ⁻¹' S` notions.
 -/
 
@@ -19,23 +24,30 @@ export SetTheory (Set Object nat)
 variable [SetTheory]
 
 /-- Definition 3.4.1.  Interestingly, the definition does not require S to be a subset of X. -/
-abbrev SetTheory.Set.image {X Y:Set} (f:X → Y) (S: Set) : Set := X.replace (P := fun x y ↦ y = f x ∧ x.val ∈ S) (by
-  intro x y y' ⟨ hy, hy' ⟩
-  simp at hy hy'
-  rw [hy.1, hy'.1])
+abbrev SetTheory.Set.image {X Y:Set} (f:X → Y) (S: Set) : Set :=
+  X.replace (P := fun x y ↦ y = f x ∧ x.val ∈ S) (by
+    intro x y y' ⟨ hy, hy' ⟩
+    simp at hy hy'
+    rw [hy.1, hy'.1]
+  )
 
 /-- Definition 3.4.1 -/
-theorem SetTheory.Set.mem_image {X Y:Set} (f:X → Y) (S: Set) (y:Object) : y ∈ image f S ↔ ∃ x:X, x.val ∈ S ∧ f x = y := by
+theorem SetTheory.Set.mem_image {X Y:Set} (f:X → Y) (S: Set) (y:Object) :
+    y ∈ image f S ↔ ∃ x:X, x.val ∈ S ∧ f x = y := by
   rw [SetTheory.Set.replacement_axiom]
   apply exists_congr; intro x
   tauto
 
 /-- Alternate definition of image using axiom of specification -/
-theorem SetTheory.Set.image_eq_specify {X Y:Set} (f:X → Y) (S: Set) : image f S = Y.specify (fun y ↦ ∃ x:X, x.val ∈ S ∧ f x = y) := by sorry
+theorem SetTheory.Set.image_eq_specify {X Y:Set} (f:X → Y) (S: Set) :
+    image f S = Y.specify (fun y ↦ ∃ x:X, x.val ∈ S ∧ f x = y) := by sorry
 
-/-- Connection with Mathlib's notion of image.  Note the need to utilize the `Subtype.val` coercion to make everything type consistent. -/
-theorem SetTheory.Set.image_eq_image {X Y:Set} (f:X → Y) (S: Set): (image f S: _root_.Set Object) = Subtype.val '' (f '' {x | x.val ∈ S}) := by sorry
-
+/--
+  Connection with Mathlib's notion of image.  Note the need to utilize the `Subtype.val` coercion
+  to make everything type consistent.
+-/
+theorem SetTheory.Set.image_eq_image {X Y:Set} (f:X → Y) (S: Set):
+    (image f S: _root_.Set Object) = Subtype.val '' (f '' {x | x.val ∈ S}) := by sorry
 
 /-- Example 3.4.2 -/
 abbrev f_3_4_2 : nat → nat := fun n ↦ (2*n:ℕ)
@@ -45,23 +57,32 @@ theorem SetTheory.Set.image_f_3_4_2 : image f_3_4_2 {1,2,3} = {2,4,6} := by sorr
 /-- Example 3.4.3 is written using Mathlib's notion of image -/
 example : (fun n:ℤ ↦ n^2) '' {-1,0,1,2} = {0,1,4} := by sorry
 
-theorem SetTheory.Set.mem_image_of_eval {X Y:Set} (f:X → Y) (S: Set) (x:X) : x.val ∈ S → (f x).val ∈ image f S := by sorry
+theorem SetTheory.Set.mem_image_of_eval {X Y:Set} (f:X → Y) (S: Set) (x:X) :
+    x.val ∈ S → (f x).val ∈ image f S := by sorry
 
-theorem SetTheory.Set.mem_image_of_eval_counter : ∃ (X Y:Set) (f:X → Y) (S: Set) (x:X), ¬ ((f x).val ∈ image f S → x.val ∈ S) := by sorry
+theorem SetTheory.Set.mem_image_of_eval_counter :
+    ∃ (X Y:Set) (f:X → Y) (S: Set) (x:X), ¬((f x).val ∈ image f S → x.val ∈ S) := by sorry
 
-/-- Definition 3.4.4 (inverse images).  Again, it is not required that U be a subset of Y. -/
-abbrev SetTheory.Set.preimage {X Y:Set} (f:X → Y) (U: Set) : Set := X.specify (P := fun x ↦ (f x).val ∈ U)
+/--
+  Definition 3.4.4 (inverse images).
+  Again, it is not required that U be a subset of Y.
+-/
+abbrev SetTheory.Set.preimage {X Y:Set} (f:X → Y) (U: Set) : Set :=
+  X.specify (P := fun x ↦ (f x).val ∈ U)
 
-theorem SetTheory.Set.mem_preimage {X Y:Set} (f:X → Y) (U: Set) (x:X) : x.val ∈ preimage f U ↔ (f x).val ∈ U := by
+theorem SetTheory.Set.mem_preimage {X Y:Set} (f:X → Y) (U: Set) (x:X) :
+    x.val ∈ preimage f U ↔ (f x).val ∈ U := by
   rw [specification_axiom']
 
 /-- Connection with Mathlib's notion of preimage. -/
-theorem SetTheory.Set.preimage_eq {X Y:Set} (f:X → Y) (U: Set) : ((preimage f U): _root_.Set Object) = Subtype.val '' (f⁻¹' {y | y.val ∈ U}) := by sorry
+theorem SetTheory.Set.preimage_eq {X Y:Set} (f:X → Y) (U: Set) :
+    ((preimage f U): _root_.Set Object) = Subtype.val '' (f⁻¹' {y | y.val ∈ U}) := by sorry
 
 /-- Example 3.4.5 -/
 theorem SetTheory.Set.preimage_f_3_4_2 : preimage f_3_4_2 {2,4,6} = {1,2,3} := by sorry
 
-theorem SetTheory.Set.image_preimage_f_3_4_2 : image f_3_4_2 (preimage f_3_4_2 {1,2,3}) ≠ {1,2,3} := by sorry
+theorem SetTheory.Set.image_preimage_f_3_4_2 :
+    image f_3_4_2 (preimage f_3_4_2 {1,2,3}) ≠ {1,2,3} := by sorry
 
 /-- Example 3.4.6 (using the Mathlib notion of preimage) -/
 example : (fun n:ℤ ↦ n^2) ⁻¹' {0,1,4} = {-2,-1,0,1,2} := by sorry
@@ -74,44 +95,64 @@ instance SetTheory.Set.inst_pow : Pow Set Set where
 /-- I could not make this a coercion because of a technical `semiOutParam` issue. -/
 abbrev SetTheory.Set.object_of {X Y:Set} (f: X → Y) : Object := function_to_object X Y f
 
-theorem SetTheory.Set.power_set_axiom {X Y:Set} (F:Object) : F ∈ (X ^ Y) ↔ ∃ f: Y → X, object_of f = F := SetTheory.power_set_axiom X Y F
-
+theorem SetTheory.Set.power_set_axiom {X Y:Set} (F:Object) :
+    F ∈ (X ^ Y) ↔ ∃ f: Y → X, object_of f = F := SetTheory.power_set_axiom X Y F
 
 /-- Example 3.4.8 -/
 abbrev f_3_4_8_a : ({4,7}:Set) → ({0,1}:Set) := fun x ↦ ⟨ 0, by simp ⟩
 
 open Classical in
-noncomputable abbrev f_3_4_8_b : ({4,7}:Set) → ({0,1}:Set) := fun x ↦ if x.val = 4 then ⟨ 0, by simp ⟩ else ⟨ 1, by simp ⟩
+noncomputable abbrev f_3_4_8_b : ({4,7}:Set) → ({0,1}:Set) :=
+  fun x ↦ if x.val = 4 then ⟨ 0, by simp ⟩ else ⟨ 1, by simp ⟩
 
 open Classical in
-noncomputable abbrev f_3_4_8_c : ({4,7}:Set) → ({0,1}:Set) := fun x ↦ if x.val = 4 then ⟨ 1, by simp ⟩ else ⟨ 0, by simp ⟩
+noncomputable abbrev f_3_4_8_c : ({4,7}:Set) → ({0,1}:Set) :=
+  fun x ↦ if x.val = 4 then ⟨ 1, by simp ⟩ else ⟨ 0, by simp ⟩
 
 abbrev f_3_4_8_d : ({4,7}:Set) → ({0,1}:Set) := fun x ↦ ⟨ 1, by simp ⟩
 
-theorem SetTheory.Set.example_3_4_8 (F:Object) : F ∈ ({4,7}:Set) ^ ({0,1}:Set) ↔ F = object_of f_3_4_8_a ∨ F = object_of f_3_4_8_b ∨ F = object_of f_3_4_8_c ∨ F = object_of f_3_4_8_d := by sorry
+theorem SetTheory.Set.example_3_4_8 (F:Object) :
+    F ∈ ({4,7}:Set) ^ ({0,1}:Set) ↔ F = object_of f_3_4_8_a
+    ∨ F = object_of f_3_4_8_b ∨ F = object_of f_3_4_8_c ∨ F = object_of f_3_4_8_d := by sorry
 
 /-- Lemma 3.4.9.  One needs to provide a suitable definition of the power set here. -/
 abbrev SetTheory.Set.powerset (X:Set) : Set := sorry
 
-theorem SetTheory.Set.mem_powerset {X:Set} (x:Object) : x ∈ powerset X ↔ ∃ Y:Set, x = Y ∧ Y ⊆ X := by sorry
+theorem SetTheory.Set.mem_powerset {X:Set} (x:Object) :
+    x ∈ powerset X ↔ ∃ Y:Set, x = Y ∧ Y ⊆ X := by sorry
 
 /-- Remark 3.4.10 -/
-theorem SetTheory.Set.powerset_of_triple (a b c x:Object) : x ∈ powerset {a,b,c} ↔ x = (∅:Set) ∨ x = ({a}:Set) ∨ x = ({b}:Set) ∨ x = ({c}:Set) ∨ x = ({a,b}:Set) ∨ x = ({a,c}:Set) ∨ x = ({b,c}:Set) ∨ x = ({a,b,c}:Set) := by sorry
+theorem SetTheory.Set.powerset_of_triple (a b c x:Object) :
+    x ∈ powerset {a,b,c}
+    ↔ x = (∅:Set)
+    ∨ x = ({a}:Set)
+    ∨ x = ({b}:Set)
+    ∨ x = ({c}:Set)
+    ∨ x = ({a,b}:Set)
+    ∨ x = ({a,c}:Set)
+    ∨ x = ({b,c}:Set)
+    ∨ x = ({a,b,c}:Set) := by sorry
 
 /-- Axiom 3.11 (Union) -/
-theorem SetTheory.Set.union_axiom (A: Set) (x:Object) : x ∈ union A ↔ ∃ (S:Set), x ∈ S ∧ (S:Object) ∈ A := SetTheory.union_axiom A x
+theorem SetTheory.Set.union_axiom (A: Set) (x:Object) :
+    x ∈ union A ↔ ∃ (S:Set), x ∈ S ∧ (S:Object) ∈ A := SetTheory.union_axiom A x
 
 /-- Example 3.4.11 -/
-theorem SetTheory.Set.example_3_4_11 : union { (({2,3}:Set):Object), (({3,4}:Set):Object), (({4,5}:Set):Object) } = {2,3,4,5} := by sorry
+theorem SetTheory.Set.example_3_4_11 :
+    union { (({2,3}:Set):Object), (({3,4}:Set):Object), (({4,5}:Set):Object) } = {2,3,4,5} := by
+  sorry
 
-/-- Connection with Mathlib union
--/
-theorem SetTheory.Set.union_eq (A: Set) : (union A : _root_.Set Object) = ⋃₀ { S : _root_.Set Object | ∃ S':Set, S = S' ∧ (S':Object) ∈ A } := by sorry
+/-- Connection with Mathlib union -/
+theorem SetTheory.Set.union_eq (A: Set) :
+    (union A : _root_.Set Object) =
+    ⋃₀ { S : _root_.Set Object | ∃ S':Set, S = S' ∧ (S':Object) ∈ A } := by sorry
 
 /-- Indexed union -/
-abbrev SetTheory.Set.iUnion (I: Set) (A: I → Set) : Set := union (I.replace (P := fun α S ↦ S = A α) (by intro x y y' ⟨ h1, h2⟩; simp at h1 h2; rw [h1,h2]))
+abbrev SetTheory.Set.iUnion (I: Set) (A: I → Set) : Set :=
+  union (I.replace (P := fun α S ↦ S = A α) (by intro x y y' ⟨ h1, h2⟩; simp at h1 h2; rw [h1,h2]))
 
-theorem SetTheory.Set.mem_iUnion {I:Set} (A: I → Set) (x:Object) : x ∈ iUnion I A ↔ ∃ α:I, x ∈ A α := by
+theorem SetTheory.Set.mem_iUnion {I:Set} (A: I → Set) (x:Object) :
+    x ∈ iUnion I A ↔ ∃ α:I, x ∈ A α := by
   rw [union_axiom]
   constructor
   . intro h
@@ -130,28 +171,36 @@ theorem SetTheory.Set.mem_iUnion {I:Set} (A: I → Set) (x:Object) : x ∈ iUnio
   use α
 
 open Classical in
-noncomputable abbrev SetTheory.Set.index_example : ({1,2,3}:Set) → Set := fun i ↦ if i.val = 1 then {2,3} else if i.val = 2 then {3,4} else {4,5}
+noncomputable abbrev SetTheory.Set.index_example : ({1,2,3}:Set) → Set :=
+  fun i ↦ if i.val = 1 then {2,3} else if i.val = 2 then {3,4} else {4,5}
 
 theorem SetTheory.Set.iUnion_example : iUnion {1,2,3} index_example = {2,3,4,5} := by sorry
 
 /-- Connection with Mathlib indexed union
 -/
-theorem SetTheory.Set.iUnion_eq (I: Set) (A: I → Set) : (iUnion I A : _root_.Set Object) = ⋃ α, (A α: _root_.Set Object) := by sorry
+theorem SetTheory.Set.iUnion_eq (I: Set) (A: I → Set) :
+    (iUnion I A : _root_.Set Object) = ⋃ α, (A α: _root_.Set Object) := by sorry
 
 theorem SetTheory.Set.iUnion_of_empty (A: (∅:Set) → Set) : iUnion (∅:Set) A = ∅ := by sorry
 
 /-- Indexed intersection -/
-noncomputable abbrev SetTheory.Set.nonempty_choose {I:Set} (hI: I ≠ ∅) : I := ⟨ (nonempty_def hI).choose, (nonempty_def hI).choose_spec ⟩
+noncomputable abbrev SetTheory.Set.nonempty_choose {I:Set} (hI: I ≠ ∅) : I :=
+  ⟨(nonempty_def hI).choose, (nonempty_def hI).choose_spec⟩
 
-abbrev SetTheory.Set.iInter' (I:Set) (β:I) (A: I → Set) : Set := (A β).specify (P := fun x ↦ ∀ α:I, x.val ∈ A α)
+abbrev SetTheory.Set.iInter' (I:Set) (β:I) (A: I → Set) : Set :=
+  (A β).specify (P := fun x ↦ ∀ α:I, x.val ∈ A α)
 
-noncomputable abbrev SetTheory.Set.iInter (I: Set) (hI: I ≠ ∅) (A: I → Set) : Set := iInter' I (nonempty_choose hI) A
+noncomputable abbrev SetTheory.Set.iInter (I: Set) (hI: I ≠ ∅) (A: I → Set) : Set :=
+  iInter' I (nonempty_choose hI) A
 
-theorem SetTheory.Set.mem_iInter {I:Set} (hI: I ≠ ∅) (A: I → Set) (x:Object) : x ∈ iInter I hI A ↔ ∀ α:I, x ∈ A α := by
+theorem SetTheory.Set.mem_iInter {I:Set} (hI: I ≠ ∅) (A: I → Set) (x:Object) :
+    x ∈ iInter I hI A ↔ ∀ α:I, x ∈ A α := by
   sorry
 
 /-- Exercise 3.4.1 -/
-theorem SetTheory.Set.preimage_eq_image_of_inv {X Y V:Set} (f:X → Y) (f_inv: Y → X) (hf: Function.LeftInverse f_inv f ∧ Function.RightInverse f_inv f) (hV: V ⊆ Y) : image f_inv V = preimage f V := by sorry
+theorem SetTheory.Set.preimage_eq_image_of_inv {X Y V:Set} (f:X → Y) (f_inv: Y → X)
+  (hf: Function.LeftInverse f_inv f ∧ Function.RightInverse f_inv f) (hV: V ⊆ Y) :
+    image f_inv V = preimage f V := by sorry
 
 /- Exercise 3.4.2.  State and prove an assertion connecting `preimage (image f S)` and `S`. -/
 -- theorem SetTheory.Set.preimage_of_image {X Y:Set} (f:X → Y) (S: Set) : sorry := by sorry
@@ -159,48 +208,73 @@ theorem SetTheory.Set.preimage_eq_image_of_inv {X Y V:Set} (f:X → Y) (f_inv: Y
 /- Exercise 3.4.2.  State and prove an assertion connecting `image (preimage f U)` and `U`. -/
 -- theorem SetTheory.Set.preimage_of_image {X Y:Set} (f:X → Y) (U: Set) : sorry := by sorry
 
-/-- Exercise 3.4.3.  Also state and prove an assertion regarding whether `⊆` can be improved to `=`. -/
-theorem SetTheory.Set.image_of_inter {X Y:Set} (f:X → Y) (A B: Set) : image f (A ∩ B) ⊆ (image f A) ∩ (image f B) := by sorry
+/--
+  Exercise 3.4.3.  Also state and prove an assertion regarding whether `⊆` can be improved to `=`.
+-/
+theorem SetTheory.Set.image_of_inter {X Y:Set} (f:X → Y) (A B: Set) :
+    image f (A ∩ B) ⊆ (image f A) ∩ (image f B) := by sorry
 
-theorem SetTheory.Set.image_of_diff {X Y:Set} (f:X → Y) (A B: Set) : (image f A) \ (image f B) ⊆ image f (A \ B) := by sorry
+theorem SetTheory.Set.image_of_diff {X Y:Set} (f:X → Y) (A B: Set) :
+    (image f A) \ (image f B) ⊆ image f (A \ B) := by sorry
 
-theorem SetTheory.Set.image_of_union {X Y:Set} (f:X → Y) (A B: Set) : image f (A ∪ B) = (image f A) ∪ (image f B) := by sorry
+theorem SetTheory.Set.image_of_union {X Y:Set} (f:X → Y) (A B: Set) :
+    image f (A ∪ B) = (image f A) ∪ (image f B) := by sorry
 
 /-- Exercise 3.4.4 -/
-theorem SetTheory.Set.preimage_of_inter {X Y:Set} (f:X → Y) (A B: Set) : preimage f (A ∩ B) = (preimage f A) ∩ (preimage f B) := by sorry
+theorem SetTheory.Set.preimage_of_inter {X Y:Set} (f:X → Y) (A B: Set) :
+    preimage f (A ∩ B) = (preimage f A) ∩ (preimage f B) := by sorry
 
-theorem SetTheory.Set.preimage_of_union {X Y:Set} (f:X → Y) (A B: Set) : preimage f (A ∪ B) = (preimage f A) ∪ (preimage f B) := by sorry
+theorem SetTheory.Set.preimage_of_union {X Y:Set} (f:X → Y) (A B: Set) :
+    preimage f (A ∪ B) = (preimage f A) ∪ (preimage f B) := by sorry
 
-theorem SetTheory.Set.preimage_of_diff {X Y:Set} (f:X → Y) (A B: Set) : preimage f (A \ B) = (preimage f A) \ (preimage f B)  := by sorry
+theorem SetTheory.Set.preimage_of_diff {X Y:Set} (f:X → Y) (A B: Set) :
+    preimage f (A \ B) = (preimage f A) \ (preimage f B)  := by sorry
 
 /-- Exercise 3.4.5 -/
-theorem SetTheory.Set.image_preimage_of_surj {X Y:Set} (f:X → Y) : (∀ S, S ⊆ Y → image f (preimage f S) = S) ↔ Function.Surjective f := by sorry
+theorem SetTheory.Set.image_preimage_of_surj {X Y:Set} (f:X → Y) :
+    (∀ S, S ⊆ Y → image f (preimage f S) = S) ↔ Function.Surjective f := by sorry
 
 /-- Exercise 3.4.5 -/
-theorem SetTheory.Set.preimage_image_of_inj {X Y:Set} (f:X → Y) : (∀ S, S ⊆ X → preimage f (image f S) = S) ↔ Function.Injective f := by sorry
+theorem SetTheory.Set.preimage_image_of_inj {X Y:Set} (f:X → Y) :
+    (∀ S, S ⊆ X → preimage f (image f S) = S) ↔ Function.Injective f := by sorry
 
 /-- Exercise 3.4.7 -/
-theorem SetTheory.Set.partial_functions {X Y:Set} : ∃ Z:Set, ∀ F:Object, F ∈ Z ↔ ∃ X' Y':Set, X' ⊆ X ∧ Y' ⊆ Y ∧ ∃ f: X' → Y', F = object_of f := by sorry
+theorem SetTheory.Set.partial_functions {X Y:Set} :
+    ∃ Z:Set, ∀ F:Object, F ∈ Z ↔ ∃ X' Y':Set, X' ⊆ X ∧ Y' ⊆ Y ∧ ∃ f: X' → Y', F = object_of f := by
+  sorry
 
-/-- Exercise 3.4.8.  The point of this exercise is to prove it without using the pairwise union operation `∪`. -/
-theorem SetTheory.Set.union_pair_exists (X Y:Set) : ∃ Z:Set, ∀ x, x ∈ Z ↔ (x ∈ X ∨ x ∈ Y) := by sorry
+/--
+  Exercise 3.4.8.  The point of this exercise is to prove it without using the
+  pairwise union operation `∪`.
+-/
+theorem SetTheory.Set.union_pair_exists (X Y:Set) : ∃ Z:Set, ∀ x, x ∈ Z ↔ (x ∈ X ∨ x ∈ Y) := by
+  sorry
 
 /-- Exercise 3.4.9 -/
-theorem SetTheory.Set.iInter'_insensitive {I:Set} (β β':I) (A: I → Set) : iInter' I β A = iInter' I β' A := by sorry
+theorem SetTheory.Set.iInter'_insensitive {I:Set} (β β':I) (A: I → Set) :
+    iInter' I β A = iInter' I β' A := by sorry
 
 /-- Exercise 3.4.10 -/
-theorem SetTheory.Set.union_iUnion {I J:Set} (A: (I ∪ J:Set) → Set) : iUnion I (fun α ↦ A ⟨ α.val, by simp [α.property]⟩) ∪ iUnion J (fun α ↦ A ⟨ α.val, by simp [α.property]⟩) = iUnion (I ∪ J) A := by sorry
+theorem SetTheory.Set.union_iUnion {I J:Set} (A: (I ∪ J:Set) → Set) :
+    iUnion I (fun α ↦ A ⟨ α.val, by simp [α.property]⟩)
+    ∪ iUnion J (fun α ↦ A ⟨ α.val, by simp [α.property]⟩)
+    = iUnion (I ∪ J) A := by sorry
 
 /-- Exercise 3.4.10 -/
 theorem SetTheory.Set.union_of_nonempty {I J:Set} (hI: I ≠ ∅) (hJ: J ≠ ∅) : I ∪ J ≠ ∅ := by sorry
 
 /-- Exercise 3.4.10 -/
-theorem SetTheory.Set.inter_iInter {I J:Set} (hI: I ≠ ∅) (hJ: J ≠ ∅) (A: (I ∪ J:Set) → Set) : iInter I hI (fun α ↦ A ⟨ α.val, by simp [α.property]⟩) ∪ iInter J hJ (fun α ↦ A ⟨ α.val, by simp [α.property]⟩) = iInter (I ∪ J) (union_of_nonempty hI hJ) A := by sorry
+theorem SetTheory.Set.inter_iInter {I J:Set} (hI: I ≠ ∅) (hJ: J ≠ ∅) (A: (I ∪ J:Set) → Set) :
+    iInter I hI (fun α ↦ A ⟨ α.val, by simp [α.property]⟩)
+    ∪ iInter J hJ (fun α ↦ A ⟨ α.val, by simp [α.property]⟩)
+    = iInter (I ∪ J) (union_of_nonempty hI hJ) A := by sorry
 
 /-- Exercise 3.4.11 -/
-theorem SetTheory.Set.compl_iUnion {X I: Set} (hI: I ≠ ∅) (A: I → Set) : X \ iUnion I A = iInter I hI (fun α ↦ X \ A α) := by sorry
+theorem SetTheory.Set.compl_iUnion {X I: Set} (hI: I ≠ ∅) (A: I → Set) :
+    X \ iUnion I A = iInter I hI (fun α ↦ X \ A α) := by sorry
 
 /-- Exercise 3.4.11 -/
-theorem SetTheory.Set.compl_iInter {X I: Set} (hI: I ≠ ∅) (A: I → Set) : X \ iInter I hI A = iUnion I (fun α ↦ X \ A α) := by sorry
+theorem SetTheory.Set.compl_iInter {X I: Set} (hI: I ≠ ∅) (A: I → Set) :
+    X \ iInter I hI A = iUnion I (fun α ↦ X \ A α) := by sorry
 
 end Chapter3

--- a/analysis/Analysis/Section_3_5.lean
+++ b/analysis/Analysis/Section_3_5.lean
@@ -6,7 +6,11 @@ import Analysis.Section_3_4
 /-!
 # Analysis I, Section 3.5
 
-I have attempted to make the translation as faithful a paraphrasing as possible of the original text.   When there is a choice between a more idiomatic Lean solution and a more faithful translation, I have generally chosen the latter.  In particular, there will be places where the Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided doing so.
+I have attempted to make the translation as faithful a paraphrasing as possible of the original
+text. When there is a choice between a more idiomatic Lean solution and a more faithful
+translation, I have generally chosen the latter. In particular, there will be places where the
+Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided
+doing so.
 
 Main constructions and results of this section:
 
@@ -32,7 +36,8 @@ structure OrderedPair where
 #check OrderedPair.ext
 
 /-- Definition 3.5.1 (Ordered pair) -/
-theorem OrderedPair.eq (x y x' y':Object) : (⟨ x, y ⟩:OrderedPair) = (⟨ x', y' ⟩:OrderedPair) ↔ x = x' ∧ y = y' := by aesop
+theorem OrderedPair.eq (x y x' y' : Object) :
+    (⟨ x, y ⟩ : OrderedPair) = (⟨ x', y' ⟩ : OrderedPair) ↔ x = x' ∧ y = y' := by aesop
 
 /-- Exercise 3.5.1 -/
 abbrev OrderedPair.toObject : OrderedPair ↪ Object where
@@ -42,25 +47,34 @@ abbrev OrderedPair.toObject : OrderedPair ↪ Object where
 instance OrderedPair.inst_coeObject : Coe OrderedPair Object where
   coe := OrderedPair.toObject
 
-/-- A technical operation, turning a object `x` and a set `Y` to a set `{x} × Y`, needed to define the full Cartesian product-/
-abbrev SetTheory.Set.slice (x:Object) (Y:Set) : Set := Y.replace (P := fun y z ↦ z = (⟨x, y⟩:OrderedPair)) (by
-  intro y z z' ⟨ hz, hz'⟩
-  simp at hz hz'
-  rw [hz, hz'])
+/--
+  A technical operation, turning a object `x` and a set `Y` to a set `{x} × Y`, needed to define
+  the full Cartesian product
+-/
+abbrev SetTheory.Set.slice (x:Object) (Y:Set) : Set :=
+  Y.replace (P := fun y z ↦ z = (⟨x, y⟩:OrderedPair)) (by
+    intro y z z' ⟨ hz, hz'⟩
+    simp at hz hz'
+    rw [hz, hz']
+  )
 
-theorem SetTheory.Set.mem_slice (x z:Object) (Y:Set) : z ∈ (SetTheory.Set.slice x Y) ↔ ∃ y:Y, z = (⟨x, y⟩:OrderedPair) :=  replacement_axiom _ _
+theorem SetTheory.Set.mem_slice (x z:Object) (Y:Set) :
+    z ∈ (SetTheory.Set.slice x Y) ↔ ∃ y:Y, z = (⟨x, y⟩:OrderedPair) := replacement_axiom _ _
 
 /-- Definition 3.5.2 (Cartesian product) -/
-abbrev SetTheory.Set.cartesian (X Y:Set) : Set := union (X.replace (P := fun x z ↦ z = slice x Y) (by
-  intro x z z' ⟨ hz, hz' ⟩
-  simp at hz hz'
-  rw [hz, hz']))
+abbrev SetTheory.Set.cartesian (X Y:Set) : Set :=
+  union (X.replace (P := fun x z ↦ z = slice x Y) (by
+    intro x z z' ⟨ hz, hz' ⟩
+    simp at hz hz'
+    rw [hz, hz']
+  ))
 
 /-- This instance enables the ×ˢ notation for Cartesian product. -/
 instance SetTheory.Set.inst_SProd : SProd Set Set Set where
   sprod := cartesian
 
-theorem SetTheory.Set.mem_cartesian (z:Object) (X Y:Set) : z ∈ X ×ˢ Y ↔ ∃ x:X, ∃ y:Y, z = (⟨x, y⟩:OrderedPair) := by
+theorem SetTheory.Set.mem_cartesian (z:Object) (X Y:Set) :
+    z ∈ X ×ˢ Y ↔ ∃ x:X, ∃ y:Y, z = (⟨x, y⟩:OrderedPair) := by
   simp only [SProd.sprod, union_axiom]
   constructor
   . intro h
@@ -81,13 +95,19 @@ theorem SetTheory.Set.mem_cartesian (z:Object) (X Y:Set) : z ∈ X ×ˢ Y ↔ �
   rw [replacement_axiom]
   use x
 
-abbrev SetTheory.Set.curry {X Y Z:Set} (f: X ×ˢ Y → Z) : X → Y → Z := fun x y ↦ f ⟨ (⟨ x, y ⟩:OrderedPair), by rw [mem_cartesian]; use x, y ⟩
+abbrev SetTheory.Set.curry {X Y Z:Set} (f: X ×ˢ Y → Z) : X → Y → Z :=
+  fun x y ↦ f ⟨ (⟨ x, y ⟩:OrderedPair), by rw [mem_cartesian]; use x, y ⟩
 
-noncomputable abbrev SetTheory.Set.fst {X Y:Set} (z:X ×ˢ Y) : X := (show ∃ x:X, ∃ y:Y, z.val = (⟨ x, y ⟩:OrderedPair) by exact (mem_cartesian _ _ _).mp z.property).choose
+noncomputable abbrev SetTheory.Set.fst {X Y:Set} (z:X ×ˢ Y) : X :=
+  (show ∃ x:X, ∃ y:Y, z.val = (⟨ x, y ⟩:OrderedPair)
+  by exact (mem_cartesian _ _ _).mp z.property).choose
 
-noncomputable abbrev SetTheory.Set.snd {X Y:Set} (z:X ×ˢ Y) : Y := (show ∃ y:Y, ∃ x:X, z.val = (⟨ x, y ⟩:OrderedPair) by rw [exists_comm]; exact (mem_cartesian _ _ _).mp z.property).choose
+noncomputable abbrev SetTheory.Set.snd {X Y:Set} (z:X ×ˢ Y) : Y :=
+  (show ∃ y:Y, ∃ x:X, z.val = (⟨ x, y ⟩:OrderedPair)
+  by rw [exists_comm]; exact (mem_cartesian _ _ _).mp z.property).choose
 
-theorem SetTheory.Set.pair_eq_fst_snd {X Y:Set} (z:X ×ˢ Y) : z.val = (⟨ fst z, snd z ⟩:OrderedPair) := by
+theorem SetTheory.Set.pair_eq_fst_snd {X Y:Set} (z:X ×ˢ Y) :
+    z.val = (⟨ fst z, snd z ⟩:OrderedPair) := by
   obtain ⟨ y, hy ⟩ := ((mem_cartesian _ _ _).mp z.property).choose_spec
   obtain ⟨ x, hx ⟩ := (exists_comm.mp ((mem_cartesian _ _ _).mp z.property)).choose_spec
   change z.val = (⟨ fst z, y ⟩:OrderedPair) at hy
@@ -96,7 +116,8 @@ theorem SetTheory.Set.pair_eq_fst_snd {X Y:Set} (z:X ×ˢ Y) : z.val = (⟨ fst 
   simp only [EmbeddingLike.apply_eq_iff_eq, OrderedPair.eq] at hy ⊢
   simp [hy.1]
 
-noncomputable abbrev SetTheory.Set.uncurry {X Y Z:Set} (f: X → Y → Z) : X ×ˢ Y → Z := fun z ↦ f (fst z) (snd z)
+noncomputable abbrev SetTheory.Set.uncurry {X Y Z:Set} (f: X → Y → Z) : X ×ˢ Y → Z :=
+  fun z ↦ f (fst z) (snd z)
 
 theorem SetTheory.Set.curry_uncurry {X Y Z:Set} (f: X → Y → Z) : curry (uncurry f) = f := by sorry
 
@@ -115,7 +136,8 @@ noncomputable abbrev SetTheory.Set.prod_associator (X Y Z:Set) : (X ×ˢ Y) ×ˢ
   right_inv := sorry
 
 /-- Connections with the Mathlib set product -/
-noncomputable abbrev SetTheory.Set.prod_equiv_prod (X Y:Set) : ((X ×ˢ Y):_root_.Set Object) ≃ (X:_root_.Set Object) ×ˢ (Y:_root_.Set Object) where
+noncomputable abbrev SetTheory.Set.prod_equiv_prod (X Y:Set) :
+    ((X ×ˢ Y):_root_.Set Object) ≃ (X:_root_.Set Object) ×ˢ (Y:_root_.Set Object) where
   toFun := sorry
   invFun := sorry
   left_inv := sorry
@@ -123,13 +145,16 @@ noncomputable abbrev SetTheory.Set.prod_equiv_prod (X Y:Set) : ((X ×ˢ Y):_root
 
 
 /-- Definition 3.5.7 -/
-abbrev SetTheory.Set.tuple {I:Set} {X: I → Set} (a: ∀ i, X i) : Object := object_of ((fun i ↦ ⟨ a i, by rw [mem_iUnion]; use i; exact (a i).property ⟩):I → iUnion I X)
+abbrev SetTheory.Set.tuple {I:Set} {X: I → Set} (a: ∀ i, X i) : Object :=
+  object_of ((fun i ↦ ⟨ a i, by rw [mem_iUnion]; use i; exact (a i).property ⟩):I → iUnion I X)
 
 /-- Definition 3.5.7 -/
-abbrev SetTheory.Set.iProd {I: Set} (X: I → Set) : Set := ((iUnion I X)^I).specify (fun t ↦ ∃ a : ∀ i, X i, t = tuple a)
+abbrev SetTheory.Set.iProd {I: Set} (X: I → Set) : Set :=
+  ((iUnion I X)^I).specify (fun t ↦ ∃ a : ∀ i, X i, t = tuple a)
 
 /-- Definition 3.5.7 -/
-theorem SetTheory.Set.mem_iProd {I: Set} {X: I → Set} (t:Object) : t ∈ iProd X ↔ ∃ a: ∀ i, X i, t = tuple a := by
+theorem SetTheory.Set.mem_iProd {I: Set} {X: I → Set} (t:Object) :
+    t ∈ iProd X ↔ ∃ a: ∀ i, X i, t = tuple a := by
   simp only [iProd, specification_axiom'']
   constructor
   . intro ⟨ ht, a, h ⟩
@@ -140,13 +165,19 @@ theorem SetTheory.Set.mem_iProd {I: Set} {X: I → Set} (t:Object) : t ∈ iProd
     use fun i ↦ ⟨ a i, by rw [mem_iUnion]; use i; exact (a i).property ⟩
   use h, a
 
-theorem SetTheory.Set.tuple_mem_iProd {I: Set} {X: I → Set} (a: ∀ i, X i) : tuple a ∈ iProd X := by rw [mem_iProd]; use a
+theorem SetTheory.Set.tuple_mem_iProd {I: Set} {X: I → Set} (a: ∀ i, X i) :
+    tuple a ∈ iProd X := by rw [mem_iProd]; use a
 
 @[simp]
-theorem SetTheory.Set.tuple_inj {I:Set} {X: I → Set} (a b: ∀ i, X i) : tuple a = tuple b ↔ a = b := by sorry
+theorem SetTheory.Set.tuple_inj {I:Set} {X: I → Set} (a b: ∀ i, X i) :
+    tuple a = tuple b ↔ a = b := by sorry
 
-/-- Example 3.5.11.  I suspect most of the equivalences will require classical reasoning and only be defined non-computably, but would be happy to learn of counterexamples. -/
-noncomputable abbrev SetTheory.Set.singleton_iProd_equiv (i:Object) (X:Set) : iProd (fun _:({i}:Set) ↦ X) ≃ X where
+/--
+  Example 3.5.11. I suspect most of the equivalences will require classical reasoning and only be
+  defined non-computably, but would be happy to learn of counterexamples.
+-/
+noncomputable abbrev SetTheory.Set.singleton_iProd_equiv (i:Object) (X:Set) :
+    iProd (fun _:({i}:Set) ↦ X) ≃ X where
   toFun := sorry
   invFun := sorry
   left_inv := sorry
@@ -160,37 +191,46 @@ noncomputable abbrev SetTheory.Set.empty_iProd_equiv (X: (∅:Set) → Set) : iP
   right_inv := sorry
 
 /-- Example 3.5.11 -/
-noncomputable abbrev SetTheory.Set.iProd_of_const_equiv (I:Set) (X: Set) : iProd (fun i:I ↦ X) ≃ (I → X) where
+noncomputable abbrev SetTheory.Set.iProd_of_const_equiv (I:Set) (X: Set) :
+    iProd (fun i:I ↦ X) ≃ (I → X) where
   toFun := sorry
   invFun := sorry
   left_inv := sorry
   right_inv := sorry
 
-noncomputable abbrev SetTheory.Set.iProd_equiv_prod (X: ({0,1}:Set) → Set) : iProd X ≃ (X ⟨ 0, by simp ⟩) ×ˢ (X ⟨ 1, by simp ⟩) where
+noncomputable abbrev SetTheory.Set.iProd_equiv_prod (X: ({0,1}:Set) → Set) :
+    iProd X ≃ (X ⟨ 0, by simp ⟩) ×ˢ (X ⟨ 1, by simp ⟩) where
   toFun := sorry
   invFun := sorry
   left_inv := sorry
   right_inv := sorry
 
 /-- Example 3.5.9 -/
-noncomputable abbrev SetTheory.Set.iProd_equiv_prod_triple (X: ({0,1,2}:Set) → Set) : iProd X ≃ (X ⟨ 0, by simp ⟩) ×ˢ (X ⟨ 1, by simp ⟩) ×ˢ (X ⟨ 2, by simp ⟩) where
+noncomputable abbrev SetTheory.Set.iProd_equiv_prod_triple (X: ({0,1,2}:Set) → Set) :
+    iProd X ≃ (X ⟨ 0, by simp ⟩) ×ˢ (X ⟨ 1, by simp ⟩) ×ˢ (X ⟨ 2, by simp ⟩) where
   toFun := sorry
   invFun := sorry
   left_inv := sorry
   right_inv := sorry
 
 /-- Connections with Mathlib's `Set.pi` -/
-noncomputable abbrev SetTheory.Set.iProd_equiv_pi (I:Set) (X: I → Set) : iProd X ≃ Set.pi Set.univ (fun i:I ↦ ((X i):_root_.Set Object)) where
+noncomputable abbrev SetTheory.Set.iProd_equiv_pi (I:Set) (X: I → Set) :
+    iProd X ≃ Set.pi Set.univ (fun i:I ↦ ((X i):_root_.Set Object)) where
   toFun := sorry
   invFun := sorry
   left_inv := sorry
   right_inv := sorry
 
 
--- remark: there are also additional relations between these equivalences, but this begins to drift into the field of higher order category theory, which we will not pursue here.
+/-
+remark: there are also additional relations between these equivalences, but this begins to drift
+into the field of higher order category theory, which we will not pursue here.
+-/
 
-
-/-- Here we set up some an analogue of Mathlib `Fin n` types within the Chapter 3 Set Theory, with rudimentary API. -/
+/--
+  Here we set up some an analogue of Mathlib `Fin n` types within the Chapter 3 Set Theory,
+  with rudimentary API.
+-/
 abbrev SetTheory.Set.Fin (n:ℕ) : Set := nat.specify (fun m ↦ (m:ℕ) < n)
 
 theorem SetTheory.Set.mem_Fin (n:ℕ) (x:Object) : x ∈ Fin n ↔ ∃ m, m < n ∧ x = m := by
@@ -225,7 +265,10 @@ abbrev SetTheory.Set.Fin_embed (n N:ℕ) (h: n ≤ N) (i: Fin n) : Fin N := ⟨ 
   use m, by linarith
 ⟩
 
-/-- I suspect that this equivalence is non-computable and requires classical logic, unless there is a clever trick. -/
+/--
+  I suspect that this equivalence is non-computable and requires classical logic,
+  unless there is a clever trick.
+-/
 noncomputable abbrev SetTheory.Set.Fin_equiv_Fin (n:ℕ) : Fin n ≃ _root_.Fin n where
   toFun := sorry
   invFun := sorry
@@ -234,7 +277,8 @@ noncomputable abbrev SetTheory.Set.Fin_equiv_Fin (n:ℕ) : Fin n ≃ _root_.Fin 
 
 /-- Lemma 3.5.12 (finite choice) -/
 theorem SetTheory.Set.finite_choice {n:ℕ} {X: Fin n → Set} (h: ∀ i, X i ≠ ∅) : iProd X ≠ ∅ := by
-  -- This proof broadly follows the one in the text (although it is more convenient to induct from 0 rather than 1)
+  -- This proof broadly follows the one in the text
+  -- (although it is more convenient to induct from 0 rather than 1)
   induction' n with n hn
   . have : Fin 0 = ∅ := by
       rw [eq_empty_iff_forall_notMem]
@@ -257,7 +301,10 @@ theorem SetTheory.Set.finite_choice {n:ℕ} {X: Fin n → Set} (h: ∀ i, X i �
   set x : ∀ i, X i := by
     intro i
     have := mem_Fin' i
-    classical -- it is unfortunate here that classical logic is required to perform this gluing; this is because `nat` is technically not an inductive type.  There should be some workaround involving the equivalence betweeen `nat` and `ℕ` (which is an inductive type).
+    classical
+    -- it is unfortunate here that classical logic is required to perform this gluing; this is
+    -- because `nat` is technically not an inductive type.  There should be some workaround
+    -- involving the equivalence betweeen `nat` and `ℕ` (which is an inductive type).
     cases decEq i last with
       | isTrue heq =>
         rw [heq]
@@ -288,26 +335,35 @@ structure SetTheory.Set.Tuple (n:ℕ) where
   surj: Function.Surjective x
 
 /-- Exercise 3.5.2 -/
-theorem SetTheory.Set.Tuple.eq {n:ℕ} (t t':Tuple n) : t = t' ↔ ∀ n : Fin n, ((t.x n):Object) = ((t'.x n):Object) := by sorry
+theorem SetTheory.Set.Tuple.eq {n:ℕ} (t t':Tuple n) :
+    t = t' ↔ ∀ n : Fin n, ((t.x n):Object) = ((t'.x n):Object) := by sorry
 
-noncomputable abbrev SetTheory.Set.iProd_equiv_tuples (n:ℕ) (X: Fin n → Set) : iProd X ≃ { t:Tuple n // ∀ i, (t.x i:Object) ∈ X i } where
+noncomputable abbrev SetTheory.Set.iProd_equiv_tuples (n:ℕ) (X: Fin n → Set) :
+    iProd X ≃ { t:Tuple n // ∀ i, (t.x i:Object) ∈ X i } where
   toFun := sorry
   invFun := sorry
   left_inv := sorry
   right_inv := sorry
 
-/-- Exercise 3.5.3.  The spirit here is to avoid direct rewrites (which make all of these claims trivial), and instead use `OrderedPair.eq` or `SetTheory.Set.tuple_inj` -/
+/--
+  Exercise 3.5.3. The spirit here is to avoid direct rewrites (which make all of these claims
+  trivial), and instead use `OrderedPair.eq` or `SetTheory.Set.tuple_inj`
+-/
 theorem OrderedPair.refl (p: OrderedPair) : p = p := by sorry
 
 theorem OrderedPair.symm (p q: OrderedPair) : p = q ↔ q = p := by sorry
 
 theorem OrderedPair.trans {p q r: OrderedPair} (hpq: p=q) (hqr: q=r) : p=r := by sorry
 
-theorem SetTheory.Set.tuple_refl {I:Set} {X: I → Set} (a: ∀ i, X i) : tuple a = tuple a := by sorry
+theorem SetTheory.Set.tuple_refl {I:Set} {X: I → Set} (a: ∀ i, X i) :
+    tuple a = tuple a := by sorry
 
-theorem SetTheory.Set.tuple_symm {I:Set} {X: I → Set} (a b: ∀ i, X i) : tuple a = tuple b ↔ tuple b = tuple a := by sorry
+theorem SetTheory.Set.tuple_symm {I:Set} {X: I → Set} (a b: ∀ i, X i) :
+    tuple a = tuple b ↔ tuple b = tuple a := by sorry
 
-theorem SetTheory.Set.tuple_trans {I:Set} {X: I → Set} {a b c: ∀ i, X i} (hab: tuple a = tuple b) (hbc : tuple b = tuple c) : tuple a = tuple c := by sorry
+theorem SetTheory.Set.tuple_trans {I:Set} {X: I → Set} {a b c: ∀ i, X i}
+  (hab: tuple a = tuple b) (hbc : tuple b = tuple c) :
+    tuple a = tuple c := by sorry
 
 /-- Exercise 3.5.4 -/
 theorem SetTheory.Set.prod_union (A B C:Set) : A ×ˢ (B ∪ C) = (A ×ˢ B) ∪ (A ×ˢ C) := by sorry
@@ -328,7 +384,8 @@ theorem SetTheory.Set.inter_prod (A B C:Set) : (A ∩ B) ×ˢ C = (A ×ˢ C) ∩
 theorem SetTheory.Set.diff_prod (A B C:Set) : (A \ B) ×ˢ C = (A ×ˢ C) \ (A ×ˢ B) := by sorry
 
 /-- Exercise 3.5.5 -/
-theorem SetTheory.Set.inter_of_prod (A B C D:Set) : (A ×ˢ B) ∩ (C ×ˢ D) = (A ∩ C) ×ˢ (B ∩ D) := by sorry
+theorem SetTheory.Set.inter_of_prod (A B C D:Set) :
+    (A ×ˢ B) ∩ (C ×ˢ D) = (A ∩ C) ×ˢ (B ∩ D) := by sorry
 
 /- Exercise 3.5.5: uncomment and prove one of these theorems, and delete the other. -/
 -- theorem SetTheory.Set.union_of_prod (A B C D:Set) : (A ×ˢ B) ∪ (C ×ˢ D) = (A ∪ C) ×ˢ (B ∪ D) := by sorry
@@ -340,34 +397,55 @@ theorem SetTheory.Set.inter_of_prod (A B C D:Set) : (A ×ˢ B) ∩ (C ×ˢ D) = 
 
 -- theorem SetTheory.Set.not_union_of_prod : ¬ ∀ A B C D:Set, (A ×ˢ B) \ (C ×ˢ D) = (A \ C) ×ˢ (B \ D) := by sorry
 
-/-- Exercise 3.5.6.  State and prove a theorem describing what happens if the non-emptiness hypotheses are removed. -/
-theorem SetTheory.Set.prod_subset_prod {A B C D:Set} (hA: A ≠ ∅) (hB: B ≠ ∅) (hC: C ≠ ∅) (hD: D ≠ ∅) : A ×ˢ B ⊆ C ×ˢ D ↔ A ⊆ C ∧ B ⊆ D := by sorry
+/--
+  Exercise 3.5.6. State and prove a theorem describing what happens if the non-emptiness
+  hypotheses are removed.
+-/
+theorem SetTheory.Set.prod_subset_prod {A B C D:Set}
+  (hA: A ≠ ∅) (hB: B ≠ ∅) (hC: C ≠ ∅) (hD: D ≠ ∅) :
+    A ×ˢ B ⊆ C ×ˢ D ↔ A ⊆ C ∧ B ⊆ D := by sorry
 
 /-- Exercise 3.5.7 -/
-theorem SetTheory.Set.direct_sum {X Y Z:Set} (f: Z → X) (g: Z → Y) : ∃! h: Z → X ×ˢ Y, fst ∘ h = f ∧ snd ∘ h = g := by sorry
+theorem SetTheory.Set.direct_sum {X Y Z:Set} (f: Z → X) (g: Z → Y) :
+    ∃! h: Z → X ×ˢ Y, fst ∘ h = f ∧ snd ∘ h = g := by sorry
 
 /-- Exercise 3.5.8 -/
 @[simp]
-theorem SetTheory.Set.iProd_empty_iff {n:ℕ} {X: Fin n → Set} : iProd X = ∅ ↔ ∀ i, X i = ∅ := by sorry
+theorem SetTheory.Set.iProd_empty_iff {n:ℕ} {X: Fin n → Set} :
+    iProd X = ∅ ↔ ∀ i, X i = ∅ := by sorry
 
 /-- Exercise 3.5.9-/
-theorem SetTheory.Set.iUnion_inter_iUnion {I J: Set} (A: I → Set) (B: J → Set) : (iUnion I A) ∩ (iUnion J B) = iUnion (I ×ˢ J) (fun p ↦ (A (fst p)) ∩ (B (snd p))) := by sorry
+theorem SetTheory.Set.iUnion_inter_iUnion {I J: Set} (A: I → Set) (B: J → Set) :
+    (iUnion I A) ∩ (iUnion J B) = iUnion (I ×ˢ J) (fun p ↦ (A (fst p)) ∩ (B (snd p))) := by sorry
 
-abbrev SetTheory.Set.graph {X Y:Set} (f: X → Y) : Set := (X ×ˢ Y).specify (fun p ↦ (f (fst p) = snd p))
+abbrev SetTheory.Set.graph {X Y:Set} (f: X → Y) : Set :=
+  (X ×ˢ Y).specify (fun p ↦ (f (fst p) = snd p))
 
 /-- Exercise 3.5.10 -/
-theorem SetTheory.Set.graph_inj {X Y:Set} (f f': X → Y) : graph f = graph f' ↔ f = f' := by sorry
+theorem SetTheory.Set.graph_inj {X Y:Set} (f f': X → Y) :
+    graph f = graph f' ↔ f = f' := by sorry
 
-theorem SetTheory.Set.is_graph {X Y G:Set} (hG: G ⊆ X ×ˢ Y) (hvert: ∀ x:X, ∃! y:Y, ((⟨x,y⟩:OrderedPair):Object) ∈ G) : ∃! f: X → Y, G = graph f := by sorry
+theorem SetTheory.Set.is_graph {X Y G:Set} (hG: G ⊆ X ×ˢ Y)
+  (hvert: ∀ x:X, ∃! y:Y, ((⟨x,y⟩:OrderedPair):Object) ∈ G) :
+    ∃! f: X → Y, G = graph f := by sorry
 
-/-- Exercise 3.5.11.  This trivially follows from `SetTheory.Set.power_set_axiom'`, but the exercise is to derive it from `SetTheory.Set.mem_powerset` instead. -/
-theorem SetTheory.Set.power_set_axiom' (X Y:Set) : ∃! S:Set, ∀(F:Object), F ∈ S ↔ ∃ f: Y → X, object_of f = F := sorry
+/--
+  Exercise 3.5.11. This trivially follows from `SetTheory.Set.power_set_axiom'`, but the
+  exercise is to derive it from `SetTheory.Set.mem_powerset` instead.
+-/
+theorem SetTheory.Set.power_set_axiom' (X Y:Set) :
+    ∃! S:Set, ∀(F:Object), F ∈ S ↔ ∃ f: Y → X, object_of f = F := sorry
 
 /-- Exercise 3.5.12 -/
-theorem SetTheory.Set.recursion (f: nat → nat → nat) (c:nat) : ∃! a: nat → nat, a 0 = c ∧ ∀ n, a (n + 1:ℕ) = f n (a n) := by sorry
+theorem SetTheory.Set.recursion (f: nat → nat → nat) (c:nat) :
+    ∃! a: nat → nat, a 0 = c ∧ ∀ n, a (n + 1:ℕ) = f n (a n) := by sorry
 
 /-- Exercise 3.5.13 -/
-theorem SetTheory.Set.nat_unique (nat':Set) (zero:nat') (succ:nat' → nat') (succ_ne: ∀ n:nat', succ n ≠ zero) (succ_of_ne: ∀ n m:nat', n ≠ m → succ n ≠ succ m) (ind: ∀ P: nat' → Prop, P zero → (∀ n, P n → P (succ n)) → ∀ n, P n) : ∃! f : nat → nat', Function.Bijective f ∧ f 0 = zero ∧ ∀ (n:nat) (n':nat'), f n = n' ↔ f (n+1:ℕ) = succ n' := by sorry
+theorem SetTheory.Set.nat_unique (nat':Set) (zero:nat') (succ:nat' → nat')
+  (succ_ne: ∀ n:nat', succ n ≠ zero) (succ_of_ne: ∀ n m:nat', n ≠ m → succ n ≠ succ m)
+  (ind: ∀ P: nat' → Prop, P zero → (∀ n, P n → P (succ n)) → ∀ n, P n) :
+    ∃! f : nat → nat', Function.Bijective f ∧ f 0 = zero
+    ∧ ∀ (n:nat) (n':nat'), f n = n' ↔ f (n+1:ℕ) = succ n' := by sorry
 
 
 end Chapter3

--- a/analysis/Analysis/Section_3_6.lean
+++ b/analysis/Analysis/Section_3_6.lean
@@ -4,7 +4,11 @@ import Analysis.Section_3_5
 /-!
 # Analysis I, Section 3.6
 
-I have attempted to make the translation as faithful a paraphrasing as possible of the original text.   When there is a choice between a more idiomatic Lean solution and a more faithful translation, I have generally chosen the latter.  In particular, there will be places where the Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided doing so.
+I have attempted to make the translation as faithful a paraphrasing as possible of the original
+text. When there is a choice between a more idiomatic Lean solution and a more faithful
+translation, I have generally chosen the latter. In particular, there will be places where the
+Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided
+doing so.
 
 
 Main constructions and results of this section:
@@ -46,14 +50,17 @@ instance SetTheory.Set.inst_setoid : Setoid SetTheory.Set := {
 abbrev SetTheory.Set.has_card (X:Set) (n:ℕ) : Prop := X ≈ Fin n
 
 /-- Remark 3.6.6 -/
-theorem SetTheory.Set.Remark_3_6_6 (n:ℕ) : (nat.specify (fun x ↦ 1 ≤ (x:ℕ) ∧ (x:ℕ) ≤ n)).has_card n := by sorry
+theorem SetTheory.Set.Remark_3_6_6 (n:ℕ) :
+    (nat.specify (fun x ↦ 1 ≤ (x:ℕ) ∧ (x:ℕ) ≤ n)).has_card n := by sorry
 
 /-- Example 3.6.7 -/
 theorem SetTheory.Set.Example_3_6_7a (a:Object) : ({a}:Set).has_card 1 := by sorry
 
-theorem SetTheory.Set.Example_3_6_7b {a b c d:Object} (hab: a ≠ b) (hac: a ≠ c) (had: a ≠ d) (hbc: b ≠ c) (hbd: b ≠ d) (hcd: c ≠ d) : ({a,b,c,d}:Set).has_card 4 := by sorry
+theorem SetTheory.Set.Example_3_6_7b {a b c d:Object} (hab: a ≠ b) (hac: a ≠ c) (had: a ≠ d)
+  (hbc: b ≠ c) (hbd: b ≠ d) (hcd: c ≠ d) : ({a,b,c,d}:Set).has_card 4 := by sorry
 
-theorem SetTheory.Set.has_card_iff (X:Set) (n:ℕ) : X.has_card n ↔ ∃ f: X → Fin n, Function.Bijective f := by
+theorem SetTheory.Set.has_card_iff (X:Set) (n:ℕ) :
+    X.has_card n ↔ ∃ f: X → Fin n, Function.Bijective f := by
   simp [has_card, HasEquiv.Equiv, Setoid.r, equal_card]
 
 /-- Lemma 3.6.9 -/
@@ -66,14 +73,18 @@ theorem SetTheory.Set.pos_card_nonempty {n:ℕ} (h: n ≥ 1) {X:Set} (hX: X.has_
     use 0, (by linarith); rfl
   rw [has_card_iff] at hX
   obtain ⟨ f, hf ⟩ := hX
-  sorry -- obtain a contradiction from the fact that `f` is a bijection from the empty set to a non-empty set
+  sorry
+  -- obtain a contradiction from the fact that `f` is a bijection
+  -- from the empty set to a non-empty set
 
 /-- Exercise 3.6.2a -/
 theorem SetTheory.Set.has_card_zero {X:Set} : X.has_card 0 ↔ X = ∅ := by sorry
 
 /-- Lemma 3.6.9 -/
-theorem SetTheory.Set.card_erase {n:ℕ} (h: n ≥ 1) {X:Set} (hX: X.has_card n) (x:X) : (X \ {x.val}).has_card (n-1) := by
-  -- This proof is written to follow the structure of the original text, though with some extra notations to track some coercions that are "invisible" in the human-readable proof.
+theorem SetTheory.Set.card_erase {n:ℕ} (h: n ≥ 1) {X:Set} (hX: X.has_card n) (x:X) :
+    (X \ {x.val}).has_card (n-1) := by
+  -- This proof is written to follow the structure of the original text, though with some extra
+  -- notations to track some coercions that are "invisible" in the human-readable proof.
   rw [has_card_iff] at hX
   obtain ⟨ f, hf ⟩ := hX
   classical
@@ -169,57 +180,72 @@ theorem SetTheory.Set.has_card_card {X:Set} (hX: X.finite) : X.has_card (SetTheo
   simp [card, hX, hX.choose_spec]
 
 /-- Proposition 3.6.14 (a) / Exercise 3.6.4 -/
-theorem SetTheory.Set.card_insert {X:Set} (hX: X.finite) {x:Object} (hx: x ∉ X) : (X ∪ {x}).finite ∧ (X ∪ {x}).card = X.card + 1 := by sorry
+theorem SetTheory.Set.card_insert {X:Set} (hX: X.finite) {x:Object} (hx: x ∉ X) :
+    (X ∪ {x}).finite ∧ (X ∪ {x}).card = X.card + 1 := by sorry
 
 /-- Proposition 3.6.14 (b) / Exercise 3.6.4 -/
-theorem SetTheory.Set.card_union {X Y:Set} (hX: X.finite) (hY: Y.finite) : (X ∪ Y).finite ∧ (X ∪ Y).card ≤ X.card + Y.card := by sorry
+theorem SetTheory.Set.card_union {X Y:Set} (hX: X.finite) (hY: Y.finite) :
+    (X ∪ Y).finite ∧ (X ∪ Y).card ≤ X.card + Y.card := by sorry
 
 /-- Proposition 3.6.14 (b) / Exercise 3.6.4 -/
-theorem SetTheory.Set.card_union_disjoint {X Y:Set} (hX: X.finite) (hY: Y.finite) (hdisj: Disjoint X Y): (X ∪ Y).card = X.card + Y.card := by sorry
+theorem SetTheory.Set.card_union_disjoint {X Y:Set} (hX: X.finite) (hY: Y.finite)
+  (hdisj: Disjoint X Y) : (X ∪ Y).card = X.card + Y.card := by sorry
 
 /-- Proposition 3.6.14 (c) / Exercise 3.6.4 -/
-theorem SetTheory.Set.card_subset {X Y:Set} (hX: X.finite) (hY: Y ⊆ X) : Y.finite ∧ Y.card ≤ X.card := by sorry
+theorem SetTheory.Set.card_subset {X Y:Set} (hX: X.finite) (hY: Y ⊆ X) :
+    Y.finite ∧ Y.card ≤ X.card := by sorry
 
 /-- Proposition 3.6.14 (c) / Exercise 3.6.4 -/
-theorem SetTheory.Set.card_ssubset {X Y:Set} (hX: X.finite) (hY: Y ⊂ X) : Y.card < X.card := by sorry
+theorem SetTheory.Set.card_ssubset {X Y:Set} (hX: X.finite) (hY: Y ⊂ X) :
+    Y.card < X.card := by sorry
 
 /-- Proposition 3.6.14 (d) / Exercise 3.6.4 -/
-theorem SetTheory.Set.card_image {X Y:Set} (hX: X.finite) (f: X → Y) : (image f X).finite ∧ (image f X).card ≤ X.card := by sorry
+theorem SetTheory.Set.card_image {X Y:Set} (hX: X.finite) (f: X → Y) :
+    (image f X).finite ∧ (image f X).card ≤ X.card := by sorry
 
 /-- Proposition 3.6.14 (d) / Exercise 3.6.4 -/
-theorem SetTheory.Set.card_image_inj {X Y:Set} (hX: X.finite) {f: X → Y} (hf: Function.Injective f) : (image f X).card = X.card := by sorry
+theorem SetTheory.Set.card_image_inj {X Y:Set} (hX: X.finite) {f: X → Y}
+  (hf: Function.Injective f) : (image f X).card = X.card := by sorry
 
 /-- Proposition 3.6.14 (e) / Exercise 3.6.4 -/
-theorem SetTheory.Set.card_prod {X Y:Set} (hX: X.finite) (hY: Y.finite) : (X ×ˢ Y).finite ∧ (X ×ˢ Y).card = X.card * Y.card := by sorry
+theorem SetTheory.Set.card_prod {X Y:Set} (hX: X.finite) (hY: Y.finite) :
+    (X ×ˢ Y).finite ∧ (X ×ˢ Y).card = X.card * Y.card := by sorry
 
 /-- Proposition 3.6.14 (f) / Exercise 3.6.4 -/
-theorem SetTheory.Set.card_pow {X Y:Set} (hX: X.finite) (hY: Y.finite) : (X ^ Y).finite ∧ (X ^ Y).card = X.card ^ Y.card := by sorry
+theorem SetTheory.Set.card_pow {X Y:Set} (hX: X.finite) (hY: Y.finite) :
+    (X ^ Y).finite ∧ (X ^ Y).card = X.card ^ Y.card := by sorry
 
 /-- Exercise 3.6.2 -/
-theorem SetTheory.Set.card_eq_zero {X:Set} (hX: X.finite) : X.card = 0 ↔ X = ∅ := by sorry
-
+theorem SetTheory.Set.card_eq_zero {X:Set} (hX: X.finite) :
+    X.card = 0 ↔ X = ∅ := by sorry
 
 /-- Exercise 3.6.5 -/
-theorem SetTheory.Set.prod_equal_card_prod (A B:Set) : equal_card (A ×ˢ B) (B ×ˢ A) := by sorry
+theorem SetTheory.Set.prod_equal_card_prod (A B:Set) :
+    equal_card (A ×ˢ B) (B ×ˢ A) := by sorry
 
 /-- Exercise 3.6.6 -/
-theorem SetTheory.Set.pow_pow_equal_card_pow_prod (A B C:Set) : equal_card ((A ^ B) ^ C) (A ^ (B ×ˢ C)) := by sorry
+theorem SetTheory.Set.pow_pow_equal_card_pow_prod (A B C:Set) :
+    equal_card ((A ^ B) ^ C) (A ^ (B ×ˢ C)) := by sorry
 
 example (a b c:ℕ): (a^b)^c = a^(b*c) := by sorry
 
 example (a b c:ℕ): (a^b) * a^c = a^(b+c) := by sorry
 
 /-- Exercise 3.6.7 -/
-theorem SetTheory.Set.injection_iff_card_le {A B:Set} (hA: A.finite) (hB: B.finite) : (∃ f:A → B, Function.Injective f) ↔ A.card ≤ B.card := sorry
+theorem SetTheory.Set.injection_iff_card_le {A B:Set} (hA: A.finite) (hB: B.finite) :
+    (∃ f:A → B, Function.Injective f) ↔ A.card ≤ B.card := sorry
 
 /-- Exercise 3.6.8 -/
-theorem SetTheory.Set.surjection_from_injection {A B:Set} (hA: A ≠ ∅) (f: A → B) (hf: Function.Injective f) : ∃ g:B → A, Function.Surjective g := by sorry
+theorem SetTheory.Set.surjection_from_injection {A B:Set} (hA: A ≠ ∅) (f: A → B)
+  (hf: Function.Injective f) : ∃ g:B → A, Function.Surjective g := by sorry
 
 /-- Exercise 3.6.9 -/
-theorem SetTheory.Set.card_union_add_card_inter {A B:Set} (hA: A.finite) (hB: B.finite) : A.card + B.card = (A ∪ B).card + (A ∩ B).card := by  sorry
+theorem SetTheory.Set.card_union_add_card_inter {A B:Set} (hA: A.finite) (hB: B.finite) :
+    A.card + B.card = (A ∪ B).card + (A ∩ B).card := by  sorry
 
 /-- Exercise 3.6.10 -/
-theorem SetTheory.Set.pigeonhole_principle {n:ℕ} {A: Fin n → Set} (hA: ∀ i, (A i).finite) (hAcard: (iUnion _ A).card > n) : ∃ i, (A i).card ≥ 2 := by sorry
+theorem SetTheory.Set.pigeonhole_principle {n:ℕ} {A: Fin n → Set}
+  (hA: ∀ i, (A i).finite) (hAcard: (iUnion _ A).card > n) : ∃ i, (A i).card ≥ 2 := by sorry
 
 /-- Connections with Mathlib's `Nat.card` -/
 theorem SetTheory.Set.card_eq_nat_card {X:Set} : X.card = Nat.card X := by sorry
@@ -231,6 +257,7 @@ theorem SetTheory.Set.card_eq_ncard {X:Set} : X.card = (X: _root_.Set Object).nc
 theorem SetTheory.Set.finite_iff_finite {X:Set} : X.finite ↔ Finite X := by sorry
 
 /-- Connections with Mathlib's `Set.Finite` -/
-theorem SetTheory.Set.finite_iff_set_finite {X:Set} : X.finite ↔ (X :_root_.Set Object).Finite := by sorry
+theorem SetTheory.Set.finite_iff_set_finite {X:Set} :
+    X.finite ↔ (X :_root_.Set Object).Finite := by sorry
 
 end Chapter3

--- a/analysis/Analysis/Section_4_1.lean
+++ b/analysis/Analysis/Section_4_1.lean
@@ -4,13 +4,20 @@ import Mathlib.Algebra.Group.MinimalAxioms
 /-!
 # Analysis I, Section 4.1
 
-This file is a translation of Section 4.1 of Analysis I to Lean 4.  All numbering refers to the original text.
+This file is a translation of Section 4.1 of Analysis I to Lean 4.
+All numbering refers to the original text.
 
-I have attempted to make the translation as faithful a paraphrasing as possible of the original text.  When there is a choice between a more idiomatic Lean solution and a more faithful translation, I have generally chosen the latter.  In particular, there will be places where the Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided doing so.
+I have attempted to make the translation as faithful a paraphrasing as possible of the original
+text. When there is a choice between a more idiomatic Lean solution and a more faithful
+translation, I have generally chosen the latter. In particular, there will be places where the
+Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided
+doing so.
 
 Main constructions and results of this section:
 
-- Definition of the "Section 4.1" integers, `Section_4_1.Int`, as formal differences `a —— b` of natural numbers `a b:ℕ`, up to equivalence.  (This is a quotient of a scaffolding type `Section_4_1.PreInt`, which consists of formal differences without any equivalence imposed.)
+- Definition of the "Section 4.1" integers, `Section_4_1.Int`, as formal differences `a —— b` of
+  natural numbers `a b:ℕ`, up to equivalence.  (This is a quotient of a scaffolding type
+  `Section_4_1.PreInt`, which consists of formal differences without any equivalence imposed.)
 
 - ring operations and order these integers, as well as an embedding of ℕ
 
@@ -61,7 +68,8 @@ theorem Int.eq (a b c d:ℕ): a —— b = c —— d ↔ a + d = c + b := by
 /-- Decidability of equality -/
 instance Int.decidableEq : DecidableEq Int := by
   intro a b
-  have : ∀ (n:PreInt) (m: PreInt), Decidable (Quotient.mk PreInt.instSetoid n = Quotient.mk PreInt.instSetoid m) := by
+  have : ∀ (n:PreInt) (m: PreInt),
+      Decidable (Quotient.mk PreInt.instSetoid n = Quotient.mk PreInt.instSetoid m) := by
     intro ⟨ a,b ⟩ ⟨ c,d ⟩
     rw [eq]
     exact decEq _ _
@@ -86,7 +94,8 @@ instance Int.instAdd : Add Int where
 theorem Int.add_eq (a b c d:ℕ) : a —— b + c —— d = (a+c)——(b+d) := Quotient.lift₂_mk _ _ _ _
 
 /-- Lemma 4.1.3 (Multiplication well-defined) -/
-theorem Int.mul_congr_left (a b a' b' c d : ℕ) (h: a —— b = a' —— b') : (a*c+b*d) —— (a*d+b*c) = (a'*c+b'*d) —— (a'*d+b'*c) := by
+theorem Int.mul_congr_left (a b a' b' c d : ℕ) (h: a —— b = a' —— b') :
+    (a*c+b*d) —— (a*d+b*c) = (a'*c+b'*d) —— (a'*d+b'*c) := by
   simp only [eq] at h ⊢
   calc
     _ = c*(a+b') + d*(a'+b) := by ring
@@ -94,7 +103,8 @@ theorem Int.mul_congr_left (a b a' b' c d : ℕ) (h: a —— b = a' —— b') 
     _ = _ := by ring
 
 /-- Lemma 4.1.3 (Multiplication well-defined) -/
-theorem Int.mul_congr_right (a b c d c' d' : ℕ) (h: c —— d = c' —— d') : (a*c+b*d) —— (a*d+b*c) = (a*c'+b*d') —— (a*d'+b*c') := by
+theorem Int.mul_congr_right (a b c d c' d' : ℕ) (h: c —— d = c' —— d') :
+    (a*c+b*d) —— (a*d+b*c) = (a*c'+b*d') —— (a*d'+b*c') := by
   simp only [eq] at h ⊢
   calc
     _ = a*(c+d') + b*(c'+d) := by ring
@@ -114,7 +124,8 @@ instance Int.instMul : Mul Int where
     )
 
 /-- Definition 4.1.2 (Multiplication of integers) -/
-theorem Int.mul_eq (a b c d:ℕ) : a —— b * c —— d = (a*c+b*d) —— (a*d+b*c) := Quotient.lift₂_mk _ _ _ _
+theorem Int.mul_eq (a b c d:ℕ) : a —— b * c —— d = (a*c+b*d) —— (a*d+b*c) :=
+  Quotient.lift₂_mk _ _ _ _
 
 instance Int.instOfNat {n:ℕ} : OfNat Int n where
   ofNat := n —— 0
@@ -277,7 +288,8 @@ theorem Int.not_lt_and_eq (a b:Int) : ¬ (a < b ∧ a = b):= by sorry
 /-- (Not from textbook) Establish the decidability of this order. -/
 instance Int.decidableRel : DecidableRel (· ≤ · : Int → Int → Prop) := by
   intro n m
-  have : ∀ (n:PreInt) (m: PreInt), Decidable (Quotient.mk PreInt.instSetoid n ≤ Quotient.mk PreInt.instSetoid m) := by
+  have : ∀ (n:PreInt) (m: PreInt),
+      Decidable (Quotient.mk PreInt.instSetoid n ≤ Quotient.mk PreInt.instSetoid m) := by
     intro ⟨ a,b ⟩ ⟨ c,d ⟩
     change Decidable (a —— b ≤ c —— d)
     cases (a + d).decLe (b + c) with
@@ -310,7 +322,10 @@ theorem Int.sq_nonneg (n:Int) : n*n ≥ 0 := by sorry
 /-- Exercise 4.1.9 -/
 theorem Int.sq_nonneg' (n:Int) : ∃ (m:Nat), n*n = m := by sorry
 
-/-- Not in textbook: create an equivalence between Int and ℤ.  This requires some familiarity with the API for Mathlib's version of the integers. -/
+/--
+  Not in textbook: create an equivalence between Int and ℤ.
+  This requires some familiarity with the API for Mathlib's version of the integers.
+-/
 abbrev Int.equivInt : Int ≃ ℤ where
   toFun := Quotient.lift (fun ⟨ a, b ⟩ ↦ a - b) (by
     sorry)

--- a/analysis/Analysis/Section_4_2.lean
+++ b/analysis/Analysis/Section_4_2.lean
@@ -4,13 +4,20 @@ import Mathlib.Algebra.Group.MinimalAxioms
 /-!
 # Analysis I, Section 4.2
 
-This file is a translation of Section 4.2 of Analysis I to Lean 4.  All numbering refers to the original text.
+This file is a translation of Section 4.2 of Analysis I to Lean 4.
+All numbering refers to the original text.
 
-I have attempted to make the translation as faithful a paraphrasing as possible of the original text.  When there is a choice between a more idiomatic Lean solution and a more faithful translation, I have generally chosen the latter.  In particular, there will be places where the Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided doing so.
+I have attempted to make the translation as faithful a paraphrasing as possible of the original
+text. When there is a choice between a more idiomatic Lean solution and a more faithful
+translation, I have generally chosen the latter. In particular, there will be places where the
+Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided
+doing so.
 
 Main constructions and results of this section:
 
-- Definition of the "Section 4.2" rationals, `Section_4_2.Int`, as formal differences `a // b` of integers `a b:ℤ`, up to equivalence.  (This is a quotient of a scaffolding type `Section_4_2.PreRat`, which consists of formal differences without any equivalence imposed.)
+- Definition of the "Section 4.2" rationals, `Section_4_2.Int`, as formal differences `a // b` of
+  integers `a b:ℤ`, up to equivalence.  (This is a quotient of a scaffolding type
+  `Section_4_2.PreRat`, which consists of formal differences without any equivalence imposed.)
 
 - field operations and order on these rationals, as well as an embedding of ℕ and ℤ
 
@@ -34,12 +41,14 @@ instance PreRat.instSetoid : Setoid PreRat where
     }
 
 @[simp]
-theorem PreRat.eq (a b c d:ℤ) (hb: b ≠ 0) (hd: d ≠ 0): (⟨ a,b,hb ⟩: PreRat) ≈ ⟨ c,d,hd ⟩ ↔ a * d = c * b := by rfl
+theorem PreRat.eq (a b c d:ℤ) (hb: b ≠ 0) (hd: d ≠ 0) :
+    (⟨ a,b,hb ⟩: PreRat) ≈ ⟨ c,d,hd ⟩ ↔ a * d = c * b := by rfl
 
 abbrev Rat := Quotient PreRat.instSetoid
 
 /-- We give division a "junk" value of 0//1 if the denominator is zero -/
-abbrev Rat.formalDiv (a b:ℤ)  : Rat := Quotient.mk PreRat.instSetoid (if h:b ≠ 0 then ⟨ a,b,h ⟩ else ⟨ 0, 1, by decide ⟩)
+abbrev Rat.formalDiv (a b:ℤ)  : Rat :=
+  Quotient.mk PreRat.instSetoid (if h:b ≠ 0 then ⟨ a,b,h ⟩ else ⟨ 0, 1, by decide ⟩)
 
 infix:100 " // " => Rat.formalDiv
 
@@ -54,7 +63,11 @@ theorem Rat.eq_diff (n:Rat) : ∃ a b, b ≠ 0 ∧ n = a // b := by
   simp [formalDiv, h]
   rfl
 
-/-- Decidability of equality.  Hint: modify the proof of `DecidableEq Int` from the previous section.  However, because formal division handles the case of zero denominator separately, it may be more convenient to avoid that operation and work directly with the `Quotient` API. -/
+/--
+  Decidability of equality. Hint: modify the proof of `DecidableEq Int` from the previous
+  section. However, because formal division handles the case of zero denominator separately, it
+  may be more convenient to avoid that operation and work directly with the `Quotient` API.
+-/
 instance Rat.decidableEq : DecidableEq Rat := by
   sorry
 
@@ -70,7 +83,8 @@ instance Rat.add_inst : Add Rat where
   )
 
 /-- Definition 4.2.2 (Addition of rationals) -/
-theorem Rat.add_eq (a c:ℤ) {b d:ℤ} (hb: b ≠ 0) (hd: d ≠ 0) :(a // b) + (c // d) = (a*d + b*c) // (b*d) := by
+theorem Rat.add_eq (a c:ℤ) {b d:ℤ} (hb: b ≠ 0) (hd: d ≠ 0) :
+    (a // b) + (c // d) = (a*d + b*c) // (b*d) := by
   convert Quotient.lift₂_mk _ _ _ _
   all_goals simp [hb, hd]
 
@@ -79,7 +93,8 @@ instance Rat.mul_inst : Mul Rat where
   mul := Quotient.lift₂ (fun ⟨ a, b, h1 ⟩ ⟨ c, d, h2 ⟩ ↦ (a*c) // (b*d)) (by sorry)
 
 /-- Definition 4.2.2 (Multiplication of rationals) -/
-theorem Rat.mul_eq (a c:ℤ) {b d:ℤ} (hb: b ≠ 0) (hd: d ≠ 0) :(a // b) * (c // d) = (a*c) // (b*d) := by
+theorem Rat.mul_eq (a c:ℤ) {b d:ℤ} (hb: b ≠ 0) (hd: d ≠ 0) :
+    (a // b) * (c // d) = (a*c) // (b*d) := by
   convert Quotient.lift₂_mk _ _ _ _
   all_goals simp [hb, hd]
 
@@ -120,7 +135,10 @@ lemma Rat.neg_of_int (a:ℤ) : - (a:Rat) = (-a:ℤ) := by
 
 theorem Rat.coe_Int_inj : Function.Injective (fun n:ℤ ↦ (n:Rat)) := by sorry
 
-/-- Whereas the book leaves the inverse of 0 undefined, it is more convenient in Lean to assign a "junk" value to this inverse; we arbitrarily choose this junk value to be 0. -/
+/--
+  Whereas the book leaves the inverse of 0 undefined, it is more convenient in Lean to assign a
+  "junk" value to this inverse; we arbitrarily choose this junk value to be 0.
+-/
 instance Rat.instInv : Inv Rat where
   inv := Quotient.lift (fun ⟨ a, b, h1 ⟩ ↦ b // a) (by
     sorry -- hint: split into the `a=0` and `a≠0` cases
@@ -146,7 +164,8 @@ AddGroup.ofLeftAxioms (by
   have hdf : d*f ≠ 0 := Int.mul_ne_zero hd hf
   have hbdf : b*d*f ≠ 0 := Int.mul_ne_zero hbd hf
 
-  rw [add_eq _ _ hb hd, add_eq _ _ hbd hf, add_eq _ _ hd hf, add_eq _ _ hb hdf, ←mul_assoc b d f, eq _ _ hbdf hbdf]
+  rw [add_eq _ _ hb hd, add_eq _ _ hbd hf, add_eq _ _ hd hf,
+      add_eq _ _ hb hdf, ←mul_assoc b d f, eq _ _ hbdf hbdf]
   ring
 )
  (by sorry) (by sorry)
@@ -220,7 +239,9 @@ def Rat.coe_int_hom : ℤ →+* Rat where
   map_add' := by sorry
   map_mul' := by sorry
 
-/-- (Not from textbook) The textbook rationals are isomorphic (as a field) to the Mathlib rationals -/
+/--
+  (Not from textbook) The textbook rationals are isomorphic (as a field) to the Mathlib rationals.
+-/
 def Rat.equiv_rat : ℚ ≃+* Rat where
   toFun n := (n:Rat)
   invFun := by sorry
@@ -289,9 +310,12 @@ theorem Rat.mul_lt_mul_right {x y z:Rat} (hxy: x < y) (hz: z.isPos) : x * z < y 
 /-- (Not from textbook) Establish the decidability of this order. -/
 instance Rat.decidableRel : DecidableRel (· ≤ · : Rat → Rat → Prop) := by
   intro n m
-  have : ∀ (n:PreRat) (m: PreRat), Decidable (Quotient.mk PreRat.instSetoid n ≤ Quotient.mk PreRat.instSetoid m) := by
+  have : ∀ (n:PreRat) (m: PreRat),
+      Decidable (Quotient.mk PreRat.instSetoid n ≤ Quotient.mk PreRat.instSetoid m) := by
     intro ⟨ a,b,hb ⟩ ⟨ c,d,hd ⟩
-    -- at this point, the goal is morally `Decidable(a//b ≤ c//d)`, but there are technical issues due to the junk value of formal divisionwhen the denominator vanishes.  It may be more convenient to avoid formal division and work directly with `Quotient.mk`.
+    -- at this point, the goal is morally `Decidable(a//b ≤ c//d)`, but there are technical
+    -- issues due to the junk value of formal divisionwhen the denominator vanishes.
+    -- It may be more convenient to avoid formal division and work directly with `Quotient.mk`.
     cases (0:ℤ).decLe (b*d) with
       | isTrue hbd =>
         cases (a * d).decLe (b * c) with
@@ -330,10 +354,14 @@ instance Rat.instIsStrictOrderedRing : IsStrictOrderedRing Rat where
   zero_le_one := by sorry
 
 /-- Exercise 4.2.6 -/
-theorem Rat.mul_lt_mul_right_of_neg (x y z:Rat) (hxy: x < y) (hz: z.isNeg) : x * z > y * z := by sorry
+theorem Rat.mul_lt_mul_right_of_neg (x y z:Rat) (hxy: x < y) (hz: z.isNeg) : x * z > y * z := by
+  sorry
 
 
-/-- Not in textbook: create an equivalence between Rat and ℚ.  This requires some familiarity with the API for Mathlib's version of the rationals. -/
+/--
+  Not in textbook: create an equivalence between Rat and ℚ. This requires some familiarity with
+  the API for Mathlib's version of the rationals.
+-/
 abbrev Rat.equivRat : Rat ≃ ℚ where
   toFun := Quotient.lift (fun ⟨ a, b, h ⟩ ↦ a / b) (by
     sorry)
@@ -351,16 +379,5 @@ abbrev Rat.equivRat_ring : Rat ≃+* ℚ where
   toEquiv := equivRat
   map_add' := by sorry
   map_mul' := by sorry
-
-
-
-
-
-
-
-
-
-
-
 
 end Section_4_2

--- a/analysis/Analysis/Section_4_3.lean
+++ b/analysis/Analysis/Section_4_3.lean
@@ -3,19 +3,29 @@ import Mathlib.Tactic
 /-!
 # Analysis I, Section 4.3
 
-
-I have attempted to make the translation as faithful a paraphrasing as possible of the original text.  When there is a choice between a more idiomatic Lean solution and a more faithful translation, I have generally chosen the latter.  In particular, there will be places where the Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided doing so.
+I have attempted to make the translation as faithful a paraphrasing as possible of the original
+text. When there is a choice between a more idiomatic Lean solution and a more faithful
+translation, I have generally chosen the latter.  In particular, there will be places where the
+Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided
+doing so.
 
 Main constructions and results of this section:
 
-- Basic properties of absolute value and exponentiation on the rational numbers (here we use the Mathlib rational numbers `ℚ` rather than the Section 4.2 rational numbers).
+- Basic properties of absolute value and exponentiation on the rational numbers (here we use the
+  Mathlib rational numbers `ℚ` rather than the Section 4.2 rational numbers).
 
-Note: to avoid notational conflict, we are using the standard Mathlib definitions of absolute value and exponentiation.  As such, it is possible to solve several of the exercises here rather easily using the Mathlib API for these operations.  However, the spirit of the exercises is to solve these instead using the API provided in this section, as well as more basic Mathlib API for the rational numbers that does not reference either absolute value or exponentiation.
+Note: to avoid notational conflict, we are using the standard Mathlib definitions of absolute
+value and exponentiation.  As such, it is possible to solve several of the exercises here rather
+easily using the Mathlib API for these operations.  However, the spirit of the exercises is to
+solve these instead using the API provided in this section, as well as more basic Mathlib API for
+the rational numbers that does not reference either absolute value or exponentiation.
 
 -/
 
 
-/-- This definition needs to be made outside of the Section 4.3 namespace for technical reasons. -/
+/--
+  This definition needs to be made outside of the Section 4.3 namespace for technical reasons.
+-/
 def Rat.close (ε : ℚ) (x y:ℚ) := |x-y| ≤ ε
 
 
@@ -35,13 +45,19 @@ theorem abs_of_neg {x: ℚ} (hx: x < 0) : abs x = -x := by
 /-- Definition 4.3.1 (Absolute value) -/
 theorem abs_of_zero : abs 0 = 0 := by rfl
 
-/-- (Not from textbook) This definition of absolute value agrees with the Mathlib one.  Henceforth we use the Mathlib absolute value. -/
+/--
+  (Not from textbook) This definition of absolute value agrees with the Mathlib one.
+  Henceforth we use the Mathlib absolute value.
+-/
 theorem abs_eq_abs (x: ℚ) : abs x = |x| := by
   sorry
 
 abbrev dist (x y : ℚ) := |x - y|
 
-/-- Definition 4.2 (Distance).  We avoid the Mathlib notion of distance here because it is real-valued.  -/
+/--
+  Definition 4.2 (Distance).
+  We avoid the Mathlib notion of distance here because it is real-valued.
+-/
 theorem dist_eq (x y: ℚ) : dist x y = |x-y| := rfl
 
 /-- Proposition 4.3.3(a) / Exercise 4.3.1 -/
@@ -78,7 +94,11 @@ theorem dist_symm (x y:ℚ) : dist x y = dist y x := by sorry
 /-- Proposition 4.3.3(f) / Exercise 4.3.1 -/
 theorem dist_le (x y z:ℚ) : dist x z ≤ dist x y + dist y z := by sorry
 
-/-- Definition 4.3.4 (eps-closeness).  In the text the notion is undefined for ε zero or negative, but it is more convenient in Lean to assign a "junk" definition in this case.  But this also allows some relaxations of hypotheses in the lemmas that follow.-/
+/--
+  Definition 4.3.4 (eps-closeness).  In the text the notion is undefined for ε zero or negative,
+  but it is more convenient in Lean to assign a "junk" definition in this case.  But this also
+  allows some relaxations of hypotheses in the lemmas that follow.
+-/
 theorem close_iff (ε x y:ℚ): ε.close x y ↔ |x - y| ≤ ε := by rfl
 
 /-- Examples 4.3.6 -/
@@ -99,25 +119,32 @@ theorem eq_if_close (x y:ℚ) : x = y ↔ ∀ ε:ℚ, ε > 0 → ε.close x y :=
 theorem close_symm (ε x y:ℚ) : ε.close x y ↔ ε.close y x := by sorry
 
 /-- Proposition 4.3.7(c) / Exercise 4.3.2 -/
-theorem close_trans {ε δ x y:ℚ} (hxy: ε.close x y) (hyz: δ.close y z) : (ε + δ).close x z := by sorry
+theorem close_trans {ε δ x y:ℚ} (hxy: ε.close x y) (hyz: δ.close y z) :
+    (ε + δ).close x z := by sorry
 
 /-- Proposition 4.3.7(d) / Exercise 4.3.2 -/
-theorem add_close {ε δ x y z w:ℚ} (hxy: ε.close x y) (hzw: δ.close z w) : (ε + δ).close (x+z) (y+w) := by sorry
+theorem add_close {ε δ x y z w:ℚ} (hxy: ε.close x y) (hzw: δ.close z w) :
+    (ε + δ).close (x+z) (y+w) := by sorry
 
 /-- Proposition 4.3.7(d) / Exercise 4.3.2 -/
-theorem sub_close {ε δ x y z w:ℚ} (hxy: ε.close x y) (hzw: δ.close z w) : (ε + δ).close (x-z) (y-w) := by sorry
+theorem sub_close {ε δ x y z w:ℚ} (hxy: ε.close x y) (hzw: δ.close z w) :
+    (ε + δ).close (x-z) (y-w) := by sorry
 
 /-- Proposition 4.3.7(e) / Exercise 4.3.2, slightly strengthened -/
-theorem close_mono {ε ε' x y:ℚ} (hxy: ε.close x y) (hε: ε' ≥  ε) : ε'.close x y := by sorry
+theorem close_mono {ε ε' x y:ℚ} (hxy: ε.close x y) (hε: ε' ≥  ε) :
+    ε'.close x y := by sorry
 
 /-- Proposition 4.3.7(f) / Exercise 4.3.2 -/
-theorem close_between {ε x y z w:ℚ} (hxy: ε.close x y) (hyz: ε.close x z) (hbetween: (y ≤ w ∧ w ≤ z) ∨ (z ≤ w ∧ w ≤ y)) : ε.close x w := by sorry
+theorem close_between {ε x y z w:ℚ} (hxy: ε.close x y) (hyz: ε.close x z)
+  (hbetween: (y ≤ w ∧ w ≤ z) ∨ (z ≤ w ∧ w ≤ y)) : ε.close x w := by sorry
 
 /-- Proposition 4.3.7(g) / Exercise 4.3.2 -/
-theorem close_mul_right {ε x y z:ℚ} (hε: ε ≥ 0) (hxy: ε.close x y) : (ε*|z|).close (x * z) (y * z) := by sorry
+theorem close_mul_right {ε x y z:ℚ} (hε: ε ≥ 0) (hxy: ε.close x y) :
+    (ε*|z|).close (x * z) (y * z) := by sorry
 
 /-- Proposition 4.3.7(h) / Exercise 4.3.2 -/
-theorem close_mul_mul {ε δ x y z w:ℚ} (hε: ε ≥ 0) (hxy: ε.close x y) (hzw: δ.close z w) : (ε*|z|+δ*|x|+ε*δ).close (x * z) (y * w) := by
+theorem close_mul_mul {ε δ x y z w:ℚ} (hε: ε ≥ 0) (hxy: ε.close x y) (hzw: δ.close z w) :
+    (ε*|z|+δ*|x|+ε*δ).close (x * z) (y * w) := by
   -- The proof is written to follow the structure of the original text, though on formalization it was revealed that the hypothesis δ ≥ 0 was unnecessary.
   set a := y-x
   have ha : y = x + a := by simp [a]
@@ -172,8 +199,12 @@ theorem pow_gt_pow (x y:ℚ) (n:ℕ) (hxy: x > y) (hy: y ≥ 0) (hn: n > 0) : x^
 /-- Proposition 4.3.10(d) (Properties of exponentiation, I) / Exercise 4.3.3 -/
 theorem pow_abs (x:ℚ) (n:ℕ) : |x|^n = |x^n| := by sorry
 
-/-- Definition 4.3.11 (Exponentiation to a negative number).  Here we use the Mathlib notion of integer exponentiation -/
-theorem zpow_neg (x:ℚ) (n:ℕ) : x^(-(n:ℤ)) = 1/(x^n) := by simp only [ne_eq, _root_.zpow_neg, zpow_natCast, one_div]
+/--
+  Definition 4.3.11 (Exponentiation to a negative number).
+  Here we use the Mathlib notion of integer exponentiation
+-/
+theorem zpow_neg (x:ℚ) (n:ℕ) : x^(-(n:ℤ)) = 1/(x^n) := by
+  simp only [ne_eq, _root_.zpow_neg, zpow_natCast, one_div]
 
 example (x:ℚ): x^(-3:ℤ) = 1/(x^3) := zpow_neg x 3
 
@@ -197,10 +228,12 @@ theorem zpow_pos {x:ℚ} (n:ℤ) (hx: x > 0) : x^n > 0 := by sorry
 /-- Proposition 4.3.12(b) (Properties of exponentiation, II) / Exercise 4.3.4 -/
 theorem zpow_ge_zpow {x y:ℚ} {n:ℤ} (hxy: x ≥ y) (hy: y > 0) (hn: n > 0): x^n ≥ y^n := by sorry
 
-theorem zpow_ge_zpow_ofneg {x y:ℚ} {n:ℤ} (hxy: x ≥ y) (hy: y > 0) (hn: n < 0) : x^n ≤ y^n := by sorry
+theorem zpow_ge_zpow_ofneg {x y:ℚ} {n:ℤ} (hxy: x ≥ y) (hy: y > 0) (hn: n < 0) : x^n ≤ y^n := by
+  sorry
 
 /-- Proposition 4.3.12(c) (Properties of exponentiation, II) / Exercise 4.3.4 -/
-theorem zpow_inj {x y:ℚ} {n:ℤ} (hx: x > 0) (hy : y > 0) (hn: n ≠ 0) (hxy: x^n = y^n) : x = y := by sorry
+theorem zpow_inj {x y:ℚ} {n:ℤ} (hx: x > 0) (hy : y > 0) (hn: n ≠ 0) (hxy: x^n = y^n) : x = y := by
+  sorry
 
 /-- Proposition 4.3.12(d) (Properties of exponentiation, II) / Exercise 4.3.4 -/
 theorem zpow_abs (x:ℚ) (n:ℤ) (hx: x ≠ 0) : |x|^n = |x^n| := by sorry

--- a/analysis/Analysis/Section_5_1.lean
+++ b/analysis/Analysis/Section_5_1.lean
@@ -4,7 +4,11 @@ import Analysis.Section_4_3
 /-!
 # Analysis I, Section 5.1
 
-I have attempted to make the translation as faithful a paraphrasing as possible of the original text.  When there is a choice between a more idiomatic Lean solution and a more faithful translation, I have generally chosen the latter.  In particular, there will be places where the Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided doing so.
+I have attempted to make the translation as faithful a paraphrasing as possible of the original
+text. When there is a choice between a more idiomatic Lean solution and a more faithful
+translation, I have generally chosen the latter. In particular, there will be places where the
+Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided
+doing so.
 
 Main constructions and results of this section:
 
@@ -15,7 +19,10 @@ Main constructions and results of this section:
 
 namespace Chapter5
 
-/-- Definition 5.1.1 (Sequence). To avoid some technicalities involving dependent types, we extend sequences by zero to the left of the starting point `n₀`. -/
+/--
+  Definition 5.1.1 (Sequence). To avoid some technicalities involving dependent types, we extend
+  sequences by zero to the left of the starting point `n₀`.
+-/
 @[ext]
 structure Sequence where
   n₀ : ℤ
@@ -44,7 +51,8 @@ abbrev Sequence.mk' (n₀:ℤ) (a: { n // n ≥ n₀ } → ℚ) : Sequence where
     simp [hn]
 
 
-lemma Sequence.eval_mk {n n₀:ℤ} (a: { n // n ≥ n₀ } → ℚ) (h: n ≥ n₀) : (Sequence.mk' n₀ a) n = a ⟨ n, h ⟩ := by simp [seq, h]
+lemma Sequence.eval_mk {n n₀:ℤ} (a: { n // n ≥ n₀ } → ℚ) (h: n ≥ n₀) :
+    (Sequence.mk' n₀ a) n = a ⟨ n, h ⟩ := by simp [seq, h]
 
 @[simp]
 lemma Sequence.eval_coe (n:ℕ) (a: ℕ → ℚ) : (a:Sequence) n = a n := by simp [seq]
@@ -99,9 +107,13 @@ example (ε:ℚ) (hε: ε>0) : ε.steady ((fun _:ℕ ↦ (2:ℚ) ):Sequence) := 
 
 example : (10:ℚ).steady ((fun n:ℕ ↦ if n = 0 then (10:ℚ) else (0:ℚ)):Sequence) := by sorry
 
-example (ε:ℚ) (hε:ε<10):  ¬ ε.steady ((fun n:ℕ ↦ if n = 0 then (10:ℚ) else (0:ℚ)):Sequence) := by sorry
+example (ε:ℚ) (hε:ε<10):  ¬ ε.steady ((fun n:ℕ ↦ if n = 0 then (10:ℚ) else (0:ℚ)):Sequence) := by
+  sorry
 
-/-- a.from n₁ starts `a:Sequence` from `n₁`.  It is intended for use when `n₁ ≥ n₀`, but returns the "junk" value of the original sequence `a` otherwise. -/
+/--
+  a.from n₁ starts `a:Sequence` from `n₁`.  It is intended for use when `n₁ ≥ n₀`, but returns
+  the "junk" value of the original sequence `a` otherwise.
+-/
 abbrev Sequence.from (a:Sequence) (n₁:ℤ) : Sequence :=
   mk' (max a.n₀ n₁) (fun n ↦ a (n:ℤ))
 
@@ -114,7 +126,8 @@ lemma Sequence.from_eval (a:Sequence) {n₁ n:ℤ} (hn: n ≥ n₁) :
 end Chapter5
 
 /-- Definition 5.1.6 (Eventually ε-steady) -/
-abbrev Rat.eventuallySteady (ε: ℚ) (a: Chapter5.Sequence) : Prop := ∃ N ≥ a.n₀, ε.steady (a.from N)
+abbrev Rat.eventuallySteady (ε: ℚ) (a: Chapter5.Sequence) : Prop :=
+  ∃ N ≥ a.n₀, ε.steady (a.from N)
 
 lemma Rat.eventuallySteady_def (ε: ℚ) (a: Chapter5.Sequence) :
   ε.eventuallySteady a ↔ ∃ N ≥ a.n₀, ε.steady (a.from N) := by rfl
@@ -125,34 +138,47 @@ namespace Chapter5
 /-- Example 5.1.7 -/
 lemma Sequence.ex_5_1_7_a : ¬ (0.1:ℚ).steady ((fun n:ℕ ↦ (n+1:ℚ)⁻¹ ):Sequence) := by sorry
 
-lemma Sequence.ex_5_1_7_b : (0.1:ℚ).steady (((fun n:ℕ ↦ (n+1:ℚ)⁻¹ ):Sequence).from 10) := by sorry
+lemma Sequence.ex_5_1_7_b : (0.1:ℚ).steady (((fun n:ℕ ↦ (n+1:ℚ)⁻¹ ):Sequence).from 10) := by
+  sorry
 
-lemma Sequence.ex_5_1_7_c : (0.1:ℚ).eventuallySteady ((fun n:ℕ ↦ (n+1:ℚ)⁻¹ ):Sequence) := by sorry
+lemma Sequence.ex_5_1_7_c : (0.1:ℚ).eventuallySteady ((fun n:ℕ ↦ (n+1:ℚ)⁻¹ ):Sequence) := by
+  sorry
 
-lemma Sequence.ex_5_1_7_d {ε:ℚ} (hε:ε>0) : ε.eventuallySteady ((fun n:ℕ ↦ if n=0 then (10:ℚ) else (0:ℚ) ):Sequence) := by sorry
+lemma Sequence.ex_5_1_7_d {ε:ℚ} (hε:ε>0) :
+    ε.eventuallySteady ((fun n:ℕ ↦ if n=0 then (10:ℚ) else (0:ℚ) ):Sequence) := by sorry
 
 abbrev Sequence.isCauchy (a:Sequence) : Prop := ∀ ε > (0:ℚ), ε.eventuallySteady a
 
 lemma Sequence.isCauchy_def (a:Sequence) :
   a.isCauchy ↔ ∀ ε > (0:ℚ), ε.eventuallySteady a := by rfl
 
-lemma Sequence.isCauchy_of_coe (a:ℕ → ℚ) : (a:Sequence).isCauchy ↔ ∀ ε > (0:ℚ), ∃ N, ∀ j ≥ N, ∀ k ≥ N, Section_4_3.dist (a j) (a k) ≤ ε := by sorry
+lemma Sequence.isCauchy_of_coe (a:ℕ → ℚ) :
+    (a:Sequence).isCauchy ↔ ∀ ε > (0:ℚ), ∃ N, ∀ j ≥ N, ∀ k ≥ N,
+    Section_4_3.dist (a j) (a k) ≤ ε := by sorry
 
-lemma Sequence.isCauchy_of_mk {n₀:ℤ} (a: {n // n ≥ n₀} → ℚ) : (mk' n₀ a).isCauchy ↔ ∀ ε > (0:ℚ), ∃ N ≥ n₀, ∀ j ≥ N, ∀ k ≥ N, Section_4_3.dist (mk' n₀ a j) (mk' n₀ a k) ≤ ε := by sorry
+lemma Sequence.isCauchy_of_mk {n₀:ℤ} (a: {n // n ≥ n₀} → ℚ) :
+    (mk' n₀ a).isCauchy ↔ ∀ ε > (0:ℚ), ∃ N ≥ n₀, ∀ j ≥ N, ∀ k ≥ N,
+    Section_4_3.dist (mk' n₀ a j) (mk' n₀ a k) ≤ ε := by sorry
 
-noncomputable def Sequence.sqrt_two : Sequence := (fun n:ℕ ↦ ((⌊ (Real.sqrt 2)*10^n ⌋ / 10^n):ℚ))
+noncomputable def Sequence.sqrt_two : Sequence :=
+  (fun n:ℕ ↦ ((⌊ (Real.sqrt 2)*10^n ⌋ / 10^n):ℚ))
 
-/-- Example 5.1.10.  (This requires extensive familiarity with Mathlib's API for the real numbers. )-/
+/--
+  Example 5.1.10. (This requires extensive familiarity with Mathlib's API for the real numbers.)
+-/
 theorem Sequence.ex_5_1_10_a : (1:ℚ).steady sqrt_two := by sorry
 
-/-- Example 5.1.10.  (This requires extensive familiarity with Mathlib's API for the real numbers. )-/
+/--
+  Example 5.1.10. (This requires extensive familiarity with Mathlib's API for the real numbers.)
+-/
 theorem Sequence.ex_5_1_10_b : (0.1:ℚ).steady (sqrt_two.from 1) := by sorry
 
 theorem Sequence.ex_5_1_10_c : (0.1:ℚ).eventuallySteady sqrt_two := by sorry
 
 /-- Proposition 5.1.11 -/
 theorem Sequence.harmonic_steady : (mk' 1 (fun n ↦ (1:ℚ)/n)).isCauchy := by
-  -- This is proof is probably longer than it needs to be; there should be a shorter proof that is still in the spirit of  the proof in the book.
+  -- This is proof is probably longer than it needs to be; there should be a shorter proof that
+  -- is still in the spirit of  the proof in the book.
   rw [isCauchy_of_mk (fun n ↦ (1:ℚ)/n)]
   intro ε hε
   have : ∃ N:ℕ, N > 1/ε := exists_nat_gt (1 / ε)
@@ -193,7 +219,10 @@ theorem Sequence.harmonic_steady : (mk' 1 (fun n ↦ (1:ℚ)/n)).isCauchy := by
 abbrev BoundedBy {n:ℕ} (a: Fin n → ℚ) (M:ℚ) : Prop :=
   ∀ i, |a i| ≤ M
 
-/-- Definition 5.1.12 (bounded sequences).  Here we start sequences from 0 rather than 1 to align better with Mathlib conventions. -/
+/--
+  Definition 5.1.12 (bounded sequences). Here we start sequences from 0 rather than 1 to align
+  better with Mathlib conventions.
+-/
 lemma BoundedBy_def {n:ℕ} (a: Fin n → ℚ) (M:ℚ) :
   BoundedBy a M ↔ ∀ i, |a i| ≤ M := by rfl
 

--- a/analysis/Analysis/Section_5_2.lean
+++ b/analysis/Analysis/Section_5_2.lean
@@ -5,7 +5,10 @@ import Analysis.Section_5_1
 /-!
 # Analysis I, Section 5.2
 
-I have attempted to make the translation as faithful a paraphrasing as possible of the original text.  When there is a choice between a more idiomatic Lean solution and a more faithful translation, I have generally chosen the latter.  In particular, there will be places where the Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided doing so.
+I have attempted to make the translation as faithful a paraphrasing as possible of the original
+text. When there is a choice between a more idiomatic Lean solution and a more faithful
+translation, I have generally chosen the latter. In particular, there will be places where the
+Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided doing so.
 
 Main constructions and results of this section:
 
@@ -15,14 +18,17 @@ Main constructions and results of this section:
 -/
 
 
-abbrev Rat.close_seq (ε: ℚ) (a b: Chapter5.Sequence) : Prop := ∀ n, n ≥ a.n₀ → n ≥ b.n₀ → ε.close (a n) (b n)
+abbrev Rat.close_seq (ε: ℚ) (a b: Chapter5.Sequence) : Prop :=
+  ∀ n, n ≥ a.n₀ → n ≥ b.n₀ → ε.close (a n) (b n)
 
-abbrev Rat.eventually_close (ε: ℚ) (a b: Chapter5.Sequence) : Prop := ∃ N, ε.close_seq (a.from N) (b.from N)
+abbrev Rat.eventually_close (ε: ℚ) (a b: Chapter5.Sequence) : Prop :=
+  ∃ N, ε.close_seq (a.from N) (b.from N)
 
 namespace Chapter5
 
 /-- Definition 5.2.1 ($ε$-close sequences) -/
-lemma Rat.close_seq_def (ε: ℚ) (a b: Sequence) : ε.close_seq a b ↔ ∀ n, n ≥ a.n₀ → n ≥ b.n₀ → ε.close (a n) (b n) := by rfl
+lemma Rat.close_seq_def (ε: ℚ) (a b: Sequence) :
+    ε.close_seq a b ↔ ∀ n, n ≥ a.n₀ → n ≥ b.n₀ → ε.close (a n) (b n) := by rfl
 
 /-- Example 5.2.2 -/
 example : (0.1:ℚ).close_seq ((fun n:ℕ ↦ ((-1)^n:ℚ)):Sequence)
@@ -37,31 +43,39 @@ example : ¬ (0.1:ℚ).steady ((fun n:ℕ ↦ ((1.1:ℚ) * (-1)^n)):Sequence)
 := by sorry
 
 /-- Definition 5.2.3 (Eventually ε-close sequences) -/
-lemma Rat.eventually_close_def (ε: ℚ) (a b: Sequence) : ε.eventually_close a b ↔  ∃ N, ε.close_seq (a.from N) (b.from N) := by rfl
+lemma Rat.eventually_close_def (ε: ℚ) (a b: Sequence) :
+    ε.eventually_close a b ↔ ∃ N, ε.close_seq (a.from N) (b.from N) := by rfl
 
 /-- Definition 5.2.3 (Eventually ε-close sequences) -/
-lemma Rat.eventually_close_iff (ε: ℚ) (a b: ℕ → ℚ) : ε.eventually_close (a:Sequence) (b:Sequence) ↔  ∃ N, ∀ n ≥ N, |a n - b n| ≤ ε := by sorry
+lemma Rat.eventually_close_iff (ε: ℚ) (a b: ℕ → ℚ) :
+    ε.eventually_close (a:Sequence) (b:Sequence) ↔  ∃ N, ∀ n ≥ N, |a n - b n| ≤ ε := by sorry
 
 /-- Example 5.2.5 -/
-example : ¬ (0.1:ℚ).close_seq ((fun n:ℕ ↦ (1:ℚ)+10^(-(n:ℤ)-1)):Sequence) ((fun n:ℕ ↦ (1:ℚ)-10^(-(n:ℤ)-1)):Sequence) := by sorry
+example : ¬ (0.1:ℚ).close_seq ((fun n:ℕ ↦ (1:ℚ)+10^(-(n:ℤ)-1)):Sequence)
+  ((fun n:ℕ ↦ (1:ℚ)-10^(-(n:ℤ)-1)):Sequence) := by sorry
 
-example : (0.1:ℚ).eventually_close ((fun n:ℕ ↦ (1:ℚ)+10^(-(n:ℤ)-1)):Sequence) ((fun n:ℕ ↦ (1:ℚ)-10^(-(n:ℤ)-1)):Sequence) := by sorry
+example : (0.1:ℚ).eventually_close ((fun n:ℕ ↦ (1:ℚ)+10^(-(n:ℤ)-1)):Sequence)
+  ((fun n:ℕ ↦ (1:ℚ)-10^(-(n:ℤ)-1)):Sequence) := by sorry
 
-example : (0.01:ℚ).eventually_close ((fun n:ℕ ↦ (1:ℚ)+10^(-(n:ℤ)-1)):Sequence) ((fun n:ℕ ↦ (1:ℚ)-10^(-(n:ℤ)-1)):Sequence) := by sorry
+example : (0.01:ℚ).eventually_close ((fun n:ℕ ↦ (1:ℚ)+10^(-(n:ℤ)-1)):Sequence)
+  ((fun n:ℕ ↦ (1:ℚ)-10^(-(n:ℤ)-1)):Sequence) := by sorry
 
 /-- Definition 5.2.6 (Equivalent sequences) -/
 abbrev Sequence.equiv (a b: ℕ → ℚ) : Prop :=
   ∀ ε > (0:ℚ), ε.eventually_close (a:Sequence) (b:Sequence)
 
 /-- Definition 5.2.6 (Equivalent sequences) -/
-lemma Sequence.equiv_def (a b: ℕ → ℚ) : equiv a b ↔ ∀ (ε:ℚ), ε > 0 → ε.eventually_close (a:Sequence) (b:Sequence) := by rfl
+lemma Sequence.equiv_def (a b: ℕ → ℚ) :
+    equiv a b ↔ ∀ (ε:ℚ), ε > 0 → ε.eventually_close (a:Sequence) (b:Sequence) := by rfl
 
 /-- Definition 5.2.6 (Equivalent sequences) -/
-lemma Sequence.equiv_iff (a b: ℕ → ℚ) : equiv a b ↔ ∀ ε > 0, ∃ N, ∀ n ≥ N, |a n - b n| ≤ ε := by sorry
+lemma Sequence.equiv_iff (a b: ℕ → ℚ) : equiv a b ↔ ∀ ε > 0, ∃ N, ∀ n ≥ N, |a n - b n| ≤ ε := by
+  sorry
 
 /-- Proposition 5.2.8 -/
 lemma Sequence.equiv_example :
-  -- This proof is perhaps more complicated than it needs to be; a shorter version may be possible that is still faithful to the original text.
+  -- This proof is perhaps more complicated than it needs to be; a shorter version may be
+  -- possible that is still faithful to the original text.
   equiv (fun n:ℕ ↦ (1:ℚ)+10^(-(n:ℤ)-1)) (fun n:ℕ ↦ (1:ℚ)-10^(-(n:ℤ)-1)) := by
   set a := fun n:ℕ ↦ (1:ℚ)+10^(-(n:ℤ)-1)
   set b := fun n:ℕ ↦ (1:ℚ)-10^(-(n:ℤ)-1)
@@ -86,7 +100,8 @@ lemma Sequence.equiv_example :
         simp
       _ ≤ _ := by
         gcongr
-        apply le_trans _ (pow_le_pow_left₀ (show 0 ≤ (2:ℚ) by norm_num) (show (2:ℚ) ≤ 10 by norm_num) _)
+        apply le_trans _ (pow_le_pow_left₀ (show 0 ≤ (2:ℚ) by norm_num)
+          (show (2:ℚ) ≤ 10 by norm_num) _)
         convert Nat.cast_le.mpr (Section_4_3.two_pow_geq (N+1)) using 1
         . simp
         . simp
@@ -107,9 +122,11 @@ lemma Sequence.equiv_example :
 
 
 /-- Exercise 5.2.1 -/
-theorem Sequence.equiv_of_cauchy {a b: ℕ → ℚ} (hab: Sequence.equiv a b) : (a:Sequence).isCauchy ↔ (b:Sequence).isCauchy := by sorry
+theorem Sequence.equiv_of_cauchy {a b: ℕ → ℚ} (hab: Sequence.equiv a b) :
+    (a:Sequence).isCauchy ↔ (b:Sequence).isCauchy := by sorry
 
 /-- Exercise 5.2.2 -/
-theorem Sequence.close_of_bounded {ε:ℚ} (hε: ε>0) {a b: ℕ → ℚ} (hab: ε.eventually_close a b) : (a:Sequence).isBounded ↔ (b:Sequence).isBounded := by sorry
+theorem Sequence.close_of_bounded {ε:ℚ} (hε: ε>0) {a b: ℕ → ℚ} (hab: ε.eventually_close a b) :
+    (a:Sequence).isBounded ↔ (b:Sequence).isBounded := by sorry
 
 end Chapter5

--- a/analysis/Analysis/Section_5_3.lean
+++ b/analysis/Analysis/Section_5_3.lean
@@ -6,7 +6,11 @@ import Mathlib.Algebra.Group.MinimalAxioms
 /-!
 # Analysis I, Section 5.3
 
-I have attempted to make the translation as faithful a paraphrasing as possible of the original text.  When there is a choice between a more idiomatic Lean solution and a more faithful translation, I have generally chosen the latter.  In particular, there will be places where the Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided doing so.
+I have attempted to make the translation as faithful a paraphrasing as possible of the original
+text. When there is a choice between a more idiomatic Lean solution and a more faithful
+translation, I have generally chosen the latter. In particular, there will be places where the
+Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided
+doing so.
 
 Main constructions and results of this section:
 
@@ -39,13 +43,15 @@ abbrev CauchySequence.mk' {a:ℕ → ℚ} (ha: (a:Sequence).isCauchy) : CauchySe
   cauchy := ha
 
 @[simp]
-theorem CauchySequence.coe_eq {a:ℕ → ℚ} (ha: (a:Sequence).isCauchy) : (mk' ha).toSequence = (a:Sequence) := by rfl
+theorem CauchySequence.coe_eq {a:ℕ → ℚ} (ha: (a:Sequence).isCauchy) :
+    (mk' ha).toSequence = (a:Sequence) := by rfl
 
 instance CauchySequence.instCoeFun : CoeFun CauchySequence (fun _ ↦ ℕ → ℚ) where
   coe := fun a n ↦ a.toSequence (n:ℤ)
 
 @[simp]
-theorem CauchySequence.coe_to_sequence (a: CauchySequence) : ((a:ℕ → ℚ):Sequence) = a.toSequence := by
+theorem CauchySequence.coe_to_sequence (a: CauchySequence) :
+    ((a:ℕ → ℚ):Sequence) = a.toSequence := by
   apply Sequence.ext
   . rw [a.zero]
   ext n
@@ -82,10 +88,16 @@ instance CauchySequence.instZero : Zero CauchySequence where
 abbrev Real := Quotient CauchySequence.instSetoid
 
 open Classical in
-/-- It is convenient in Lean to assign the "dummy" value of 0 to `LIM a` when `a` is not Cauchy.  This requires Classical logic, because the property of being Cauchy is not computable or decidable.  -/
-noncomputable abbrev LIM (a:ℕ → ℚ) : Real := Quotient.mk _ (if h : (a:Sequence).isCauchy then CauchySequence.mk' h else (0:CauchySequence))
+/--
+  It is convenient in Lean to assign the "dummy" value of 0 to `LIM a` when `a` is not Cauchy.
+  This requires Classical logic, because the property of being Cauchy is not computable or
+  decidable.
+-/
+noncomputable abbrev LIM (a:ℕ → ℚ) : Real :=
+  Quotient.mk _ (if h : (a:Sequence).isCauchy then CauchySequence.mk' h else (0:CauchySequence))
 
-theorem LIM_def {a:ℕ → ℚ} (ha: (a:Sequence).isCauchy) : LIM a = Quotient.mk _ (CauchySequence.mk' ha) := by
+theorem LIM_def {a:ℕ → ℚ} (ha: (a:Sequence).isCauchy) :
+    LIM a = Quotient.mk _ (CauchySequence.mk' ha) := by
   rw [LIM, dif_pos ha]
 
 /-- Definition 5.3.1 (Real numbers) -/
@@ -117,7 +129,8 @@ theorem Real.LIM_eq_LIM {a b:ℕ → ℚ} (ha: (a:Sequence).isCauchy) (hb: (b:Se
   rwa [dif_pos ha, dif_pos hb, CauchySequence.equiv_iff]
 
 /--Lemma 5.3.6 (Sum of Cauchy sequences is Cauchy)-/
-theorem Sequence.add_cauchy {a b:ℕ → ℚ}  (ha: (a:Sequence).isCauchy) (hb: (b:Sequence).isCauchy) : (a + b:Sequence).isCauchy := by
+theorem Sequence.add_cauchy {a b:ℕ → ℚ}  (ha: (a:Sequence).isCauchy) (hb: (b:Sequence).isCauchy) :
+    (a + b:Sequence).isCauchy := by
   -- This proof is written to follow the structure of the original text.
   rw [isCauchy_def] at ha hb ⊢
   intro ε hε
@@ -141,7 +154,7 @@ theorem Sequence.add_cauchy {a b:ℕ → ℚ}  (ha: (a:Sequence).isCauchy) (hb: 
 
 /--Lemma 5.3.7 (Sum of equivalent sequences is equivalent)-/
 theorem Sequence.add_equiv_left {a a':ℕ → ℚ} (b:ℕ → ℚ) (haa': Sequence.equiv a a') :
-  Sequence.equiv (a + b) (a' + b) := by
+    Sequence.equiv (a + b) (a' + b) := by
   -- This proof is written to follow the structure of the original text.
   rw [equiv_def] at haa' ⊢
   intro ε hε
@@ -159,13 +172,15 @@ theorem Sequence.add_equiv_left {a a':ℕ → ℚ} (b:ℕ → ℚ) (haa': Sequen
 
 /--Lemma 5.3.7 (Sum of equivalent sequences is equivalent)-/
 theorem Sequence.add_equiv_right {b b':ℕ → ℚ} (a:ℕ → ℚ) (hbb': Sequence.equiv b b') :
-  Sequence.equiv (a + b) (a + b') := by
+    Sequence.equiv (a + b) (a + b') := by
   simp_rw [add_comm]
   exact add_equiv_left a hbb'
 
 /--Lemma 5.3.7 (Sum of equivalent sequences is equivalent)-/
-theorem Sequence.add_equiv {a b a' b':ℕ → ℚ} (haa': Sequence.equiv a a') (hbb': Sequence.equiv b b') :
-  Sequence.equiv (a + b) (a' + b') := equiv_trans (add_equiv_left b haa') (add_equiv_right a' hbb')
+theorem Sequence.add_equiv {a b a' b':ℕ → ℚ} (haa': Sequence.equiv a a')
+  (hbb': Sequence.equiv b b') :
+    Sequence.equiv (a + b) (a' + b') :=
+  equiv_trans (add_equiv_left b haa') (add_equiv_right a' hbb')
 
 /-- Definition 5.3.4 (Addition of reals) -/
 noncomputable instance Real.add_inst : Add Real where
@@ -191,11 +206,12 @@ theorem Real.add_of_LIM {a b:ℕ → ℚ} (ha: (a:Sequence).isCauchy) (hb: (b:Se
   convert Quotient.liftOn₂_mk _ _ _ _
   rw [dif_pos _]
 
-/--Proposition 5.3.10 (Product of Cauchy sequences is Cauchy)-/
-theorem Sequence.mul_cauchy {a b:ℕ → ℚ}  (ha: (a:Sequence).isCauchy) (hb: (b:Sequence).isCauchy) : (a * b:Sequence).isCauchy := by
+/-- Proposition 5.3.10 (Product of Cauchy sequences is Cauchy) -/
+theorem Sequence.mul_cauchy {a b:ℕ → ℚ}  (ha: (a:Sequence).isCauchy) (hb: (b:Sequence).isCauchy) :
+    (a * b:Sequence).isCauchy := by
   sorry
 
-/--Proposition 5.3.10 (Product of equivalent sequences is equivalent) / Exercise 5.3.2 -/
+/-- Proposition 5.3.10 (Product of equivalent sequences is equivalent) / Exercise 5.3.2 -/
 theorem Sequence.mul_equiv_left {a a':ℕ → ℚ} (b:ℕ → ℚ) (haa': Sequence.equiv a a') :
   Sequence.equiv (a * b) (a' * b) := by
   sorry
@@ -207,8 +223,10 @@ theorem Sequence.mul_equiv_right {b b':ℕ → ℚ} (a:ℕ → ℚ) (hbb': Seque
   exact mul_equiv_left a hbb'
 
 /--Proposition 5.3.10 (Product of equivalent sequences is equivalent) / Exercise 5.3.2 -/
-theorem Sequence.mul_equiv {a b a' b':ℕ → ℚ} (haa': Sequence.equiv a a') (hbb': Sequence.equiv b b') :
-  Sequence.equiv (a * b) (a' * b') := equiv_trans (mul_equiv_left b haa') (mul_equiv_right a' hbb')
+theorem Sequence.mul_equiv {a b a' b':ℕ → ℚ} (haa': Sequence.equiv a a')
+  (hbb': Sequence.equiv b b') :
+    Sequence.equiv (a * b) (a' * b') :=
+  equiv_trans (mul_equiv_left b haa') (mul_equiv_right a' hbb')
 
 /-- Definition 5.3.9 (Product of reals) -/
 noncomputable instance Real.mul_inst : Mul Real where
@@ -272,7 +290,8 @@ theorem Real.neg_of_ratCast (a:ℚ) : -(a:Real) = (-a:ℚ) := by sorry
 /-- It may be possible to omit the Cauchy sequence hypothesis here. -/
 theorem Real.neg_of_LIM (a:ℕ → ℚ) (ha: (a:Sequence).isCauchy) : -LIM a = LIM (-a) := by sorry
 
-theorem Real.neg_of_cauchy (a:ℕ → ℚ) (ha: (a:Sequence).isCauchy) : ((-a:ℕ → ℚ):Sequence).isCauchy := by sorry
+theorem Real.neg_of_cauchy (a:ℕ → ℚ) (ha: (a:Sequence).isCauchy) :
+    ((-a:ℕ → ℚ):Sequence).isCauchy := by sorry
 
 
 /-- Proposition 5.3.11 -/
@@ -281,7 +300,8 @@ AddGroup.ofLeftAxioms (by sorry) (by sorry) (by sorry)
 
 theorem Real.sub_eq_add_neg (x y:Real) : x - y = x + (-y) :=  rfl
 
-theorem Real.sub_of_cauchy {a b:ℕ → ℚ} (ha: (a:Sequence).isCauchy) (hb: (b:Sequence).isCauchy) : ((a-b:ℕ → ℚ):Sequence).isCauchy := by sorry
+theorem Real.sub_of_cauchy {a b:ℕ → ℚ} (ha: (a:Sequence).isCauchy) (hb: (b:Sequence).isCauchy) :
+    ((a-b:ℕ → ℚ):Sequence).isCauchy := by sorry
 
 theorem Real.sub_of_LIM {a b:ℕ → ℚ} (ha: (a:Sequence).isCauchy) (hb: (b:Sequence).isCauchy) :
   LIM a - LIM b = LIM (a - b) := by sorry
@@ -317,7 +337,10 @@ abbrev Real.ratCast_hom : ℚ →+* Real where
   map_add' := by sorry
   map_mul' := by sorry
 
-/-- Definition 5.3.12 (sequences bounded away from zero).  Sequences are indexed to start from zero as this is more convenient for Mathlib purposes. -/
+/--
+  Definition 5.3.12 (sequences bounded away from zero).  Sequences are indexed to start from zero
+  as this is more convenient for Mathlib purposes.
+-/
 abbrev bounded_away_zero (a:ℕ → ℚ) : Prop :=
   ∃ (c:ℚ), c > 0 ∧ ∀ n, |a n| ≥ c
 
@@ -340,7 +363,8 @@ example : bounded_away_zero (fun n ↦ 10^(n+1)) := by sorry
 example : ((fun (n:ℕ) ↦ (10:ℚ)^(n+1)):Sequence).isBounded := by sorry
 
 /-- Lemma 5.3.14 -/
-theorem Real.bounded_away_zero_of_nonzero {x:Real} (hx: x ≠ 0) : ∃ a:ℕ → ℚ, (a:Sequence).isCauchy ∧ bounded_away_zero a ∧ x = LIM a := by
+theorem Real.bounded_away_zero_of_nonzero {x:Real} (hx: x ≠ 0) :
+    ∃ a:ℕ → ℚ, (a:Sequence).isCauchy ∧ bounded_away_zero a ∧ x = LIM a := by
   -- This proof is written to follow the structure of the original text.
   obtain ⟨ b, hb, rfl ⟩ := eq_lim x
   simp only [←LIM_zero, ne_eq] at hx
@@ -365,18 +389,22 @@ theorem Real.bounded_away_zero_of_nonzero {x:Real} (hx: x ≠ 0) : ∃ a:ℕ →
     linarith
   rw[(LIM_eq_LIM ha hb).mpr not_hard]
 
-/-- This result was not explicitly stated in the text, but is needed in the theory. It's a good exercise, so I'm setting it as such. -/
-theorem Real.lim_of_bounded_away_zero {a:ℕ → ℚ} (ha: bounded_away_zero a) (ha_cauchy: (a:Sequence).isCauchy) :
-  LIM a ≠ 0 := by
-   sorry
+/--
+  This result was not explicitly stated in the text, but is needed in the theory. It's a good
+  exercise, so I'm setting it as such.
+-/
+theorem Real.lim_of_bounded_away_zero {a:ℕ → ℚ} (ha: bounded_away_zero a)
+  (ha_cauchy: (a:Sequence).isCauchy) :
+    LIM a ≠ 0 := by sorry
 
 theorem Real.bounded_away_zero_nonzero {a:ℕ → ℚ} (ha: bounded_away_zero a) (n: ℕ) : a n ≠ 0 := by
    obtain ⟨ c, hc, ha ⟩ := ha
    specialize ha n; contrapose! ha; simp [ha, hc]
 
 /-- Lemma 5.3.15 -/
-theorem Real.inv_of_bounded_away_zero_cauchy {a:ℕ → ℚ} (ha: bounded_away_zero a) (ha_cauchy: (a:Sequence).isCauchy) :
-  ((a⁻¹:ℕ → ℚ):Sequence).isCauchy := by
+theorem Real.inv_of_bounded_away_zero_cauchy {a:ℕ → ℚ} (ha: bounded_away_zero a)
+  (ha_cauchy: (a:Sequence).isCauchy) :
+    ((a⁻¹:ℕ → ℚ):Sequence).isCauchy := by
   -- This proof is written to follow the structure of the original text.
   have ha' (n:ℕ) : a n ≠ 0 := bounded_away_zero_nonzero ha n
   rw [bounded_away_zero_def] at ha
@@ -406,8 +434,10 @@ theorem Real.inv_of_bounded_away_zero_cauchy {a:ℕ → ℚ} (ha: bounded_away_z
       field_simp [hc]
 
 /-- Lemma 5.3.17 (Reciprocation is well-defined) -/
-theorem Real.inv_of_equiv {a b:ℕ → ℚ} (ha: bounded_away_zero a) (ha_cauchy: (a:Sequence).isCauchy) (hb: bounded_away_zero b) (hb_cauchy: (b:Sequence).isCauchy) (hlim: LIM a = LIM b) :
-  LIM a⁻¹ = LIM b⁻¹ := by
+theorem Real.inv_of_equiv {a b:ℕ → ℚ} (ha: bounded_away_zero a)
+  (ha_cauchy: (a:Sequence).isCauchy) (hb: bounded_away_zero b)
+  (hb_cauchy: (b:Sequence).isCauchy) (hlim: LIM a = LIM b) :
+    LIM a⁻¹ = LIM b⁻¹ := by
   -- This proof is written to follow the structure of the original text.
   set P := LIM a⁻¹ * LIM a * LIM b⁻¹
   have ha' (n:ℕ) : a n ≠ 0 := bounded_away_zero_nonzero ha n
@@ -429,11 +459,15 @@ theorem Real.inv_of_equiv {a b:ℕ → ℚ} (ha: bounded_away_zero a) (ha_cauchy
   simp [←claim1, ←claim2]
 
 open Classical in
-/-- Definition 5.3.16 (Reciprocation of real numbers).  Requires classical logic because we need to assign a "junk" value to the inverse of 0.  -/
+/--
+  Definition 5.3.16 (Reciprocation of real numbers).  Requires classical logic because we need to
+  assign a "junk" value to the inverse of 0.
+-/
 noncomputable instance Real.instInv : Inv Real where
   inv x := if h: x ≠ 0 then LIM (bounded_away_zero_of_nonzero h).choose⁻¹ else 0
 
-theorem Real.inv_def {a:ℕ → ℚ} (h: bounded_away_zero a) (hc: (a:Sequence).isCauchy) : (LIM a)⁻¹ = LIM a⁻¹ := by
+theorem Real.inv_def {a:ℕ → ℚ} (h: bounded_away_zero a) (hc: (a:Sequence).isCauchy) :
+    (LIM a)⁻¹ = LIM a⁻¹ := by
   set x := LIM a
   have hx : x ≠ 0 := lim_of_bounded_away_zero h hc
   set hb := bounded_away_zero_of_nonzero hx
@@ -468,10 +502,12 @@ noncomputable instance Real.instField : Field Real where
 
 theorem Real.mul_right_cancel₀ {x y z:Real} (hz: z ≠ 0) (h: x * z = y * z) : x = y := by sorry
 
-theorem Real.mul_right_nocancel : ¬ ∀ (x y z:Real), (hz: z = 0) → (x * z = y * z) → x = y := by sorry
+theorem Real.mul_right_nocancel : ¬ ∀ (x y z:Real), (hz: z = 0) → (x * z = y * z) → x = y := by
+  sorry
 
 /-- Exercise 5.3.4 -/
-theorem Real.equiv_of_bounded {a b:ℕ → ℚ} (ha: (a:Sequence).isBounded) (hab: Sequence.equiv a b) : (b:Sequence).isBounded := by sorry
+theorem Real.equiv_of_bounded {a b:ℕ → ℚ} (ha: (a:Sequence).isBounded) (hab: Sequence.equiv a b) :
+    (b:Sequence).isBounded := by sorry
 
 /-- Exercise 5.3.5 -/
 theorem Real.Cauchy_of_harmonic : ((fun n ↦ 1/((n:ℚ)+1): ℕ → ℚ):Sequence).isCauchy := by sorry

--- a/analysis/Analysis/Section_5_4.lean
+++ b/analysis/Analysis/Section_5_4.lean
@@ -5,7 +5,11 @@ import Analysis.Section_5_3
 /-!
 # Analysis I, Section 5.4
 
-I have attempted to make the translation as faithful a paraphrasing as possible of the original text.  When there is a choice between a more idiomatic Lean solution and a more faithful translation, I have generally chosen the latter.  In particular, there will be places where the Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided doing so.
+I have attempted to make the translation as faithful a paraphrasing as possible of the original
+text. When there is a choice between a more idiomatic Lean solution and a more faithful
+translation, I have generally chosen the latter. In particular, there will be places where the
+Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided
+doing so.
 
 Main constructions and results of this section:
 
@@ -15,19 +19,24 @@ Main constructions and results of this section:
 namespace Chapter5
 
 
-/-- Definition 5.4.1 (sequences bounded away from zero with sign).  Sequences are indexed to start from zero as this is more convenient for Mathlib purposes. -/
+/--
+  Definition 5.4.1 (sequences bounded away from zero with sign). Sequences are indexed to start
+  from zero as this is more convenient for Mathlib purposes.
+-/
 abbrev bounded_away_pos (a:ℕ → ℚ) : Prop :=
   ∃ (c:ℚ), c > 0 ∧ ∀ n, a n ≥ c
 
-/-- Definition 5.4.1 (sequences bounded away from zero with sign).-/
+/-- Definition 5.4.1 (sequences bounded away from zero with sign). -/
 abbrev bounded_away_neg (a:ℕ → ℚ) : Prop :=
   ∃ (c:ℚ), c > 0 ∧ ∀ n, a n ≤ -c
 
 /-- Definition 5.4.1 (sequences bounded away from zero with sign). -/
-theorem bounded_away_pos_def (a:ℕ → ℚ) : bounded_away_pos a ↔ ∃ (c:ℚ), c > 0 ∧ ∀ n, a n ≥ c := by rfl
+theorem bounded_away_pos_def (a:ℕ → ℚ) : bounded_away_pos a ↔ ∃ (c:ℚ), c > 0 ∧ ∀ n, a n ≥ c := by
+  rfl
 
 /-- Definition 5.4.1 (sequences bounded away from zero with sign). -/
-theorem bounded_away_neg_def (a:ℕ → ℚ) : bounded_away_neg a ↔ ∃ (c:ℚ), c > 0 ∧ ∀ n, a n ≤ -c := by rfl
+theorem bounded_away_neg_def (a:ℕ → ℚ) : bounded_away_neg a ↔ ∃ (c:ℚ), c > 0 ∧ ∀ n, a n ≤ -c := by
+  rfl
 
 /-- Examples 5.4.2 -/
 example : bounded_away_pos (fun n ↦ 1 + 10^(-(n:ℤ)-1)) := by sorry
@@ -42,19 +51,26 @@ example : ¬ bounded_away_neg (fun n ↦ (-1)^n) := by sorry
 
 example : bounded_away_zero (fun n ↦ (-1)^n) := by sorry
 
-theorem bounded_away_zero_of_pos {a:ℕ → ℚ} (ha: bounded_away_pos a) : bounded_away_zero a := by sorry
+theorem bounded_away_zero_of_pos {a:ℕ → ℚ} (ha: bounded_away_pos a) : bounded_away_zero a := by
+  sorry
 
-theorem bounded_away_zero_of_neg {a:ℕ → ℚ} (ha: bounded_away_neg a) : bounded_away_zero a := by sorry
+theorem bounded_away_zero_of_neg {a:ℕ → ℚ} (ha: bounded_away_neg a) : bounded_away_zero a := by
+  sorry
 
-theorem not_bounded_away_pos_neg {a:ℕ → ℚ} : ¬ (bounded_away_pos a ∧ bounded_away_neg a) := by sorry
+theorem not_bounded_away_pos_neg {a:ℕ → ℚ} : ¬ (bounded_away_pos a ∧ bounded_away_neg a) := by
+  sorry
 
-abbrev Real.isPos (x:Real) : Prop := ∃ a:ℕ → ℚ, bounded_away_pos a ∧ (a:Sequence).isCauchy ∧ x = LIM a
+abbrev Real.isPos (x:Real) : Prop :=
+  ∃ a:ℕ → ℚ, bounded_away_pos a ∧ (a:Sequence).isCauchy ∧ x = LIM a
 
-abbrev Real.isNeg (x:Real) : Prop := ∃ a:ℕ → ℚ, bounded_away_neg a ∧ (a:Sequence).isCauchy ∧ x = LIM a
+abbrev Real.isNeg (x:Real) : Prop :=
+  ∃ a:ℕ → ℚ, bounded_away_neg a ∧ (a:Sequence).isCauchy ∧ x = LIM a
 
-theorem Real.isPos_def (x:Real) : Real.isPos x ↔ ∃ a:ℕ → ℚ, bounded_away_pos a ∧ (a:Sequence).isCauchy ∧ x = LIM a := by rfl
+theorem Real.isPos_def (x:Real) :
+    Real.isPos x ↔ ∃ a:ℕ → ℚ, bounded_away_pos a ∧ (a:Sequence).isCauchy ∧ x = LIM a := by rfl
 
-theorem Real.isNeg_def (x:Real) : Real.isNeg x ↔ ∃ a:ℕ → ℚ, bounded_away_neg a ∧ (a:Sequence).isCauchy ∧ x = LIM a := by rfl
+theorem Real.isNeg_def (x:Real) :
+    Real.isNeg x ↔ ∃ a:ℕ → ℚ, bounded_away_neg a ∧ (a:Sequence).isCauchy ∧ x = LIM a := by rfl
 
 /-- Proposition 5.4.4 (basic properties of positive reals) / Exercise 5.4.1 -/
 theorem Real.trichotomous (x:Real) : x = 0 ∨ x.isPos ∨ x.isNeg := by sorry
@@ -111,8 +127,12 @@ theorem Real.abs_of_neg (x:Real) (hx: x.isNeg) : Real.abs x = -x := by
 /-- Definition 5.4.5 (absolute value) -/
 @[simp]
 theorem Real.abs_of_zero : Real.abs 0 = 0 := by
-  have hpos: ¬ (0:Real).isPos := by have := Real.not_zero_pos 0; simp only [true_and] at this; assumption
-  have hneg: ¬ (0:Real).isNeg := by have := Real.not_zero_neg 0; simp only [true_and] at this; assumption
+  have hpos: ¬ (0:Real).isPos := by
+    have := Real.not_zero_pos 0
+    simp only [true_and] at this; assumption
+  have hneg: ¬ (0:Real).isNeg := by
+    have := Real.not_zero_neg 0
+    simp only [true_and] at this; assumption
   simp [Real.abs, hpos, hneg]
 
 /-- Definition 5.4.6 (Ordering of the reals) -/
@@ -169,7 +189,10 @@ theorem Real.mul_le_mul_left {x y z:Real} (hxy: x ≤ y) (hz: z.isPos) : z * x �
 theorem Real.mul_pos_neg {x y:Real} (hx: x.isPos) (hy: y.isNeg) : (x * y).isNeg := by
   sorry
 
-/-- (Not from textbook) Real has the structure of a linear ordering.  The order is not computable, and so classical logic is required to impose decidability.-/
+/--
+  (Not from textbook) Real has the structure of a linear ordering. The order is not computable,
+  and so classical logic is required to impose decidability.
+-/
 noncomputable instance Real.instLinearOrder : LinearOrder Real where
   le_refl := sorry
   le_trans := sorry
@@ -219,7 +242,8 @@ instance Real.instIsStrictOrderedRing : IsStrictOrderedRing Real where
   zero_le_one := by sorry
 
 /-- Proposition 5.4.9 (The non-negative reals are closed)-/
-theorem Real.LIM_of_nonneg {a: ℕ → ℚ} (ha: ∀ n, a n ≥ 0) (hcauchy: (a:Sequence).isCauchy) : LIM a ≥ 0 := by
+theorem Real.LIM_of_nonneg {a: ℕ → ℚ} (ha: ∀ n, a n ≥ 0) (hcauchy: (a:Sequence).isCauchy) :
+    LIM a ≥ 0 := by
   -- This proof is written to follow the structure of the original text.
   by_contra! hlim
   set x := LIM a
@@ -251,20 +275,27 @@ theorem Real.LIM_of_nonneg {a: ℕ → ℚ} (ha: ∀ n, a n ≥ 0) (hcauchy: (a:
   contradiction
 
 /-- Corollary 5.4.10 -/
-theorem Real.LIM_mono {a b:ℕ → ℚ} (ha: (a:Sequence).isCauchy) (hb: (b:Sequence).isCauchy) (hmono: ∀ n, a n ≤ b n) : LIM a ≤ LIM b := by
+theorem Real.LIM_mono {a b:ℕ → ℚ} (ha: (a:Sequence).isCauchy) (hb: (b:Sequence).isCauchy)
+  (hmono: ∀ n, a n ≤ b n) :
+    LIM a ≤ LIM b := by
   -- This proof is written to follow the structure of the original text.
   have := LIM_of_nonneg (a := b - a) (by intro n; simp [hmono n]) (sub_of_cauchy hb ha)
   rw [←Real.sub_of_LIM hb ha] at this
   linarith
 
 /-- Remark 5.4.11 --/
-theorem Real.LIM_mono_fail : ∃ (a b:ℕ → ℚ), (a:Sequence).isCauchy ∧ (b:Sequence).isCauchy ∧ ¬ (∀ n, a n > b n) ∧ ¬ LIM a > LIM b := by
+theorem Real.LIM_mono_fail :
+    ∃ (a b:ℕ → ℚ), (a:Sequence).isCauchy
+    ∧ (b:Sequence).isCauchy
+    ∧ ¬ (∀ n, a n > b n)
+    ∧ ¬ LIM a > LIM b := by
   use (fun n ↦ 1 + 1/(n:ℚ))
   use (fun n ↦ 1 - 1/(n:ℚ))
   sorry
 
 /-- Proposition 5.4.12 (Bounding reals by rationals) -/
-theorem Real.exists_rat_le_and_nat_ge {x:Real} (hx: x.isPos) : (∃ q:ℚ, q > 0 ∧ (q:Real) ≤ x) ∧ ∃ N:ℕ, x < (N:Real) := by
+theorem Real.exists_rat_le_and_nat_ge {x:Real} (hx: x.isPos) :
+    (∃ q:ℚ, q > 0 ∧ (q:Real) ≤ x) ∧ ∃ N:ℕ, x < (N:Real) := by
   -- This proof is written to follow the structure of the original text.
   rw [isPos_def] at hx
   obtain ⟨ a, hbound, hcauchy, heq ⟩ := hx
@@ -335,10 +366,12 @@ theorem Real.le_add_eps_iff (x y:Real) : ∀ ε > 0, x ≤ y+ε ↔ x ≤ y := b
 theorem Real.dist_le_eps_iff (x y:Real) : ∀ ε > 0, |x-y| ≤ ε ↔ x = y := by sorry
 
 /-- Exercise 5.4.8 -/
-theorem Real.LIM_of_le {x:Real} {a:ℕ → ℚ} (hcauchy: (a:Sequence).isCauchy) (h: ∀ n, a n ≤ x) : LIM a ≤ x := by sorry
+theorem Real.LIM_of_le {x:Real} {a:ℕ → ℚ} (hcauchy: (a:Sequence).isCauchy) (h: ∀ n, a n ≤ x) :
+    LIM a ≤ x := by sorry
 
 /-- Exercise 5.4.8 -/
-theorem Real.LIM_of_ge {x:Real} {a:ℕ → ℚ} (hcauchy: (a:Sequence).isCauchy) (h: ∀ n, a n ≥ x) : LIM a ≥ x := by sorry
+theorem Real.LIM_of_ge {x:Real} {a:ℕ → ℚ} (hcauchy: (a:Sequence).isCauchy) (h: ∀ n, a n ≥ x) :
+    LIM a ≥ x := by sorry
 
 theorem Real.max_eq (x y:Real) : max x y = (if x ≥ y then x else y) :=  max_def' x y
 
@@ -360,7 +393,8 @@ theorem Real.max_self (x:Real) : max x x = x := by sorry
 theorem Real.max_add (x y z:Real) : max (x + z) (y + z) = max x y + z := by sorry
 
 /-- Exercise 5.4.9 -/
-theorem Real.max_mul (x y :Real) {z:Real} (hz: z.isPos) : max (x * z) (y * z) = max x y * z := by sorry
+theorem Real.max_mul (x y :Real) {z:Real} (hz: z.isPos) : max (x * z) (y * z) = max x y * z := by
+  sorry
 /- Additional exercise: What happens if z is negative? -/
 
 /-- Exercise 5.4.9 -/
@@ -373,7 +407,8 @@ theorem Real.min_self (x:Real) : min x x = x := by sorry
 theorem Real.min_add (x y z:Real) : min (x + z) (y + z) = min x y + z := by sorry
 
 /-- Exercise 5.4.9 -/
-theorem Real.min_mul (x y :Real) {z:Real} (hz: z.isPos) : min (x * z) (y * z) = min x y * z := by sorry
+theorem Real.min_mul (x y :Real) {z:Real} (hz: z.isPos) : min (x * z) (y * z) = min x y * z := by
+  sorry
 
 /-- Exercise 5.4.9 -/
 theorem Real.inv_max {x y :Real} (hx:x.isPos) (hy:y.isPos) : (max x y)⁻¹ = min x⁻¹ y⁻¹ := by sorry

--- a/analysis/Analysis/Section_5_5.lean
+++ b/analysis/Analysis/Section_5_5.lean
@@ -5,9 +5,14 @@ import Analysis.Section_5_4
 /-!
 # Analysis I, Section 5.5
 
-I have attempted to make the translation as faithful a paraphrasing as possible of the original text.  When there is a choice between a more idiomatic Lean solution and a more faithful translation, I have generally chosen the latter.  In particular, there will be places where the Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided doing so.
+I have attempted to make the translation as faithful a paraphrasing as possible of the original
+text.  When there is a choice between a more idiomatic Lean solution and a more faithful
+translation, I have generally chosen the latter.  In particular, there will be places where the
+Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided
+doing so.
 
-In this section we begin to use the Mathlib API for sets; the Chapter 3 set theory is deprecated in favor of this API.
+In this section we begin to use the Mathlib API for sets; the Chapter 3 set theory is deprecated
+in favor of this API.
 
 Main constructions and results of this section:
 
@@ -17,9 +22,11 @@ Main constructions and results of this section:
 namespace Chapter5
 
 /-- Definition 5.5.1 (upper bounds).  Here we use the `upperBounds` set defined in Mathlib. -/
-theorem Real.upperBound_def (E: Set Real) (M: Real) : M ∈ upperBounds E ↔ ∀ x ∈ E, x ≤ M := mem_upperBounds
+theorem Real.upperBound_def (E: Set Real) (M: Real) : M ∈ upperBounds E ↔ ∀ x ∈ E, x ≤ M :=
+  mem_upperBounds
 
-theorem Real.lowerBound_def (E: Set Real) (M: Real) : M ∈ lowerBounds E ↔ ∀ x ∈ E, x ≥ M := mem_lowerBounds
+theorem Real.lowerBound_def (E: Set Real) (M: Real) : M ∈ lowerBounds E ↔ ∀ x ∈ E, x ≥ M :=
+  mem_lowerBounds
 
 /-- API for Example 5.5.2 -/
 theorem Real.Icc_def (x y:Real) : Set.Icc x y = { z | x ≤ z ∧ z ≤ y } := rfl
@@ -40,14 +47,17 @@ example : ¬ ∃ M, M ∈ upperBounds (Set.Ioi 0) := by sorry
 /-- Example 5.5.4 -/
 example : ∀ M, M ∈ upperBounds (∅ : Set Real) := by sorry
 
-theorem Real.upperBound_upper {M M': Real} (h: M ≤ M') {E: Set Real} (hb: M ∈ upperBounds E) : M' ∈ upperBounds E := by sorry
+theorem Real.upperBound_upper {M M': Real} (h: M ≤ M') {E: Set Real} (hb: M ∈ upperBounds E) :
+    M' ∈ upperBounds E := by sorry
 
 /-- Definition 5.5.5 (least upper bound).  Here we use the `isLUB` predicate defined in Mathlib. -/
-theorem Real.isLUB_def (E: Set Real) (M: Real) : IsLUB E M ↔ M ∈ upperBounds E ∧ ∀ M' ∈ upperBounds E, M' ≥ M := by
+theorem Real.isLUB_def (E: Set Real) (M: Real) :
+    IsLUB E M ↔ M ∈ upperBounds E ∧ ∀ M' ∈ upperBounds E, M' ≥ M := by
   simp_rw [ge_iff_le]
   rfl
 
-theorem Real.isGLB_def (E: Set Real) (M: Real) : IsGLB E M ↔ M ∈ lowerBounds E ∧ ∀ M' ∈ lowerBounds E, M' ≤ M := by
+theorem Real.isGLB_def (E: Set Real) (M: Real) :
+    IsGLB E M ↔ M ∈ lowerBounds E ∧ ∀ M' ∈ lowerBounds E, M' ≤ M := by
   rfl
 
 /-- Example 5.5.6 -/
@@ -70,20 +80,33 @@ theorem Real.bddAbove_def (E: Set Real) : BddAbove E ↔ ∃ M, M ∈  upperBoun
 theorem Real.bddBelow_def (E: Set Real) : BddBelow E ↔ ∃ M, M ∈  lowerBounds E := Set.nonempty_def
 
 /-- Exercise 5.5.2 -/
-theorem Real.upperBound_between {E: Set Real} {n:ℕ} {L K:ℤ} (hLK: L < K) (hK: K*((1/(n+1):ℚ):Real) ∈ upperBounds E) (hL: L*((1/(n+1):ℚ):Real) ∉ upperBounds E) : ∃ m, L < m ∧ m ≤ K ∧ m*((1/(n+1):ℚ):Real) ∈ upperBounds E ∧ (m-1)*((1/(n+1):ℚ):Real) ∉ upperBounds E := by sorry
+theorem Real.upperBound_between {E: Set Real} {n:ℕ} {L K:ℤ} (hLK: L < K)
+  (hK: K*((1/(n+1):ℚ):Real) ∈ upperBounds E) (hL: L*((1/(n+1):ℚ):Real) ∉ upperBounds E) :
+    ∃ m, L < m
+    ∧ m ≤ K
+    ∧ m*((1/(n+1):ℚ):Real) ∈ upperBounds E
+    ∧ (m-1)*((1/(n+1):ℚ):Real) ∉ upperBounds E := by sorry
 
 /-- Exercise 5.5.3 -/
-theorem Real.upperBound_discrete_unique {E: Set Real} {n:ℕ} {m m':ℤ} (hm1: (((m:ℚ) / (n+1):ℚ):Real) ∈ upperBounds E) (hm2: (((m:ℚ) / (n+1) - 1 / (n+1):ℚ):Real) ∉ upperBounds E) (hm'1: (((m':ℚ) / (n+1):ℚ):Real) ∈ upperBounds E) (hm'2: (((m':ℚ) / (n+1) - 1 / (n+1):ℚ):Real) ∉ upperBounds E) : m = m' := by sorry
+theorem Real.upperBound_discrete_unique {E: Set Real} {n:ℕ} {m m':ℤ}
+  (hm1: (((m:ℚ) / (n+1):ℚ):Real) ∈ upperBounds E)
+  (hm2: (((m:ℚ) / (n+1) - 1 / (n+1):ℚ):Real) ∉ upperBounds E)
+  (hm'1: (((m':ℚ) / (n+1):ℚ):Real) ∈ upperBounds E)
+  (hm'2: (((m':ℚ) / (n+1) - 1 / (n+1):ℚ):Real) ∉ upperBounds E) :
+    m = m' := by sorry
 
 /-- Exercise 5.5.4 -/
-theorem Real.LIM_of_Cauchy {q:ℕ → ℚ} (hq: ∀ M, ∀ n ≥ M, ∀ n' ≥ M, |q n - q n'| ≤ 1 / (M+1)) : (q:Sequence).isCauchy ∧ ∀ M, |q M - LIM q| ≤ 1 / (M+1) := by sorry
+theorem Real.LIM_of_Cauchy {q:ℕ → ℚ} (hq: ∀ M, ∀ n ≥ M, ∀ n' ≥ M, |q n - q n'| ≤ 1 / (M+1)) :
+    (q:Sequence).isCauchy ∧ ∀ M, |q M - LIM q| ≤ 1 / (M+1) := by sorry
 
 /-- Theorem 5.5.9 (Existence of least upper bound)-/
 theorem Real.LUB_exist {E: Set Real} (hE: Set.Nonempty E) (hbound: BddAbove E): ∃ S, IsLUB E S := by
   -- This proof is written to follow the structure of the original text.
   set x₀ := Set.Nonempty.some hE
   have hx₀ : x₀ ∈ E := Set.Nonempty.some_mem hE
-  have claim1 (n:ℕ) : ∃! m:ℤ, (((m:ℚ) / (n+1):ℚ):Real) ∈ upperBounds E ∧ ¬ (((m:ℚ) / (n+1) - 1 / (n+1):ℚ):Real) ∈ upperBounds E := by
+  have claim1 (n:ℕ) : ∃! m:ℤ,
+      (((m:ℚ) / (n+1):ℚ):Real) ∈ upperBounds E
+      ∧ ¬ (((m:ℚ) / (n+1) - 1 / (n+1):ℚ):Real) ∈ upperBounds E := by
     set ε := ((1/(n+1):ℚ):Real)
     have hpos : ε.isPos := by
       simp [isPos_iff, ε, ←lt_of_coe]
@@ -207,7 +230,8 @@ abbrev ExtendedReal.is_finite (X : ExtendedReal) : Prop := match X with
   | real _ => True
   | infty => False
 
-theorem ExtendedReal.finite_eq_coe {X: ExtendedReal} (hX: X.is_finite) : X = ((X:Real):ExtendedReal) := by
+theorem ExtendedReal.finite_eq_coe {X: ExtendedReal} (hX: X.is_finite) :
+    X = ((X:Real):ExtendedReal) := by
   cases X
   . simp [is_finite] at hX
   . simp [coe_real, real_coe]
@@ -215,7 +239,10 @@ theorem ExtendedReal.finite_eq_coe {X: ExtendedReal} (hX: X.is_finite) : X = ((X
 
 open Classical in
 /-- Definition 5.5.10 (Supremum)-/
-noncomputable abbrev ExtendedReal.sup (E: Set Real) : ExtendedReal := dite E.Nonempty (fun h1 ↦ dite (BddAbove E) (fun h2 ↦ ((Real.LUB_exist h1 h2).choose:Real)) (fun _ ↦ ⊤)) (fun _ ↦ ⊥)
+noncomputable abbrev ExtendedReal.sup (E: Set Real) : ExtendedReal :=
+  dite E.Nonempty
+  (fun h1 ↦ dite (BddAbove E) (fun h2 ↦ ((Real.LUB_exist h1 h2).choose:Real))
+  (fun _ ↦ ⊤)) (fun _ ↦ ⊥)
 
 /-- Definition 5.5.10 (Supremum)-/
 theorem ExtendedReal.sup_of_empty : sup ∅ = ⊥ := by
@@ -229,11 +256,13 @@ theorem ExtendedReal.sup_of_unbounded {E: Set Real} (hb: ¬ BddAbove E) : sup E 
   simp [sup, hE, hb]
 
 /-- Definition 5.5.10 (Supremum)-/
-theorem ExtendedReal.sup_of_bounded {E: Set Real} (hnon: E.Nonempty) (hb: BddAbove E) : IsLUB E (sup E) := by
+theorem ExtendedReal.sup_of_bounded {E: Set Real} (hnon: E.Nonempty) (hb: BddAbove E) :
+    IsLUB E (sup E) := by
   simp [hnon, hb, sup]
   convert (Real.LUB_exist hnon hb).choose_spec
 
-theorem ExtendedReal.sup_of_bounded_finite {E: Set Real} (hnon: E.Nonempty) (hb: BddAbove E) : (sup E).is_finite := by
+theorem ExtendedReal.sup_of_bounded_finite {E: Set Real} (hnon: E.Nonempty) (hb: BddAbove E) :
+    (sup E).is_finite := by
   simp [sup, hnon, hb, is_finite]
 
 /-- Proposition 5.5.12 -/
@@ -318,7 +347,9 @@ theorem Real.GLB_exist {E: Set Real} (hE: Set.Nonempty E) (hbound: BddBelow E): 
   sorry
 
 open Classical in
-noncomputable abbrev ExtendedReal.inf (E: Set Real) : ExtendedReal := dite E.Nonempty (fun h1 ↦ dite (BddBelow E) (fun h2 ↦ ((Real.GLB_exist h1 h2).choose:Real)) (fun _ ↦ ⊥)) (fun _ ↦ ⊤)
+noncomputable abbrev ExtendedReal.inf (E: Set Real) : ExtendedReal :=
+  dite E.Nonempty (fun h1 ↦ dite (BddBelow E) (fun h2 ↦ ((Real.GLB_exist h1 h2).choose:Real))
+  (fun _ ↦ ⊥)) (fun _ ↦ ⊤)
 
 theorem ExtendedReal.inf_of_empty : inf ∅ = ⊤ := by
   simp [inf]
@@ -329,11 +360,13 @@ theorem ExtendedReal.inf_of_unbounded {E: Set Real} (hb: ¬ BddBelow E) : inf E 
     simp [hb]
   simp [inf, hE, hb]
 
-theorem ExtendedReal.inf_of_bounded {E: Set Real} (hnon: E.Nonempty) (hb: BddBelow E) : IsGLB E (inf E) := by
+theorem ExtendedReal.inf_of_bounded {E: Set Real} (hnon: E.Nonempty) (hb: BddBelow E) :
+    IsGLB E (inf E) := by
   simp [hnon, hb, inf]
   convert (Real.GLB_exist hnon hb).choose_spec
 
-theorem ExtendedReal.inf_of_bounded_finite {E: Set Real} (hnon: E.Nonempty) (hb: BddBelow E) : (inf E).is_finite := by
+theorem ExtendedReal.inf_of_bounded_finite {E: Set Real} (hnon: E.Nonempty) (hb: BddBelow E) :
+    (inf E).is_finite := by
   simp [inf, hnon, hb, is_finite]
 
 /-- Helper lemma for Exercise 5.5.1. -/
@@ -343,16 +376,21 @@ theorem Real.mem_neg (E: Set Real) (x:Real) : x ∈ -E ↔ -x ∈ E := Set.mem_n
 theorem Real.inf_neg {E: Set Real} {M:Real} (h: IsLUB E M) : IsGLB (-E) (-M) := by sorry
 
 /-- Exercise 5.5.5 -/
-theorem Real.irrat_between {x y:Real} (hxy: x < y) : ∃ z, x < z ∧ z < y ∧ ¬ ∃ q:ℚ, z = (q:Real) := by sorry
+theorem Real.irrat_between {x y:Real} (hxy: x < y) :
+    ∃ z, x < z ∧ z < y ∧ ¬ ∃ q:ℚ, z = (q:Real) := by sorry
 
 /- Use the notion of supremum in this section to define a Mathlib `sSup` operation -/
 noncomputable instance Real.inst_SupSet : SupSet Real where
   sSup E := ((ExtendedReal.sup E):Real)
 
 /-- Use the `sSup` operation to build a conditionally complete lattice structure on `Real`-/
-noncomputable instance Real.inst_conditionallyCompleteLattice : ConditionallyCompleteLattice Real := conditionallyCompleteLatticeOfsSup Real (fun _ _ ↦ Set.Finite.bddAbove (by norm_num)) (fun _ _ ↦ Set.Finite.bddBelow (by norm_num))
-(by intro E hbound hnon; exact ExtendedReal.sup_of_bounded hnon hbound)
+noncomputable instance Real.inst_conditionallyCompleteLattice :
+    ConditionallyCompleteLattice Real :=
+  conditionallyCompleteLatticeOfsSup Real (fun _ _ ↦ Set.Finite.bddAbove (by norm_num))
+  (fun _ _ ↦ Set.Finite.bddBelow (by norm_num))
+  (by intro E hbound hnon; exact ExtendedReal.sup_of_bounded hnon hbound)
 
-theorem ExtendedReal.sSup_of_bounded {E: Set Real} (hnon: E.Nonempty) (hb: BddAbove E) : IsLUB E (sSup E) := sup_of_bounded hnon hb
+theorem ExtendedReal.sSup_of_bounded {E: Set Real} (hnon: E.Nonempty) (hb: BddAbove E) :
+    IsLUB E (sSup E) := sup_of_bounded hnon hb
 
 end Chapter5

--- a/analysis/Analysis/Section_5_epilogue.lean
+++ b/analysis/Analysis/Section_5_epilogue.lean
@@ -4,11 +4,17 @@ import Analysis.Section_5_5
 /-!
 # Analysis I, Chapter 5 epilogue
 
-In this (technical) epilogue, we show that the "Chapter 5" real numbers `Chapter5.Real` are isomorphic in various standard senses to the standard real numbers `ℝ`.  This we do by matching both structures with Dedekind cuts of the (Mathlib) rational numbers `ℚ`.
+In this (technical) epilogue, we show that the "Chapter 5" real numbers `Chapter5.Real` are
+isomorphic in various standard senses to the standard real numbers `ℝ`.  This we do by matching
+both structures with Dedekind cuts of the (Mathlib) rational numbers `ℚ`.
 
-From this point onwards, `Chapter5.Real` will be deprecated, and we will use the standard real numbers `ℝ` instead.  In particular, one should use the full Mathlib API for `ℝ` for all subsequent chapters, in lieu of the `Chapter5.Real` API.
+From this point onwards, `Chapter5.Real` will be deprecated, and we will use the standard real
+numbers `ℝ` instead.  In particular, one should use the full Mathlib API for `ℝ` for all
+subsequent chapters, in lieu of the `Chapter5.Real` API.
 
-Filling the sorries here requires both the Chapter5.Real API and the Mathlib API for the standard natural numbers `ℝ`.  As such, they are excellent exercises to prepare you for the aforementioned transition.
+Filling the sorries here requires both the Chapter5.Real API and the Mathlib API for the standard
+natural numbers `ℝ`.  As such, they are excellent exercises to prepare you for the aforementioned
+transition.
 
 --/
 
@@ -22,7 +28,8 @@ structure DedekindCut where
   lower: IsLowerSet E
   nomax : ∀ q ∈ E, ∃ r ∈ E, r > q
 
-theorem isLowerSet_iff (E: Set ℚ) : IsLowerSet E ↔ ∀ q r, r < q → q ∈ E → r ∈ E := isLowerSet_iff_forall_lt
+theorem isLowerSet_iff (E: Set ℚ) : IsLowerSet E ↔ ∀ q r, r < q → q ∈ E → r ∈ E :=
+  isLowerSet_iff_forall_lt
 
 abbrev Real.toSet_Rat (x:Real) : Set ℚ := { q | (q:Real) < x }
 
@@ -51,7 +58,8 @@ lemma DedekindCut.toSet_Real_bounded (c: DedekindCut) : BddAbove c.toSet_Real :=
 
 noncomputable abbrev DedekindCut.toReal (c: DedekindCut) : Real := sSup c.toSet_Real
 
-lemma DedekindCut.toReal_isLUB (c: DedekindCut) : IsLUB c.toSet_Real c.toReal := ExtendedReal.sSup_of_bounded c.toSet_Real_nonempty c.toSet_Real_bounded
+lemma DedekindCut.toReal_isLUB (c: DedekindCut) : IsLUB c.toSet_Real c.toReal :=
+  ExtendedReal.sSup_of_bounded c.toSet_Real_nonempty c.toSet_Real_bounded
 
 noncomputable abbrev Real.equivCut : Real ≃ DedekindCut where
   toFun := Real.toCut
@@ -94,7 +102,8 @@ lemma DedekindCut.toSet_R_bounded (c: DedekindCut) : BddAbove c.toSet_R := by so
 
 noncomputable abbrev DedekindCut.toR (c: DedekindCut) : ℝ := sSup c.toSet_R
 
-lemma DedekindCut.toR_isLUB (c: DedekindCut) : IsLUB c.toSet_R c.toR := isLUB_csSup c.toSet_R_nonempty c.toSet_R_bounded
+lemma DedekindCut.toR_isLUB (c: DedekindCut) : IsLUB c.toSet_R c.toR :=
+  isLUB_csSup c.toSet_R_nonempty c.toSet_R_bounded
 
 end Chapter5
 

--- a/analysis/Analysis/Section_6_1.lean
+++ b/analysis/Analysis/Section_6_1.lean
@@ -6,7 +6,11 @@ import Analysis.Section_5_epilogue
 /-!
 # Analysis I, Section 6.1
 
-I have attempted to make the translation as faithful a paraphrasing as possible of the original text.  When there is a choice between a more idiomatic Lean solution and a more faithful translation, I have generally chosen the latter.  In particular, there will be places where the Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided doing so.
+I have attempted to make the translation as faithful a paraphrasing as possible of the original
+text. When there is a choice between a more idiomatic Lean solution and a more faithful
+translation, I have generally chosen the latter. In particular, there will be places where the
+Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided
+doing so.
 
 Main constructions and results of this section:
 
@@ -21,12 +25,18 @@ Main constructions and results of this section:
 
 abbrev Real.close (ε x y : ℝ) : Prop := dist x y ≤ ε
 
-/-- Definition 6.1.2 (ε-close). This is similar to the previous notion of ε-closeness, but where all quantities are real instead of rational. -/
+/--
+  Definition 6.1.2 (ε-close). This is similar to the previous notion of ε-closeness, but where
+  all quantities are real instead of rational.
+-/
 theorem Real.close_def (ε x y : ℝ) : ε.close x y ↔ dist x y ≤ ε := by rfl
 
 namespace Chapter6
 
-/-- Definition 6.1.3 (Sequence). This is similar to the Chapter 5 sequence, except that now the sequence is real-valued. As with Chapter 5, we start sequences from 0 by default. -/
+/--
+  Definition 6.1.3 (Sequence). This is similar to the Chapter 5 sequence, except that now the
+  sequence is real-valued. As with Chapter 5, we start sequences from 0 by default.
+-/
 @[ext]
 structure Sequence where
   m : ℤ
@@ -55,12 +65,16 @@ abbrev Sequence.mk' (m:ℤ) (a: { n // n ≥ m } → ℝ) : Sequence where
     simp [hn]
 
 
-lemma Sequence.eval_mk {n m:ℤ} (a: { n // n ≥ m } → ℝ) (h: n ≥ m) : (Sequence.mk' m a) n = a ⟨ n, h ⟩ := by simp [seq, h]
+lemma Sequence.eval_mk {n m:ℤ} (a: { n // n ≥ m } → ℝ) (h: n ≥ m) :
+    (Sequence.mk' m a) n = a ⟨ n, h ⟩ := by simp [seq, h]
 
 @[simp]
 lemma Sequence.eval_coe (n:ℕ) (a: ℕ → ℝ) : (a:Sequence) n = a n := by simp [seq]
 
-/-- a.from n₁ starts `a:Sequence` from `n₁`.  It is intended for use when `n₁ ≥ n₀`, but returns the "junk" value of the original sequence `a` otherwise. -/
+/--
+  a.from n₁ starts `a:Sequence` from `n₁`.  It is intended for use when `n₁ ≥ n₀`, but returns
+  the "junk" value of the original sequence `a` otherwise.
+-/
 abbrev Sequence.from (a:Sequence) (m₁:ℤ) : Sequence :=
   mk' (max a.m m₁) (fun n ↦ a (n:ℤ))
 
@@ -81,17 +95,19 @@ lemma Real.steady_def (ε: ℝ) (a: Chapter6.Sequence) :
   ε.steady a ↔ ∀ n ≥ a.m, ∀ m ≥ a.m, ε.close (a n) (a m) := by rfl
 
 /-- Definition 6.1.3 (Eventually ε-steady) -/
-abbrev Real.eventuallySteady (ε: ℝ) (a: Chapter6.Sequence) : Prop := ∃ N ≥ a.m, ε.steady (a.from N)
+abbrev Real.eventuallySteady (ε: ℝ) (a: Chapter6.Sequence) : Prop :=
+  ∃ N ≥ a.m, ε.steady (a.from N)
 
 /-- Definition 6.1.3 (Eventually ε-steady) -/
 lemma Real.eventuallySteady_def (ε: ℝ) (a: Chapter6.Sequence) :
   ε.eventuallySteady a ↔ ∃ N, (N ≥ a.m) ∧ ε.steady (a.from N) := by rfl
 
 theorem Real.steady_mono {a: Chapter6.Sequence} {ε₁ ε₂: ℝ} (hε: ε₁ ≤ ε₂) (hsteady: ε₁.steady a) :
-  ε₂.steady a := by sorry
+    ε₂.steady a := by sorry
 
-theorem Real.eventuallySteady_mono {a: Chapter6.Sequence} {ε₁ ε₂: ℝ} (hε: ε₁ ≤ ε₂) (hsteady: ε₁.eventuallySteady a) :
-  ε₂.eventuallySteady a := by sorry
+theorem Real.eventuallySteady_mono {a: Chapter6.Sequence} {ε₁ ε₂: ℝ} (hε: ε₁ ≤ ε₂)
+  (hsteady: ε₁.eventuallySteady a) :
+    ε₂.eventuallySteady a := by sorry
 
 namespace Chapter6
 
@@ -102,9 +118,12 @@ abbrev Sequence.isCauchy (a:Sequence) : Prop := ∀ ε > (0:ℝ), ε.eventuallyS
 lemma Sequence.isCauchy_def (a:Sequence) :
   a.isCauchy ↔ ∀ ε > (0:ℝ), ε.eventuallySteady a := by rfl
 
-lemma Sequence.isCauchy_of_coe (a:ℕ → ℝ) : (a:Sequence).isCauchy ↔ ∀ ε > 0, ∃ N, ∀ j ≥ N, ∀ k ≥ N, dist (a j) (a k) ≤ ε := by sorry
+lemma Sequence.isCauchy_of_coe (a:ℕ → ℝ) :
+    (a:Sequence).isCauchy ↔ ∀ ε > 0, ∃ N, ∀ j ≥ N, ∀ k ≥ N, dist (a j) (a k) ≤ ε := by sorry
 
-lemma Sequence.isCauchy_of_mk {n₀:ℤ} (a: {n // n ≥ n₀} → ℝ) : (mk' n₀ a).isCauchy ↔ ∀ ε > 0, ∃ N ≥ n₀, ∀ j ≥ N, ∀ k ≥ N, dist (mk' n₀ a j) (mk' n₀ a k) ≤ ε := by sorry
+lemma Sequence.isCauchy_of_mk {n₀:ℤ} (a: {n // n ≥ n₀} → ℝ) :
+    (mk' n₀ a).isCauchy
+    ↔ ∀ ε > 0, ∃ N ≥ n₀, ∀ j ≥ N, ∀ k ≥ N, dist (mk' n₀ a j) (mk' n₀ a k) ≤ ε := by sorry
 
 instance Chapter5.Sequence.inst_coe_sequence : Coe Chapter5.Sequence Sequence  where
   coe := fun a ↦ {
@@ -119,9 +138,11 @@ instance Chapter5.Sequence.inst_coe_sequence : Coe Chapter5.Sequence Sequence  w
 @[simp]
 theorem Chapter5.coe_sequence_eval (a: Chapter5.Sequence) (n:ℤ) : (a:Sequence) n = (a n:ℝ) := rfl
 
-theorem Sequence.is_steady_of_rat (ε:ℚ) (a: Chapter5.Sequence) : ε.steady a ↔ (ε:ℝ).steady (a:Sequence) := by sorry
+theorem Sequence.is_steady_of_rat (ε:ℚ) (a: Chapter5.Sequence) :
+    ε.steady a ↔ (ε:ℝ).steady (a:Sequence) := by sorry
 
-theorem Sequence.is_eventuallySteady_of_rat (ε:ℚ) (a: Chapter5.Sequence) : ε.eventuallySteady a ↔ (ε:ℝ).eventuallySteady (a:Sequence) := by sorry
+theorem Sequence.is_eventuallySteady_of_rat (ε:ℚ) (a: Chapter5.Sequence) :
+    ε.eventuallySteady a ↔ (ε:ℝ).eventuallySteady (a:Sequence) := by sorry
 
 /-- Proposition 6.1.4 -/
 theorem Sequence.isCauchy_of_rat (a: Chapter5.Sequence) : a.isCauchy ↔ (a:Sequence).isCauchy := by
@@ -154,17 +175,20 @@ theorem Real.close_seq_def (ε: ℝ) (a: Chapter6.Sequence) (L:ℝ) :
   ε.close_seq a L ↔ ∀ n ≥ a.m, dist (a n) L ≤ ε := by rfl
 
 /-- Definition 6.1.5 -/
-abbrev Real.eventually_close (ε: ℝ) (a: Chapter6.Sequence) (L:ℝ) : Prop := ∃ N ≥ a.m, ε.close_seq (a.from N) L
+abbrev Real.eventually_close (ε: ℝ) (a: Chapter6.Sequence) (L:ℝ) : Prop :=
+  ∃ N ≥ a.m, ε.close_seq (a.from N) L
 
 /-- Definition 6.1.5 -/
 theorem Real.eventually_close_def (ε: ℝ) (a: Chapter6.Sequence) (L:ℝ) :
   ε.eventually_close a L ↔ ∃ N, (N ≥ a.m) ∧ ε.close_seq (a.from N) L := by rfl
 
-theorem Real.close_seq_mono {a: Chapter6.Sequence} {ε₁ ε₂: ℝ} (hε: ε₁ ≤ ε₂) (hclose: ε₁.close_seq a L) :
-  ε₂.close_seq a L := by sorry
+theorem Real.close_seq_mono {a: Chapter6.Sequence} {ε₁ ε₂: ℝ} (hε: ε₁ ≤ ε₂)
+  (hclose: ε₁.close_seq a L) :
+    ε₂.close_seq a L := by sorry
 
-theorem Real.eventually_close_mono {a: Chapter6.Sequence} {ε₁ ε₂: ℝ} (hε: ε₁ ≤ ε₂) (hclose: ε₁.eventually_close a L) :
-  ε₂.eventually_close a L := by sorry
+theorem Real.eventually_close_mono {a: Chapter6.Sequence} {ε₁ ε₂: ℝ} (hε: ε₁ ≤ ε₂)
+  (hclose: ε₁.eventually_close a L) :
+    ε₂.eventually_close a L := by sorry
 
 namespace Chapter6
 
@@ -193,7 +217,8 @@ example : (0.01:ℝ).eventually_close seq_6_1_6 1 := by sorry
 example : seq_6_1_6.tendsTo 1 := by sorry
 
 /-- Proposition 6.1.7 (Uniqueness of limits) -/
-theorem Sequence.tendsTo_unique (a:Sequence) {L L':ℝ} (h:L ≠ L') : ¬ (a.tendsTo L ∧ a.tendsTo L') := by
+theorem Sequence.tendsTo_unique (a:Sequence) {L L':ℝ} (h:L ≠ L') :
+    ¬ (a.tendsTo L ∧ a.tendsTo L') := by
   -- This proof is written to follow the structure of the original text.
   by_contra this
   obtain ⟨ hL, hL' ⟩ := this
@@ -233,10 +258,12 @@ abbrev Sequence.divergent (a:Sequence) : Prop := ¬ a.convergent
 theorem Sequence.divergent_def (a:Sequence) : a.divergent ↔ ¬ a.convergent := by rfl
 
 open Classical in
-/-- Definition 6.1.8.  We give the limit of a sequence the junk value of 0 if it is not convergent. -/
+/--
+  Definition 6.1.8.  We give the limit of a sequence the junk value of 0 if it is not convergent.
+-/
 noncomputable abbrev lim (a:Sequence) : ℝ := if h: a.convergent then h.choose else 0
 
-/-- Definition 6.1.8-/
+/-- Definition 6.1.8 -/
 theorem Sequence.lim_def {a:Sequence} (h: a.convergent) : a.tendsTo (lim a) := by
   unfold lim
   simp [h]
@@ -258,7 +285,8 @@ a.tendsTo L ↔ a.convergent ∧ lim a = L := by
 
 
 /-- Proposition 6.1.11 -/
-theorem Sequence.lim_harmonic : ((fun (n:ℕ) ↦ (n+1:ℝ)⁻¹):Sequence).convergent ∧ lim ((fun (n:ℕ) ↦ (n+1:ℝ)⁻¹):Sequence) = 0 := by
+theorem Sequence.lim_harmonic :
+    ((fun (n:ℕ) ↦ (n+1:ℝ)⁻¹):Sequence).convergent ∧ lim ((fun (n:ℕ) ↦ (n+1:ℝ)⁻¹):Sequence) = 0 := by
   -- This proof is written to follow the structure of the original text.
   rw [←lim_eq, tendsTo_iff]
   intro ε hε
@@ -299,7 +327,8 @@ example : ¬ ((fun n ↦ (-1:ℝ)^n):Sequence).isCauchy := by sorry
 example : ¬ ((fun n ↦ (-1:ℝ)^n):Sequence).convergent := by sorry
 
 /-- Proposition 6.1.15 / Exercise 6.1.6 (Formal limits are genuine limits)-/
-theorem Sequence.lim_eq_LIM {a:ℕ → ℚ} (h: (a:Chapter5.Sequence).isCauchy) : ((a:Chapter5.Sequence):Sequence).tendsTo (Chapter5.Real.equivR (Chapter5.LIM a)) := by sorry
+theorem Sequence.lim_eq_LIM {a:ℕ → ℚ} (h: (a:Chapter5.Sequence).isCauchy) :
+    ((a:Chapter5.Sequence):Sequence).tendsTo (Chapter5.Real.equivR (Chapter5.LIM a)) := by sorry
 
 /-- Definition 6.1.16 -/
 abbrev Sequence.BoundedBy (a:Sequence) (M:ℝ) : Prop :=
@@ -340,8 +369,8 @@ instance Sequence.inst_add : Add Sequence where
   }
 
 /-- Theorem 6.1.19(a) (limit laws) -/
-theorem Sequence.lim_add {a b:Sequence} (ha: a.convergent) (hb: b.convergent)   :
-  (a + b).convergent ∧ lim (a + b) = lim a + lim b := by
+theorem Sequence.lim_add {a b:Sequence} (ha: a.convergent) (hb: b.convergent) :
+    (a + b).convergent ∧ lim (a + b) = lim a + lim b := by
   sorry
 
 instance Sequence.inst_mul : Mul Sequence where
@@ -355,8 +384,8 @@ instance Sequence.inst_mul : Mul Sequence where
   }
 
 /-- Theorem 6.1.19(b) (limit laws) -/
-theorem Sequence.lim_mul {a b:Sequence} (ha: a.convergent) (hb: b.convergent)   :
-  (a * b).convergent ∧ lim (a * b) = lim a * lim b := by
+theorem Sequence.lim_mul {a b:Sequence} (ha: a.convergent) (hb: b.convergent) :
+    (a * b).convergent ∧ lim (a * b) = lim a * lim b := by
   sorry
 
 
@@ -371,7 +400,7 @@ instance Sequence.inst_smul : SMul ℝ Sequence where
 
 /-- Theorem 6.1.19(c) (limit laws) -/
 theorem Sequence.lim_smul (c:ℝ) {a:Sequence} (ha: a.convergent) :
-  (c • a).convergent ∧ lim (c • a) = c * lim a := by
+    (c • a).convergent ∧ lim (c • a) = c * lim a := by
   sorry
 
 instance Sequence.inst_sub : Sub Sequence where
@@ -385,8 +414,8 @@ instance Sequence.inst_sub : Sub Sequence where
   }
 
 /-- Theorem 6.1.19(d) (limit laws) -/
-theorem Sequence.lim_sub {a b:Sequence} (ha: a.convergent) (hb: b.convergent)   :
-  (a - b).convergent ∧ lim (a - b) = lim a - lim b := by
+theorem Sequence.lim_sub {a b:Sequence} (ha: a.convergent) (hb: b.convergent) :
+    (a - b).convergent ∧ lim (a - b) = lim a - lim b := by
   sorry
 
 noncomputable instance Sequence.inst_inv : Inv Sequence where
@@ -399,7 +428,7 @@ noncomputable instance Sequence.inst_inv : Inv Sequence where
   }
 
 /-- Theorem 6.1.19(e) (limit laws) -/
-theorem Sequence.lim_inv {a:Sequence} (ha: a.convergent) (hnon: lim a ≠ 0)   :
+theorem Sequence.lim_inv {a:Sequence} (ha: a.convergent) (hnon: lim a ≠ 0) :
   (a⁻¹).convergent ∧ lim (a⁻¹) = (lim a)⁻¹ := by
   sorry
 
@@ -414,7 +443,7 @@ noncomputable instance Sequence.inst_div : Div Sequence where
   }
 
 /-- Theorem 6.1.19(f) (limit laws) -/
-theorem Sequence.lim_div {a b:Sequence} (ha: a.convergent) (hb: b.convergent) (hnon: lim b ≠ 0)   :
+theorem Sequence.lim_div {a b:Sequence} (ha: a.convergent) (hb: b.convergent) (hnon: lim b ≠ 0) :
   (a / b).convergent ∧ lim (a / b) = lim a / lim b := by
   sorry
 
@@ -429,8 +458,8 @@ instance Sequence.inst_max : Max Sequence where
   }
 
 /-- Theorem 6.1.19(g) (limit laws) -/
-theorem Sequence.lim_max {a b:Sequence} (ha: a.convergent) (hb: b.convergent) (hnon: lim b ≠ 0)   :
-  (max a b).convergent ∧ lim (max a b) = max (lim a) (lim b) := by
+theorem Sequence.lim_max {a b:Sequence} (ha: a.convergent) (hb: b.convergent) (hnon: lim b ≠ 0) :
+    (max a b).convergent ∧ lim (max a b) = max (lim a) (lim b) := by
   sorry
 
 instance Sequence.inst_min : Min Sequence where
@@ -444,28 +473,41 @@ instance Sequence.inst_min : Min Sequence where
   }
 
 /-- Theorem 6.1.19(h) (limit laws) -/
-theorem Sequence.lim_min {a b:Sequence} (ha: a.convergent) (hb: b.convergent) (hnon: lim b ≠ 0)   :
-  (min a b).convergent ∧ lim (min a b) = min (lim a) (lim b) := by
+theorem Sequence.lim_min {a b:Sequence} (ha: a.convergent) (hb: b.convergent) (hnon: lim b ≠ 0) :
+    (min a b).convergent ∧ lim (min a b) = min (lim a) (lim b) := by
   sorry
 
 /-- Exercise 6.1.1 -/
-theorem Sequence.mono_if {a: ℕ → ℝ} (ha: ∀ n, a (n+1) > a n) {n m:ℕ} (hnm: m > n) : a m > a n := by sorry
+theorem Sequence.mono_if {a: ℕ → ℝ} (ha: ∀ n, a (n+1) > a n) {n m:ℕ} (hnm: m > n) : a m > a n := by
+  sorry
 
 /-- Exercise 6.1.3 -/
-theorem Sequence.tendsTo_of_from {a: Sequence} {c:ℝ} (m:ℤ) : a.tendsTo c ↔ (a.from m).tendsTo c := by sorry
+theorem Sequence.tendsTo_of_from {a: Sequence} {c:ℝ} (m:ℤ) :
+    a.tendsTo c ↔ (a.from m).tendsTo c := by
+  sorry
 
 /-- Exercise 6.1.4 -/
-theorem Sequence.tendsTo_of_shift {a: Sequence} {c:ℝ} (k:ℕ) : a.tendsTo c ↔ (Sequence.mk' a.m (fun n : {n // n ≥ a.m} ↦ a (n+k))).tendsTo c := by sorry
+theorem Sequence.tendsTo_of_shift {a: Sequence} {c:ℝ} (k:ℕ) :
+    a.tendsTo c ↔ (Sequence.mk' a.m (fun n : {n // n ≥ a.m} ↦ a (n+k))).tendsTo c := by
+  sorry
 
 /-- Exercise 6.1.7 -/
-theorem Sequence.isBounded_of_rat (a: Chapter5.Sequence) : a.isBounded ↔ (a:Sequence).isBounded := by sorry
+theorem Sequence.isBounded_of_rat (a: Chapter5.Sequence) :
+    a.isBounded ↔ (a:Sequence).isBounded := by
+  sorry
 
 /-- Exercise 6.1.9 -/
-theorem Sequence.lim_div_fail : ∃ a b, a.convergent ∧ b.convergent ∧ lim b = 0 ∧ ¬ ((a / b).convergent ∧ lim (a / b) = lim a / lim b) := by
+theorem Sequence.lim_div_fail :
+    ∃ a b, a.convergent
+    ∧ b.convergent
+    ∧ lim b = 0
+    ∧ ¬ ((a / b).convergent ∧ lim (a / b) = lim a / lim b) := by
   sorry
 
 /-- Exercise 6.1.10 -/
-theorem Chapter5.Sequence.isCauchy_iff (a:Chapter5.Sequence) : a.isCauchy ↔ ∀ ε > (0:ℝ), ∃ N ≥ a.n₀, ∀ n ≥ N, ∀ m ≥ N, |a n - a m| ≤ ε := by sorry
+theorem Chapter5.Sequence.isCauchy_iff (a:Chapter5.Sequence) :
+    a.isCauchy ↔ ∀ ε > (0:ℝ), ∃ N ≥ a.n₀, ∀ n ≥ N, ∀ m ≥ N, |a n - a m| ≤ ε := by
+  sorry
 
 
 

--- a/analysis/Analysis/Section_6_2.lean
+++ b/analysis/Analysis/Section_6_2.lean
@@ -5,11 +5,16 @@ import Analysis.Section_5_epilogue
 /-!
 # Analysis I, Section 6.2
 
-I have attempted to make the translation as faithful a paraphrasing as possible of the original text.  When there is a choice between a more idiomatic Lean solution and a more faithful translation, I have generally chosen the latter.  In particular, there will be places where the Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided doing so.
+I have attempted to make the translation as faithful a paraphrasing as possible of the original
+text. When there is a choice between a more idiomatic Lean solution and a more faithful
+translation, I have generally chosen the latter. In particular, there will be places where the
+Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided
+doing so.
 
 Main constructions and results of this section:
 
-- Some API for Mathlib's extended reals `EReal`, particularly with regard to the supremum operation `sSup` and infimum operation `sInf`.
+- Some API for Mathlib's extended reals `EReal`, particularly with regard to the supremum
+  operation `sSup` and infimum operation `sInf`.
 
 -/
 
@@ -43,7 +48,8 @@ theorem EReal.neg_of_real (x:Real) : -(x:EReal) = (-x:ℝ) := rfl
 #check EReal.neg_bot
 
 /-- Definition 6.2.3 (Ordering of extended reals) -/
-theorem EReal.le_iff (x y:EReal) : x ≤ y ↔ (∃ (x' y':Real), x = x' ∧ y = y' ∧ x' ≤ y') ∨ y = ⊤ ∨ x = ⊥ := by
+theorem EReal.le_iff (x y:EReal) :
+    x ≤ y ↔ (∃ (x' y':Real), x = x' ∧ y = y' ∧ x' ≤ y') ∨ y = ⊤ ∨ x = ⊥ := by
   rcases EReal.def x with hx | rfl | rfl
   all_goals rcases EReal.def y with hy | rfl | rfl
   all_goals simp
@@ -92,8 +98,10 @@ theorem EReal.trans {x y z:EReal} (hxy : x ≤ y) (hyz: y ≤ z) : x ≤ z := by
 theorem EReal.neg_of_lt {x y:EReal} (hxy : x ≤ y): -y ≤ -x := by sorry
 
 /-- Definition 6.2.6 -/
-theorem EReal.sup_of_bounded_nonempty {E: Set ℝ} (hbound: BddAbove E) (hnon: E.Nonempty) : sSup ((fun (x:ℝ) ↦ (x:EReal)) '' E) = sSup E := calc
-  _ = sSup ((fun (x:WithTop ℝ) ↦ (x:WithBot (WithTop ℝ))) '' ((fun (x:ℝ) ↦ (x:WithTop ℝ)) '' E)) := by
+theorem EReal.sup_of_bounded_nonempty {E: Set ℝ} (hbound: BddAbove E) (hnon: E.Nonempty) :
+    sSup ((fun (x:ℝ) ↦ (x:EReal)) '' E) = sSup E := calc
+  _ = sSup
+      ((fun (x:WithTop ℝ) ↦ (x:WithBot (WithTop ℝ))) '' ((fun (x:ℝ) ↦ (x:WithTop ℝ)) '' E)) := by
     rw [←Set.image_comp]
     congr
   _ = sSup ((fun (x:ℝ) ↦ (x:WithTop ℝ)) '' E) := by
@@ -107,7 +115,8 @@ theorem EReal.sup_of_bounded_nonempty {E: Set ℝ} (hbound: BddAbove E) (hnon: E
   _ = _ := by rfl
 
 /-- Definition 6.2.6 -/
-theorem EReal.sup_of_unbounded_nonempty {E: Set ℝ} (hunbound: ¬ BddAbove E) (hnon: E.Nonempty) : sSup ((fun (x:ℝ) ↦ (x:EReal)) '' E) = ⊤ := by
+theorem EReal.sup_of_unbounded_nonempty {E: Set ℝ} (hunbound: ¬ BddAbove E) (hnon: E.Nonempty) :
+    sSup ((fun (x:ℝ) ↦ (x:EReal)) '' E) = ⊤ := by
   rw [sSup_eq_top]
   intro b hb
   rcases EReal.def b with hb' | rfl | rfl
@@ -126,7 +135,8 @@ theorem EReal.sup_of_empty : sSup (∅:Set EReal) = ⊥ := sSup_empty
 theorem EReal.sup_of_infty_mem {E: Set EReal} (hE: ⊤ ∈ E) : sSup E = ⊤ := csSup_eq_top_of_top_mem hE
 
 /-- Definition 6.2.6 -/
-theorem EReal.sup_of_neg_infty_mem {E: Set EReal} : sSup E = sSup (E \ {⊥}) := (sSup_diff_singleton_bot _).symm
+theorem EReal.sup_of_neg_infty_mem {E: Set EReal} : sSup E = sSup (E \ {⊥}) :=
+  (sSup_diff_singleton_bot _).symm
 
 theorem EReal.inf_eq_neg_sup (E: Set EReal) : sInf E = - sSup (-E) := by
   simp_rw [←isGLB_iff_sInf_eq, isGLB_iff_le_iff, EReal.le_neg]

--- a/analysis/Analysis/Section_6_3.lean
+++ b/analysis/Analysis/Section_6_3.lean
@@ -6,7 +6,11 @@ import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
 /-!
 # Analysis I, Section 6.3
 
-I have attempted to make the translation as faithful a paraphrasing as possible of the original text.  When there is a choice between a more idiomatic Lean solution and a more faithful translation, I have generally chosen the latter.  In particular, there will be places where the Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided doing so.
+I have attempted to make the translation as faithful a paraphrasing as possible of the original
+text. When there is a choice between a more idiomatic Lean solution and a more faithful
+translation, I have generally chosen the latter. In particular, there will be places where the
+Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided
+doing so.
 
 Main constructions and results of this section:
 
@@ -61,7 +65,8 @@ theorem Sequence.le_sup {a:Sequence} {n:ℤ} (hn: n ≥ a.m) : a n ≤ a.sup := 
 theorem Sequence.sup_le_upper {a:Sequence} {M:EReal} (h: ∀ n ≥ a.m, a n ≤ M) : a.sup ≤ M := by sorry
 
 /-- Proposition 6.3.6 (Least upper bound property) / Exercise 6.3.2 -/
-theorem Sequence.exists_between_lt_sup {a:Sequence} {y:EReal} (h: y < a.sup ) : ∃ n ≥ a.m, y < a n ∧ a n ≤ a.sup := by sorry
+theorem Sequence.exists_between_lt_sup {a:Sequence} {y:EReal} (h: y < a.sup ) :
+    ∃ n ≥ a.m, y < a n ∧ a n ≤ a.sup := by sorry
 
 /-- Remark 6.3.7 -/
 theorem Sequence.ge_inf {a:Sequence} {n:ℤ} (hn: n ≥ a.m) : a n ≥ a.inf := by sorry
@@ -70,25 +75,32 @@ theorem Sequence.ge_inf {a:Sequence} {n:ℤ} (hn: n ≥ a.m) : a n ≥ a.inf := 
 theorem Sequence.inf_ge_lower {a:Sequence} {M:EReal} (h: ∀ n ≥ a.m, a n ≥ M) : a.inf ≥ M := by sorry
 
 /-- Remark 6.3.7 -/
-theorem Sequence.exists_between_gt_inf {a:Sequence} {y:EReal} (h: y > a.inf ) : ∃ n ≥ a.m, y > a n ∧ a n ≥ a.inf := by sorry
+theorem Sequence.exists_between_gt_inf {a:Sequence} {y:EReal} (h: y > a.inf ) :
+    ∃ n ≥ a.m, y > a n ∧ a n ≥ a.inf := by sorry
 
 abbrev Sequence.isMonotone (a:Sequence) : Prop := ∀ n ≥ a.m, a (n+1) ≥ a n
 
 abbrev Sequence.isAntitone (a:Sequence) : Prop := ∀ n ≥ a.m, a (n+1) ≤ a n
 
 /-- Proposition 6.3.8 / Exercise 6.3.3 -/
-theorem Sequence.convergent_of_monotone {a:Sequence} (hbound: a.bddAbove) (hmono: a.isMonotone) : a.convergent := by sorry
+theorem Sequence.convergent_of_monotone {a:Sequence} (hbound: a.bddAbove) (hmono: a.isMonotone) :
+    a.convergent := by sorry
 
 /-- Proposition 6.3.8 / Exercise 6.3.3 -/
-theorem Sequence.lim_of_monotone {a:Sequence} (hbound: a.bddAbove) (hmono: a.isMonotone) : lim a = a.sup := by sorry
+theorem Sequence.lim_of_monotone {a:Sequence} (hbound: a.bddAbove) (hmono: a.isMonotone) :
+    lim a = a.sup := by sorry
 
-theorem Sequence.convergent_of_antitone {a:Sequence} (hbound: a.bddBelow) (hmono: a.isAntitone) : a.convergent := by sorry
+theorem Sequence.convergent_of_antitone {a:Sequence} (hbound: a.bddBelow) (hmono: a.isAntitone) :
+    a.convergent := by sorry
 
-theorem Sequence.lim_of_antitone {a:Sequence} (hbound: a.bddBelow) (hmono: a.isAntitone) : lim a = a.inf := by sorry
+theorem Sequence.lim_of_antitone {a:Sequence} (hbound: a.bddBelow) (hmono: a.isAntitone) :
+    lim a = a.inf := by sorry
 
-theorem Sequence.convergent_iff_bounded_of_monotone {a:Sequence} (ha: a.isMonotone) : a.convergent ↔ a.isBounded := by sorry
+theorem Sequence.convergent_iff_bounded_of_monotone {a:Sequence} (ha: a.isMonotone) :
+    a.convergent ↔ a.isBounded := by sorry
 
-theorem Sequence.bounded_iff_convergent_of_antitone {a:Sequence} (ha: a.isAntitone) : a.convergent ↔ a.isBounded := by sorry
+theorem Sequence.bounded_iff_convergent_of_antitone {a:Sequence} (ha: a.isAntitone) :
+    a.convergent ↔ a.isBounded := by sorry
 
 /-- Example 6.3.9 -/
 noncomputable abbrev Example_6_3_9 (n:ℕ) := ⌊ Real.pi * 10^n ⌋ / (10:ℝ)^n
@@ -106,7 +118,8 @@ example : (Example_6_3_9:Sequence).convergent := by sorry
 example : lim (Example_6_3_9:Sequence) ≤ 4 := by sorry
 
 /-- Proposition 6.3.1-/
-theorem lim_of_exp {x:ℝ} (hpos: 0 < x) (hbound: x < 1) : ((fun (n:ℕ) ↦ x^n):Sequence).convergent ∧ lim ((fun (n:ℕ) ↦ x^n):Sequence) = 0 := by
+theorem lim_of_exp {x:ℝ} (hpos: 0 < x) (hbound: x < 1) :
+    ((fun (n:ℕ) ↦ x^n):Sequence).convergent ∧ lim ((fun (n:ℕ) ↦ x^n):Sequence) = 0 := by
   -- This proof is written to follow the structure of the original text.
   set a := ((fun (n:ℕ) ↦ x^n):Sequence)
   have why : a.isAntitone := sorry

--- a/analysis/Analysis/Section_6_4.lean
+++ b/analysis/Analysis/Section_6_4.lean
@@ -4,7 +4,11 @@ import Analysis.Section_6_3
 /-!
 # Analysis I, Section 6.4
 
-I have attempted to make the translation as faithful a paraphrasing as possible of the original text.  When there is a choice between a more idiomatic Lean solution and a more faithful translation, I have generally chosen the latter.  In particular, there will be places where the Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided doing so.
+I have attempted to make the translation as faithful a paraphrasing as possible of the original
+text. When there is a choice between a more idiomatic Lean solution and a more faithful
+translation, I have generally chosen the latter. In particular, there will be places where the
+Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided
+doing so.
 
 Main constructions and results of this section:
 
@@ -17,11 +21,13 @@ Main constructions and results of this section:
 
 abbrev Real.adherent (ε:ℝ) (a:Chapter6.Sequence) (x:ℝ) := ∃ n ≥ a.m, ε.close (a n) x
 
-abbrev Real.continually_adherent (ε:ℝ) (a:Chapter6.Sequence) (x:ℝ) := ∀ N ≥ a.m, ε.adherent (a.from N) x
+abbrev Real.continually_adherent (ε:ℝ) (a:Chapter6.Sequence) (x:ℝ) :=
+  ∀ N ≥ a.m, ε.adherent (a.from N) x
 
 namespace Chapter6
 
-abbrev Sequence.limit_point (a:Sequence) (x:ℝ) : Prop := ∀ ε > (0:ℝ), ε.continually_adherent a x
+abbrev Sequence.limit_point (a:Sequence) (x:ℝ) : Prop :=
+  ∀ ε > (0:ℝ), ε.continually_adherent a x
 
 theorem Sequence.limit_point_def (a:Sequence) (x:ℝ) :
   a.limit_point x ↔ ∀ ε > 0, ∀ N ≥ a.m, ∃ n ≥ N, |a n - x| ≤ ε := by
@@ -42,7 +48,8 @@ example : (0.1:ℝ).continually_adherent Example_6_4_3 1 := by sorry
 /-- Example 6.4.3 -/
 example : Example_6_4_3.limit_point 1 := by sorry
 
-noncomputable abbrev Example_6_4_4 : Sequence := (fun (n:ℕ) ↦ (-1:ℝ)^n * (1 + (10:ℝ)^(-(n:ℤ)-1)))
+noncomputable abbrev Example_6_4_4 : Sequence :=
+  (fun (n:ℕ) ↦ (-1:ℝ)^n * (1 + (10:ℝ)^(-(n:ℤ)-1)))
 
 /-- Example 6.4.4 -/
 example : (0.1:ℝ).adherent Example_6_4_4 1 := by sorry
@@ -63,22 +70,33 @@ example : ¬ Example_6_4_4.limit_point 0 := by sorry
 theorem Sequence.limit_point_of_limit {a:Sequence} {x:ℝ} (h: a.tendsTo x) : a.limit_point x := by
   sorry
 
-/-- A technical issue uncovered by the formalization: the upper and lower sequences of a real sequence take values in the extended reals rather than the reals, so the definitions need to be adjusted accordingly. -/
+/--
+  A technical issue uncovered by the formalization: the upper and lower sequences of a real
+  sequence take values in the extended reals rather than the reals, so the definitions need to be
+  adjusted accordingly.
+-/
 noncomputable abbrev Sequence.upperseq (a:Sequence) : ℤ → EReal := fun N ↦ (a.from N).sup
 
-noncomputable abbrev Sequence.limsup (a:Sequence) : EReal := sInf { x | ∃ N ≥ a.m, x = a.upperseq N }
+noncomputable abbrev Sequence.limsup (a:Sequence) : EReal :=
+  sInf { x | ∃ N ≥ a.m, x = a.upperseq N }
 
 noncomputable abbrev Sequence.lowerseq (a:Sequence) : ℤ → EReal := fun N ↦ (a.from N).inf
 
-noncomputable abbrev Sequence.liminf (a:Sequence) : EReal := sSup { x | ∃ N ≥ a.m, x = a.lowerseq N }
+noncomputable abbrev Sequence.liminf (a:Sequence) : EReal :=
+  sSup { x | ∃ N ≥ a.m, x = a.lowerseq N }
 
 noncomputable abbrev Example_6_4_7 : Sequence := (fun (n:ℕ) ↦ (-1:ℝ)^n * (1 + (10:ℝ)^(-(n:ℤ)-1)))
 
-example (n:ℕ) : Example_6_4_7.upperseq n = if Even n then 1 + (10:ℝ)^(-(n:ℤ)-1) else 1 + (10:ℝ)^(-(n:ℤ)-2) := by sorry
+example (n:ℕ) :
+    Example_6_4_7.upperseq n = if Even n then 1 + (10:ℝ)^(-(n:ℤ)-1) else 1 + (10:ℝ)^(-(n:ℤ)-2) := by
+  sorry
 
 example : Example_6_4_7.limsup = 1 := by sorry
 
-example (n:ℕ) : Example_6_4_7.lowerseq n = if Even n then -(1 + (10:ℝ)^(-(n:ℤ)-2)) else -(1 + (10:ℝ)^(-(n:ℤ)-1)) := by sorry
+example (n:ℕ) :
+    Example_6_4_7.lowerseq n
+    = if Even n then -(1 + (10:ℝ)^(-(n:ℤ)-2)) else -(1 + (10:ℝ)^(-(n:ℤ)-1)) := by
+  sorry
 
 example : Example_6_4_7.liminf = -1 := by sorry
 
@@ -96,7 +114,8 @@ example (n:ℕ) : Example_6_4_8.lowerseq n = ⊥ := by sorry
 
 example : Example_6_4_8.liminf = ⊥ := by sorry
 
-noncomputable abbrev Example_6_4_9 : Sequence := (fun (n:ℕ) ↦ if Even n then (n+1:ℝ)⁻¹ else -(n+1:ℝ)⁻¹)
+noncomputable abbrev Example_6_4_9 : Sequence :=
+  (fun (n:ℕ) ↦ if Even n then (n+1:ℝ)⁻¹ else -(n+1:ℝ)⁻¹)
 
 example (n:ℕ) : Example_6_4_9.upperseq n = if Even n then (n+1:ℝ)⁻¹ else -(n+2:ℝ)⁻¹ := by sorry
 
@@ -117,7 +136,8 @@ example (n:ℕ) : Example_6_4_9.lowerseq n = n+1 := by sorry
 example : Example_6_4_9.liminf = ⊤ := by sorry
 
 /-- Proposition 6.4.12(a) -/
-theorem Sequence.gt_limsup_bounds {a:Sequence} {x:EReal} (h: x > a.limsup) : ∃ N ≥ a.m, ∀ n ≥ N, a n < x := by
+theorem Sequence.gt_limsup_bounds {a:Sequence} {x:EReal} (h: x > a.limsup) :
+    ∃ N ≥ a.m, ∀ n ≥ N, a n < x := by
   -- This proof is written to follow the structure of the original text.
   unfold Sequence.limsup at h
   simp [sInf_lt_iff] at h
@@ -131,11 +151,13 @@ theorem Sequence.gt_limsup_bounds {a:Sequence} {x:EReal} (h: x > a.limsup) : ∃
   simp [hn, hN.trans hn]
 
 /-- Proposition 6.4.12(a) -/
-theorem Sequence.lt_liminf_bounds {a:Sequence} {y:EReal} (h: y < a.liminf) : ∃ N ≥ a.m, ∀ n ≥ N, a n > y := by
+theorem Sequence.lt_liminf_bounds {a:Sequence} {y:EReal} (h: y < a.liminf) :
+    ∃ N ≥ a.m, ∀ n ≥ N, a n > y := by
   sorry
 
 /-- Proposition 6.4.12(b) -/
-theorem Sequence.lt_limsup_bounds {a:Sequence} {x:EReal} (h: x < a.limsup) {N:ℤ} (hN: N ≥ a.m) : ∃ n ≥ N, a n > x := by
+theorem Sequence.lt_limsup_bounds {a:Sequence} {x:EReal} (h: x < a.limsup) {N:ℤ} (hN: N ≥ a.m) :
+    ∃ n ≥ N, a n > x := by
   -- This proof is written to follow the structure of the original text.
   unfold Sequence.limsup at h
   have hx : x < a.upperseq N := by
@@ -150,7 +172,8 @@ theorem Sequence.lt_limsup_bounds {a:Sequence} {x:EReal} (h: x < a.limsup) {N:�
   simp [hn, hN.trans hn]
 
 /-- Proposition 6.4.12(b) -/
-theorem Sequence.gt_liminf_bounds {a:Sequence} {x:EReal} (h: x > a.liminf) {N:ℤ} (hN: N ≥ a.m) : ∃ n ≥ N, a n < x := by
+theorem Sequence.gt_liminf_bounds {a:Sequence} {x:EReal} (h: x > a.liminf) {N:ℤ} (hN: N ≥ a.m) :
+    ∃ n ≥ N, a n < x := by
   sorry
 
 /-- Proposition 6.4.12(c) / Exercise 6.4.3 -/
@@ -168,11 +191,13 @@ theorem Sequence.limit_point_between_liminf_limsup {a:Sequence} {c:ℝ} (h: a.li
   sorry
 
 /-- Proposition 6.4.12(e) / Exercise 6.4.3 -/
-theorem Sequence.limit_point_of_limsup {a:Sequence} {L_plus:ℝ} (h: a.limsup = L_plus) : a.limit_point L_plus := by
+theorem Sequence.limit_point_of_limsup {a:Sequence} {L_plus:ℝ} (h: a.limsup = L_plus) :
+    a.limit_point L_plus := by
   sorry
 
 /-- Proposition 6.4.12(e) / Exercise 6.4.3 -/
-theorem Sequence.limit_point_of_liminf {a:Sequence} {L_minus:ℝ} (h: a.liminf = L_minus) : a.limit_point L_minus := by
+theorem Sequence.limit_point_of_liminf {a:Sequence} {L_minus:ℝ} (h: a.liminf = L_minus) :
+    a.limit_point L_minus := by
   sorry
 
 /-- Proposition 6.4.12(f) / Exercise 6.4.3 -/
@@ -181,19 +206,25 @@ theorem Sequence.tendsTo_iff_eq_limsup_liminf {a:Sequence} (c:ℝ) :
   sorry
 
 /-- Lemma 6.4.13 (Comparison principle) / Exercise 6.4.4 -/
-theorem Sequence.sup_mono {a b:Sequence} (hm: a.m = b.m) (hab: ∀ n ≥ a.m, a n ≤ b n) : a.sup ≤ b.sup := by sorry
+theorem Sequence.sup_mono {a b:Sequence} (hm: a.m = b.m) (hab: ∀ n ≥ a.m, a n ≤ b n) :
+    a.sup ≤ b.sup := by sorry
 
 /-- Lemma 6.4.13 (Comparison principle) / Exercise 6.4.4 -/
-theorem Sequence.inf_mono {a b:Sequence} (hm: a.m = b.m) (hab: ∀ n ≥ a.m, a n ≤ b n) : a.inf ≤ b.inf := by sorry
+theorem Sequence.inf_mono {a b:Sequence} (hm: a.m = b.m) (hab: ∀ n ≥ a.m, a n ≤ b n) :
+    a.inf ≤ b.inf := by sorry
 
 /-- Lemma 6.4.13 (Comparison principle) / Exercise 6.4.4 -/
-theorem Sequence.limsup_mono {a b:Sequence} (hm: a.m = b.m) (hab: ∀ n ≥ a.m, a n ≤ b n) : a.limsup ≤ b.limsup := by sorry
+theorem Sequence.limsup_mono {a b:Sequence} (hm: a.m = b.m) (hab: ∀ n ≥ a.m, a n ≤ b n) :
+    a.limsup ≤ b.limsup := by sorry
 
 /-- Lemma 6.4.13 (Comparison principle) / Exercise 6.4.4 -/
-theorem Sequence.liminf_mono {a b:Sequence} (hm: a.m = b.m) (hab: ∀ n ≥ a.m, a n ≤ b n) : a.liminf ≤ b.liminf := by sorry
+theorem Sequence.liminf_mono {a b:Sequence} (hm: a.m = b.m) (hab: ∀ n ≥ a.m, a n ≤ b n) :
+    a.liminf ≤ b.liminf := by sorry
 
 /-- Corollary 6.4.14 (Squeeze test) / Exercise 6.4.5 -/
-theorem Sequence.lim_of_between {a b c:Sequence} {L:ℝ} (hm: b.m = a.m ∧ c.m = a.m) (hab: ∀ n ≥ a.m, a n ≤ b n ∧ b n ≤ c n) (ha: a.tendsTo L) (hb: b.tendsTo L) : c.tendsTo L := by sorry
+theorem Sequence.lim_of_between {a b c:Sequence} {L:ℝ} (hm: b.m = a.m ∧ c.m = a.m)
+  (hab: ∀ n ≥ a.m, a n ≤ b n ∧ b n ≤ c n) (ha: a.tendsTo L) (hb: b.tendsTo L) :
+    c.tendsTo L := by sorry
 
 /-- Example 6.4.15 -/
 example : ((fun (n:ℕ) ↦ 2/(n+1:ℝ)):Sequence).tendsTo 0 := by
@@ -224,8 +255,12 @@ theorem Sequence.tendsTo_zero_iff (a:Sequence) :
   a.tendsTo (0:ℝ) ↔ a.abs.tendsTo (0:ℝ) := by
   sorry
 
-/-- This helper lemma, implicit in the textbook proofs of Theorem 6.4.18 and Theorem 6.6.8, is made explicit here. -/
-theorem Sequence.finite_limsup_liminf_of_bounded {a:Sequence} (hbound: a.isBounded) : (∃ L_plus:ℝ, a.limsup = L_plus) ∧ (∃ L_minus:ℝ, a.liminf = L_minus) := by
+/--
+  This helper lemma, implicit in the textbook proofs of Theorem 6.4.18 and Theorem 6.6.8, is made
+  explicit here.
+-/
+theorem Sequence.finite_limsup_liminf_of_bounded {a:Sequence} (hbound: a.isBounded) :
+    (∃ L_plus:ℝ, a.limsup = L_plus) ∧ (∃ L_minus:ℝ, a.liminf = L_minus) := by
   obtain ⟨ M, hMpos, hbound ⟩ := hbound
   unfold Sequence.BoundedBy at hbound
   have hlimsup_bound : a.limsup ≤ M := by
@@ -263,7 +298,8 @@ theorem Sequence.Cauchy_iff_convergent (a:Sequence) :
   -- This proof is written to follow the structure of the original text.
   refine ⟨ ?_, Cauchy_of_convergent ⟩
   intro h
-  obtain ⟨ ⟨ L_plus, hL_plus ⟩, ⟨ L_minus, hL_minus ⟩ ⟩ := finite_limsup_liminf_of_bounded (bounded_of_cauchy h)
+  obtain ⟨ ⟨ L_plus, hL_plus ⟩, ⟨ L_minus, hL_minus ⟩ ⟩ :=
+    finite_limsup_liminf_of_bounded (bounded_of_cauchy h)
   use L_minus
   rw [tendsTo_iff_eq_limsup_liminf]
   simp [hL_minus, hL_plus]

--- a/analysis/Analysis/Section_6_5.lean
+++ b/analysis/Analysis/Section_6_5.lean
@@ -4,7 +4,11 @@ import Analysis.Section_6_4
 /-!
 # Analysis I, Section 6.5
 
-I have attempted to make the translation as faithful a paraphrasing as possible of the original text.  When there is a choice between a more idiomatic Lean solution and a more faithful translation, I have generally chosen the latter.  In particular, there will be places where the Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided doing so.
+I have attempted to make the translation as faithful a paraphrasing as possible of the original
+text. When there is a choice between a more idiomatic Lean solution and a more faithful
+translation, I have generally chosen the latter. In particular, there will be places where the
+Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided
+doing so.
 
 Main constructions and results of this section:
 
@@ -45,7 +49,8 @@ lemma Sequence.pow_succ (a:Sequence) (k:ℕ) : a^(k+1) = a^k * a := by
   simp [h, a.vanish n (by linarith)]
 
 /-- Corollary 6.5.1 -/
-theorem Sequence.lim_of_power_decay {k:ℕ}  : ((fun (n:ℕ) ↦ 1/((n:ℝ)+1)^(1/(k+1:ℝ))):Sequence).tendsTo 0 := by
+theorem Sequence.lim_of_power_decay {k:ℕ} :
+    ((fun (n:ℕ) ↦ 1/((n:ℝ)+1)^(1/(k+1:ℝ))):Sequence).tendsTo 0 := by
   -- This proof is written to follow the structure of the original text.
   set a := ((fun (n:ℕ) ↦ 1/((n:ℝ)+1)^(1/(k+1:ℝ))):Sequence)
   have ha : a.bddBelow := by
@@ -58,7 +63,8 @@ theorem Sequence.lim_of_power_decay {k:ℕ}  : ((fun (n:ℕ) ↦ 1/((n:ℝ)+1)^(
     simp [a] at hn ⊢
     have hn' : 0 ≤ n+1 := by linarith
     simp [hn,hn']
-    rw [inv_le_inv₀ (by positivity) (by positivity), Real.rpow_le_rpow_iff  (by positivity) (by positivity) (by positivity)]
+    rw [inv_le_inv₀ (by positivity) (by positivity),
+        Real.rpow_le_rpow_iff  (by positivity) (by positivity) (by positivity)]
     simp [hn]
   replace ha' := convergent_of_antitone ha ha'
   have hpow (n:ℕ): (a^(n+1)).convergent ∧ lim (a^(n+1)) = (lim a)^(n+1) := by
@@ -88,19 +94,23 @@ theorem Sequence.lim_of_geometric' {x:ℝ} (hx: x = 1) : lim ((fun (n:ℕ) ↦ x
   sorry
 
 /-- Lemma 6.5.2 / Exercise 6.5.2 -/
-theorem Sequence.lim_of_geometric'' {x:ℝ} (hx: x = -1 ∨ |x| > 1) : ((fun (n:ℕ) ↦ x^n):Sequence).divergent := by
+theorem Sequence.lim_of_geometric'' {x:ℝ} (hx: x = -1 ∨ |x| > 1) :
+    ((fun (n:ℕ) ↦ x^n):Sequence).divergent := by
   sorry
 
 /-- Lemma 6.5.3 / Exercise 6.5.3 -/
-theorem Sequence.lim_of_roots {x:ℝ} (hx: x > 0) : lim ((fun (n:ℕ) ↦ x^(1/(n+1))):Sequence) = 1 := by
+theorem Sequence.lim_of_roots {x:ℝ} (hx: x > 0) :
+    lim ((fun (n:ℕ) ↦ x^(1/(n+1))):Sequence) = 1 := by
   sorry
 
 /-- Exercise 6.5.1 -/
-theorem Sequence.lim_of_rat_power_decay {q:ℚ} (hq: q > 0) : lim ((fun (n:ℕ) ↦ 1/((n:ℝ)+1)^(q:ℝ)):Sequence) = 0 := by
+theorem Sequence.lim_of_rat_power_decay {q:ℚ} (hq: q > 0) :
+    lim ((fun (n:ℕ) ↦ 1/((n:ℝ)+1)^(q:ℝ)):Sequence) = 0 := by
   sorry
 
 /-- Exercise 6.5.1 -/
-theorem Sequence.lim_of_rat_power_growth {q:ℚ} (hq: q > 0) : ((fun (n:ℕ) ↦ ((n:ℝ)+1)^(q:ℝ)):Sequence).divergent := by
+theorem Sequence.lim_of_rat_power_growth {q:ℚ} (hq: q > 0) :
+    ((fun (n:ℕ) ↦ ((n:ℝ)+1)^(q:ℝ)):Sequence).divergent := by
   sorry
 
 

--- a/analysis/Analysis/Section_6_6.lean
+++ b/analysis/Analysis/Section_6_6.lean
@@ -4,7 +4,11 @@ import Analysis.Section_6_5
 /-!
 # Analysis I, Section 6.6
 
-I have attempted to make the translation as faithful a paraphrasing as possible of the original text.  When there is a choice between a more idiomatic Lean solution and a more faithful translation, I have generally chosen the latter.  In particular, there will be places where the Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided doing so.
+I have attempted to make the translation as faithful a paraphrasing as possible of the original
+text. When there is a choice between a more idiomatic Lean solution and a more faithful
+translation, I have generally chosen the latter. In particular, there will be places where the
+Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided
+doing so.
 
 Main constructions and results of this section:
 
@@ -21,26 +25,36 @@ example (a:ℕ → ℝ) : Sequence.subseq a (fun n ↦ a (2 * n)) := by sorry
 
 example {f: ℕ → ℕ} (hf: StrictMono f) : Function.Injective f := by sorry
 
-example : Sequence.subseq (fun n ↦ if Even n then 1 + (10:ℝ)^(-(n/2:ℤ)-1) else (1:ℝ)^(-(n/2:ℤ)-1)) (fun n ↦ 1 + (10:ℝ)^(-(n:ℤ)-1)) := by sorry
+example :
+    Sequence.subseq (fun n ↦ if Even n then 1 + (10:ℝ)^(-(n/2:ℤ)-1) else (1:ℝ)^(-(n/2:ℤ)-1))
+    (fun n ↦ 1 + (10:ℝ)^(-(n:ℤ)-1)) := by
+  sorry
 
-example : Sequence.subseq (fun n ↦ if Even n then 1 + (10:ℝ)^(-(n/2:ℤ)-1) else (1:ℝ)^(-(n/2:ℤ)-1)) (fun n ↦ (10:ℝ)^(-(n:ℤ)-1)) := by sorry
+example :
+    Sequence.subseq (fun n ↦ if Even n then 1 + (10:ℝ)^(-(n/2:ℤ)-1) else (1:ℝ)^(-(n/2:ℤ)-1))
+    (fun n ↦ (10:ℝ)^(-(n:ℤ)-1)) := by
+  sorry
 
 /-- Lemma 6.6.4 / Exercise 6.6.1 -/
 theorem Sequence.subseq_self (a:ℕ → ℝ) : Sequence.subseq a a := by sorry
 
 /-- Lemma 6.6.4 / Exercise 6.6.1 -/
-theorem Sequence.subseq_trans {a b c:ℕ → ℝ} (hab: Sequence.subseq a b) (hbc: Sequence.subseq b c) : Sequence.subseq a c := by sorry
+theorem Sequence.subseq_trans {a b c:ℕ → ℝ} (hab: Sequence.subseq a b) (hbc: Sequence.subseq b c) :
+    Sequence.subseq a c := by sorry
 
 /-- Proposition 6.6.5 / Exercise 6.6.4 -/
-theorem Sequence.convergent_iff_subseq (a:ℕ → ℝ) (L:ℝ) : (a:Sequence).tendsTo L ↔ ∀ b:ℕ → ℝ, Sequence.subseq a b → (b:Sequence).tendsTo L := by
- sorry
+theorem Sequence.convergent_iff_subseq (a:ℕ → ℝ) (L:ℝ) :
+    (a:Sequence).tendsTo L ↔ ∀ b:ℕ → ℝ, Sequence.subseq a b → (b:Sequence).tendsTo L := by
+  sorry
 
 /-- Proposition 6.6.6 / Exercise 6.6.5 -/
-theorem Sequence.limit_point_iff_subseq (a:ℕ → ℝ) (L:ℝ) : (a:Sequence).limit_point L ↔ ∃ b:ℕ → ℝ, Sequence.subseq a b ∧ (b:Sequence).tendsTo L := by
- sorry
+theorem Sequence.limit_point_iff_subseq (a:ℕ → ℝ) (L:ℝ) :
+    (a:Sequence).limit_point L ↔ ∃ b:ℕ → ℝ, Sequence.subseq a b ∧ (b:Sequence).tendsTo L := by
+  sorry
 
 /-- Theorem 6.6.8 (Bolzano-Weierstrass theorem) -/
-theorem Sequence.convergent_of_subseq_of_bounded {a:ℕ→ ℝ} (ha: (a:Sequence).isBounded) : ∃ b:ℕ → ℝ, Sequence.subseq a b ∧ (b:Sequence).convergent := by
+theorem Sequence.convergent_of_subseq_of_bounded {a:ℕ→ ℝ} (ha: (a:Sequence).isBounded) :
+    ∃ b:ℕ → ℝ, Sequence.subseq a b ∧ (b:Sequence).convergent := by
   -- This proof is written to follow the structure of the original text.
   obtain ⟨ ⟨ L_plus, hL_plus ⟩, ⟨ L_minus, hL_minus ⟩ ⟩ := finite_limsup_liminf_of_bounded ha
   have := limit_point_of_limsup hL_plus
@@ -50,12 +64,23 @@ theorem Sequence.convergent_of_subseq_of_bounded {a:ℕ→ ℝ} (ha: (a:Sequence
 
 /- Exercise 6.6.2: uncomment and prove one of the statements below and delete the other. -/
 
--- theorem Sequence.exist_subseq_of_subseq : ∃ a b:ℕ → ℝ, a ≠ b ∧ Sequence.subseq a b ∧ Sequence.subseq b a := by sorry
+/-
+theorem Sequence.exist_subseq_of_subseq :
+    ∃ a b : ℕ → ℝ, a ≠ b ∧ Sequence.subseq a b ∧ Sequence.subseq b a := by sorry
+-/
 
--- theorem Sequence.not_exist_subseq_of_subseq : ¬ ∃ a b:ℕ → ℝ, a ≠ b ∧ Sequence.subseq a b ∧ Sequence.subseq b a := by sorry
+/-
+theorem Sequence.not_exist_subseq_of_subseq :
+    ¬ ∃ a b:ℕ → ℝ, a ≠ b ∧ Sequence.subseq a b ∧ Sequence.subseq b a := by
+  sorry
+-/
 
-/-- Exercise 6.6.3.  You may find the API around Mathlib's `Nat.find` to be useful (and `open Classical` to avoid any decidability issues) -/
-theorem Sequence.subseq_of_unbounded {a:ℕ → ℝ} (ha: ¬ (a:Sequence).isBounded) : ∃ b:ℕ → ℝ, Sequence.subseq a b ∧ (b:Sequence)⁻¹.tendsTo 0 := by
+/--
+  Exercise 6.6.3.  You may find the API around Mathlib's `Nat.find` to be useful
+  (and `open Classical` to avoid any decidability issues)
+-/
+theorem Sequence.subseq_of_unbounded {a:ℕ → ℝ} (ha: ¬ (a:Sequence).isBounded) :
+    ∃ b:ℕ → ℝ, Sequence.subseq a b ∧ (b:Sequence)⁻¹.tendsTo 0 := by
   sorry
 
 

--- a/analysis/Analysis/Section_6_epilogue.lean
+++ b/analysis/Analysis/Section_6_epilogue.lean
@@ -4,12 +4,16 @@ import Analysis.Section_6_6
 /-!
 # Analysis I, Chapter 6 epilogue
 
-In this (technical) epilogue, we show that various operations and properties we have defined for "Chapter 6" sequences `Chapter6.Sequence` are equivalent to Mathlib operations.  Note however that Mathlib's operations are defined in far greater generality than the setting of real-valued sequences, in particular using the language of filters.
+In this (technical) epilogue, we show that various operations and properties we have defined for
+"Chapter 6" sequences `Chapter6.Sequence` are equivalent to Mathlib operations.  Note however
+that Mathlib's operations are defined in far greater generality than the setting of real-valued
+sequences, in particular using the language of filters.
 
 -/
 
 /-- Identification with the Cauchy sequence support in `Mathlib.Algebra.Order.CauSeq.Basic` -/
-theorem Chapter6.Sequence.Cauchy_iff_CauSeq (a: ℕ → ℝ) : (a:Sequence).isCauchy ↔ IsCauSeq _root_.abs a := by
+theorem Chapter6.Sequence.Cauchy_iff_CauSeq (a: ℕ → ℝ) :
+    (a:Sequence).isCauchy ↔ IsCauSeq _root_.abs a := by
   simp_rw [isCauchy_of_coe, Real.dist_eq, IsCauSeq]
   constructor
   . intro h ε hε
@@ -30,12 +34,14 @@ theorem Chapter6.Sequence.Cauchy_iff_CauSeq (a: ℕ → ℝ) : (a:Sequence).isCa
     _ = _ := by linarith
 
 /-- Identification with the Cauchy sequence support in `Mathlib.Topology.UniformSpace.Cauchy` -/
-theorem Chapter6.Sequence.Cauchy_iff_CauchySeq (a: ℕ → ℝ) : (a:Sequence).isCauchy ↔ CauchySeq a := by
+theorem Chapter6.Sequence.Cauchy_iff_CauchySeq (a: ℕ → ℝ) :
+    (a:Sequence).isCauchy ↔ CauchySeq a := by
   rw [Cauchy_iff_CauSeq]
   convert isCauSeq_iff_cauchySeq
 
 /-- Identifiction with `Filter.Tendsto` -/
-theorem Chapter6.Sequence.tendsto_iff_Tendsto (a: ℕ → ℝ) (L:ℝ) : (a:Sequence).tendsTo L ↔ Filter.Tendsto a Filter.atTop (nhds L) := by
+theorem Chapter6.Sequence.tendsto_iff_Tendsto (a: ℕ → ℝ) (L:ℝ) :
+    (a:Sequence).tendsTo L ↔ Filter.Tendsto a Filter.atTop (nhds L) := by
   rw [Metric.tendsto_atTop, tendsTo_iff]
   constructor
   . intro h ε hε
@@ -58,7 +64,8 @@ theorem Chapter6.Sequence.tendsto_iff_Tendsto (a: ℕ → ℝ) (L:ℝ) : (a:Sequ
   simp [hpos, ←Real.dist_eq]
   exact le_of_lt hN
 
-theorem Chapter6.Sequence.converges_iff_Tendsto (a: ℕ → ℝ) : (a:Sequence).convergent ↔ ∃ L, Filter.Tendsto a Filter.atTop (nhds L) := by
+theorem Chapter6.Sequence.converges_iff_Tendsto (a: ℕ → ℝ) :
+    (a:Sequence).convergent ↔ ∃ L, Filter.Tendsto a Filter.atTop (nhds L) := by
   simp_rw [←tendsto_iff_Tendsto]
 
 /-- A technicality: `CauSeq.IsComplete ℝ` was established for `_root_.abs` but not for `norm`. -/
@@ -76,7 +83,8 @@ theorem Chapter6.Sequence.lim_eq_CauSeq_lim (a:ℕ → ℝ) (ha: (a:Sequence).is
   tauto
 
 /-- Identification with `Bornology.IsBounded` -/
-theorem Chapter6.Sequence.isBounded_iff_isBounded_range (a:ℕ → ℝ): (a:Sequence).isBounded ↔ Bornology.IsBounded (Set.range a) := by
+theorem Chapter6.Sequence.isBounded_iff_isBounded_range (a:ℕ → ℝ):
+    (a:Sequence).isBounded ↔ Bornology.IsBounded (Set.range a) := by
   simp [isBounded_def, BoundedBy_def, Metric.isBounded_iff]
   constructor
   . intro h
@@ -106,21 +114,27 @@ theorem Chapter6.Sequence.isBounded_iff_isBounded_range (a:ℕ → ℝ): (a:Sequ
       _ ≤ C + |a 0| := by gcongr; rw [←Real.dist_eq]; convert h n.toNat 0
   positivity
 
-theorem Chapter6.Sequence.sup_eq_sSup (a:ℕ → ℝ): (a:Sequence).sup = sSup (Set.range (fun n ↦ (a n:EReal))) := by sorry
+theorem Chapter6.Sequence.sup_eq_sSup (a:ℕ → ℝ):
+    (a:Sequence).sup = sSup (Set.range (fun n ↦ (a n:EReal))) := by sorry
 
-theorem Chapter6.Sequence.inf_eq_sInf (a:ℕ → ℝ): (a:Sequence).inf = sInf (Set.range (fun n ↦ (a n:EReal))) := by sorry
+theorem Chapter6.Sequence.inf_eq_sInf (a:ℕ → ℝ):
+    (a:Sequence).inf = sInf (Set.range (fun n ↦ (a n:EReal))) := by sorry
 
-theorem Chapter6.Sequence.bddAbove_iff (a:ℕ → ℝ): (a:Sequence).bddAbove ↔ BddAbove (Set.range a) := by sorry
+theorem Chapter6.Sequence.bddAbove_iff (a:ℕ → ℝ):
+    (a:Sequence).bddAbove ↔ BddAbove (Set.range a) := by sorry
 
-theorem Chapter6.Sequence.bddBelow_iff (a:ℕ → ℝ): (a:Sequence).bddBelow ↔ BddBelow (Set.range a) := by sorry
+theorem Chapter6.Sequence.bddBelow_iff (a:ℕ → ℝ):
+    (a:Sequence).bddBelow ↔ BddBelow (Set.range a) := by sorry
 
 theorem Chapter6.Sequence.Monotone_iff (a:ℕ → ℝ): (a:Sequence).isMonotone ↔ Monotone a := by sorry
 
 theorem Chapter6.Sequence.Antitone_iff (a:ℕ → ℝ): (a:Sequence).isAntitone ↔ Antitone a := by sorry
 
 /-- Identification with `Filter.MapClusterPt` -/
-theorem Chapter6.Sequence.limit_point_iff (a:ℕ → ℝ) (L:ℝ) : (a:Sequence).limit_point L ↔ MapClusterPt L Filter.atTop a := by
-  simp_rw [limit_point_def, mapClusterPt_iff_frequently, Filter.frequently_atTop, Metric.mem_nhds_iff]
+theorem Chapter6.Sequence.limit_point_iff (a:ℕ → ℝ) (L:ℝ) :
+    (a:Sequence).limit_point L ↔ MapClusterPt L Filter.atTop a := by
+  simp_rw [limit_point_def, mapClusterPt_iff_frequently,
+           Filter.frequently_atTop, Metric.mem_nhds_iff]
   constructor
   . intro h s hs N
     obtain ⟨ ε, hε, hεs ⟩ := hs
@@ -142,12 +156,14 @@ theorem Chapter6.Sequence.limit_point_iff (a:ℕ → ℝ) (L:ℝ) : (a:Sequence)
   linarith
 
 /-- Identification with `Filter.limsup` -/
-theorem Chapter6.Sequence.limsup_eq (a:ℕ → ℝ) : (a:Sequence).limsup = Filter.limsup (fun n ↦ (a n:EReal)) Filter.atTop := by
+theorem Chapter6.Sequence.limsup_eq (a:ℕ → ℝ) :
+    (a:Sequence).limsup = Filter.limsup (fun n ↦ (a n:EReal)) Filter.atTop := by
   simp_rw [Filter.limsup_eq, Filter.eventually_atTop]
   sorry
 
 /-- Identification with `Filter.liminf` -/
-theorem Chapter6.Sequence.liminf_eq (a:ℕ → ℝ) : (a:Sequence).liminf = Filter.liminf (fun n ↦ (a n:EReal)) Filter.atTop := by
+theorem Chapter6.Sequence.liminf_eq (a:ℕ → ℝ) :
+    (a:Sequence).liminf = Filter.liminf (fun n ↦ (a n:EReal)) Filter.atTop := by
   simp_rw [Filter.liminf_eq, Filter.eventually_atTop]
   sorry
 

--- a/analysis/Analysis/Section_7_1.lean
+++ b/analysis/Analysis/Section_7_1.lean
@@ -287,8 +287,7 @@ theorem finite_series_of_finite_series {XX YY:Type*} (X: Finset XX) (Y: Finset Y
       congr 1
       rw [finite_series_of_fintype, finite_series_of_fintype f]
       set π : Finset.product {x₀} Y → Y :=
-        fun z ↦ ⟨ z.val.2, by obtain ⟨ z, hz ⟩ := z; simp at hz ⊢;
-        obtain ⟨ a, ⟨ ha, rfl ⟩ ⟩ := hz; simp [ha] ⟩
+        fun z ↦ ⟨ z.val.2, by obtain ⟨ z, hz ⟩ := z; simp at hz ⊢; obtain ⟨ a, ⟨ ha, rfl ⟩ ⟩ := hz; simp [ha] ⟩
       have hπ : Function.Bijective π := by
         constructor
         . intro ⟨ ⟨ x, y ⟩, hz ⟩ ⟨ ⟨ x', y' ⟩, hz' ⟩ hzz'

--- a/analysis/Analysis/Section_7_1.lean
+++ b/analysis/Analysis/Section_7_1.lean
@@ -3,20 +3,28 @@ import Mathlib.Tactic
 /-!
 # Analysis I, Section 7.1
 
-I have attempted to make the translation as faithful a paraphrasing as possible of the original text.  When there is a choice between a more idiomatic Lean solution and a more faithful translation, I have generally chosen the latter.  In particular, there will be places where the Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided doing so.
+I have attempted to make the translation as faithful a paraphrasing as possible of the original
+text. hen there is a choice between a more idiomatic Lean solution and a more faithful
+translation, I have generally chosen the latter. In particular, there will be places where the
+Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided
+doing so.
 
-Technical note: it is convenient in Lean to extend finite sequences (usually by zero) to be functions on the entire integers.
+Technical note: it is convenient in Lean to extend finite sequences (usually by zero) to be
+functions on the entire integers.
 
 Main constructions and results of this section:
 
-- API for summation over finite sets (encoded using Mathlib's `Finset` type), using the `Finset.sum` method and the `∑ n ∈ A, f n` notation.
+- API for summation over finite sets (encoded using Mathlib's `Finset` type), using the
+  `Finset.sum` method and the `∑ n ∈ A, f n` notation.
 - Fubini's theorem for finite series
 
-We do not attempt to replicate the full API for `Finset.sum` here, but in subsequent sections we shall make liberal use of this API.
+We do not attempt to replicate the full API for `Finset.sum` here, but in subsequent sections we
+shall make liberal use of this API.
 
 -/
 
--- This makes available the convenient notation `∑ n ∈ A, f n` to denote summation of `f n` for `n` ranging over a finite set `A`.
+-- This makes available the convenient notation `∑ n ∈ A, f n` to denote summation of `f n` for
+-- `n` ranging over a finite set `A`.
 open BigOperators
 
 -- This is a technical device to avoid Mathlib's insistence on decidable equality for finite sets.
@@ -24,7 +32,8 @@ open Classical
 
 namespace Finset
 
--- We use `Finset.Icc` to describe finite intervals in the integers.  `Finset.mem_Icc` is the standard Mathlib tool for checking membership in such intervals.
+-- We use `Finset.Icc` to describe finite intervals in the integers. `Finset.mem_Icc` is the
+-- standard Mathlib tool for checking membership in such intervals.
 #check mem_Icc
 
 /-- Definition 7.1.1 -/
@@ -34,8 +43,12 @@ theorem sum_of_empty {n m:ℤ} (h: n < m) (a: ℤ → ℝ) : ∑ i ∈ Icc m n, 
   rw [mem_Icc] at hx
   linarith
 
-/-- Definition 7.1.1.  This is similar to Mathlib's `Finset.sum_Icc_succ_top` except that the latter involves summation over the natural numbers rather than integers. -/
-theorem sum_of_nonempty {n m:ℤ} (h: n ≥ m-1) (a: ℤ → ℝ) : ∑ i ∈ Icc m (n+1), a i = ∑ i ∈ Icc m n, a i + a (n+1) := by
+/--
+  Definition 7.1.1. This is similar to Mathlib's `Finset.sum_Icc_succ_top` except that the
+  latter involves summation over the natural numbers rather than integers.
+-/
+theorem sum_of_nonempty {n m:ℤ} (h: n ≥ m-1) (a: ℤ → ℝ) :
+    ∑ i ∈ Icc m (n+1), a i = ∑ i ∈ Icc m n, a i + a (n+1) := by
   rw [add_comm _ (a (n+1))]
   convert sum_insert _
   . ext i; simp; omega
@@ -79,11 +92,19 @@ theorem abs_finite_series_le {m n:ℤ}   (a: ℤ → ℝ) (c:ℝ) :
 theorem finite_series_of_le {m n:ℤ}  {a b: ℤ → ℝ} (h: ∀ i, m ≤ i → i ≤ n → a i ≤ b i) :
   ∑ i ∈ Icc m n, a i ≤ ∑ i ∈ Icc m n, b i := by sorry
 
--- This lemma is not part of the original textbook, but proven similarly to the other results above, and is handy.
+-- This lemma is not part of the original textbook, but proven similarly to the other results
+-- above, and is handy.
 #check sum_congr
 
-/-- Proposition 7.1.8.  There is an unfortunate hack here in that one needs to extend the expressions `f g i` and `f h i` outside of `Icc 1 n`, leading to a certain uglification of the code. -/
-theorem finite_series_of_rearrange {n:ℕ} {X':Type*} (X: Finset X') (hcard: X.card = n) (f: X' → ℝ) (g h: Icc (1:ℤ) n → X) (hg: Function.Bijective g) (hh: Function.Bijective h) : ∑ i ∈ Icc (1:ℤ) n, (if hi:i ∈ Icc (1:ℤ) n then f (g ⟨ i, hi ⟩) else 0) = ∑ i ∈ Icc (1:ℤ) n, (if hi: i ∈ Icc (1:ℤ) n then f (h ⟨ i, hi ⟩) else 0) := by
+/--
+  Proposition 7.1.8. There is an unfortunate hack here in that one needs to extend the
+  expressions `f g i` and `f h i` outside of `Icc 1 n`, leading to a certain uglification of the
+  code.
+-/
+theorem finite_series_of_rearrange {n:ℕ} {X':Type*} (X: Finset X') (hcard: X.card = n)
+  (f: X' → ℝ) (g h: Icc (1:ℤ) n → X) (hg: Function.Bijective g) (hh: Function.Bijective h) :
+    ∑ i ∈ Icc (1:ℤ) n, (if hi:i ∈ Icc (1:ℤ) n then f (g ⟨ i, hi ⟩) else 0)
+    = ∑ i ∈ Icc (1:ℤ) n, (if hi: i ∈ Icc (1:ℤ) n then f (h ⟨ i, hi ⟩) else 0) := by
   -- This proof is written to broadly follow the structure of the original text.
   revert X n
   intro n
@@ -91,8 +112,11 @@ theorem finite_series_of_rearrange {n:ℕ} {X':Type*} (X: Finset X') (hcard: X.c
   . simp [sum_of_empty (show 0 < 1 by norm_num) (fun _ ↦ 0)]
   -- A technical step: we extend g, h to the entire integers using a slightly artificial map π
   intro X hX g h hg hh
-  set π : ℤ → Icc (1:ℤ) (n+1) := fun i ↦ if hi: i ∈ Icc (1:ℤ) (n+1) then ⟨ i, hi ⟩ else ⟨ 1, by simp ⟩
-  have hπ (g : Icc (1:ℤ) (n+1) → X) : ∑ i ∈ Icc (1:ℤ) (n+1), (if hi:i ∈ Icc (1:ℤ) (n+1) then f (g ⟨ i, hi ⟩) else 0) = ∑ i ∈ Icc (1:ℤ) (n+1), f (g (π i)) := by
+  set π : ℤ → Icc (1:ℤ) (n+1) :=
+    fun i ↦ if hi: i ∈ Icc (1:ℤ) (n+1) then ⟨ i, hi ⟩ else ⟨ 1, by simp ⟩
+  have hπ (g : Icc (1:ℤ) (n+1) → X) :
+      ∑ i ∈ Icc (1:ℤ) (n+1), (if hi:i ∈ Icc (1:ℤ) (n+1) then f (g ⟨ i, hi ⟩) else 0)
+      = ∑ i ∈ Icc (1:ℤ) (n+1), f (g (π i)) := by
     apply sum_congr rfl _
     intro i hi
     simp only [hi, ↓reduceDIte, π]
@@ -108,7 +132,8 @@ theorem finite_series_of_rearrange {n:ℕ} {X':Type*} (X: Finset X') (hcard: X.c
     _ = ∑ i ∈ Icc (1:ℤ) j, f (h (π i)) + ∑ i ∈ Icc (j+1:ℤ) (n + 1), f (h (π i)) := by
       convert (concat_finite_series _ _ _).symm
       all_goals linarith
-    _ = ∑ i ∈ Icc (1:ℤ) (j-1), f (h (π i)) + f ( h (π j) ) + ∑ i ∈ Icc (j+1:ℤ) (n + 1), f (h (π i)) := by
+    _ = ∑ i ∈ Icc (1:ℤ) (j-1), f (h (π i)) + f ( h (π j) ) + ∑ i
+        ∈ Icc (j+1:ℤ) (n + 1), f (h (π i)) := by
       congr
       convert sum_of_nonempty _ _ <;> simp
       tauto
@@ -142,11 +167,14 @@ theorem finite_series_of_rearrange {n:ℕ} {X':Type*} (X: Finset X') (hcard: X.c
     have hi'' : i ≤ n+1 := by linarith
     by_cases hlt: i < j
     all_goals by_contra! heq
-    all_goals simp [h', hlt, ←hj, (Function.Bijective.injective hh).eq_iff, ←Subtype.val_inj, π, hi.1, hi.2, hi',hi''] at heq
+    all_goals simp [h', hlt, ←hj, (Function.Bijective.injective hh).eq_iff, ←Subtype.val_inj,
+                    π, hi.1, hi.2, hi',hi''] at heq
     . linarith
     contrapose! hlt; linarith
-  set gtil : Icc (1:ℤ) n → X.erase x := fun i ↦ ⟨ (g (π i)).val, by simp [mem_erase, Subtype.val_inj, g_ne_x] ⟩
-  set htil : Icc (1:ℤ) n → X.erase x := fun i ↦ ⟨ (h' i).val, by simp [mem_erase, Subtype.val_inj, h'_ne_x] ⟩
+  set gtil : Icc (1:ℤ) n → X.erase x :=
+    fun i ↦ ⟨ (g (π i)).val, by simp [mem_erase, Subtype.val_inj, g_ne_x] ⟩
+  set htil : Icc (1:ℤ) n → X.erase x :=
+    fun i ↦ ⟨ (h' i).val, by simp [mem_erase, Subtype.val_inj, h'_ne_x] ⟩
   set ftil : X.erase x → ℝ := fun y ↦ f y.val
   have why : Function.Bijective gtil := by sorry
   have why2 : Function.Bijective htil := by sorry
@@ -165,15 +193,21 @@ theorem finite_series_of_rearrange {n:ℕ} {X':Type*} (X: Finset X') (hcard: X.c
       intro i hi
       simp [hi, htil, ftil]
 
-/-- This fact ensures that Definition 7.1.6 would be well-defined even if we did not appeal to the existing `Finset.sum` method. -/
-theorem exist_bijection {n:ℕ} {Y:Type*} (X: Finset Y) (hcard: X.card = n) : ∃ g: Icc (1:ℤ) n → X, Function.Bijective g := by
+/--
+  This fact ensures that Definition 7.1.6 would be well-defined even if we did not appeal to the
+  existing `Finset.sum` method.
+-/
+theorem exist_bijection {n:ℕ} {Y:Type*} (X: Finset Y) (hcard: X.card = n) :
+    ∃ g: Icc (1:ℤ) n → X, Function.Bijective g := by
   have : (Icc (1:ℤ) n).card = X.card := by simp [hcard]
   replace this := Finset.equivOfCardEq this
   use this
   exact Equiv.bijective this
 
 /-- Definition 7.1.6 -/
-theorem finite_series_eq {n:ℕ} {Y:Type*} (X: Finset Y) (f: Y → ℝ) (g: Icc (1:ℤ) n → X) (hg: Function.Bijective g) : ∑ i ∈ X, f i = ∑ i ∈ Icc (1:ℤ) n, (if hi:i ∈ Icc (1:ℤ) n then f (g ⟨ i, hi ⟩) else 0) := by
+theorem finite_series_eq {n:ℕ} {Y:Type*} (X: Finset Y) (f: Y → ℝ) (g: Icc (1:ℤ) n → X)
+  (hg: Function.Bijective g) :
+    ∑ i ∈ X, f i = ∑ i ∈ Icc (1:ℤ) n, (if hi:i ∈ Icc (1:ℤ) n then f (g ⟨ i, hi ⟩) else 0) := by
   symm
   convert sum_bij (t:=X) (fun i hi ↦ g ⟨ i, hi ⟩ ) _ _ _ _
   . intro i hi; simp [hi]
@@ -188,33 +222,47 @@ theorem finite_series_eq {n:ℕ} {Y:Type*} (X: Finset Y) (f: Y → ℝ) (g: Icc 
 theorem finite_series_of_empty {X':Type*} (f: X' → ℝ) : ∑ i ∈ ∅, f i = 0 := by sorry
 
 /-- Proposition 7.1.11(b) / Exercise 7.1.2 -/
-theorem finite_series_of_singleton {X':Type*} (f: X' → ℝ) (x₀:X') : ∑ i ∈ {x₀}, f i = f x₀ := by sorry
+theorem finite_series_of_singleton {X':Type*} (f: X' → ℝ) (x₀:X') : ∑ i ∈ {x₀}, f i = f x₀ := by
+  sorry
 
-/-- A technical lemma relating a sum over a finset with a sum over a fintype.  Combines well with tools such as `map_finite_series` below. -/
-theorem finite_series_of_fintype {X':Type*} (f: X' → ℝ) (X: Finset X') : ∑ x ∈ X, f x = ∑ x:X, f x.val := (sum_coe_sort X f).symm
+/--
+  A technical lemma relating a sum over a finset with a sum over a fintype. Combines well with
+  tools such as `map_finite_series` below.
+-/
+theorem finite_series_of_fintype {X':Type*} (f: X' → ℝ) (X: Finset X') :
+    ∑ x ∈ X, f x = ∑ x:X, f x.val := (sum_coe_sort X f).symm
 
 /-- Proposition 7.1.11(c) / Exercise 7.1.2 -/
-theorem map_finite_series {X:Type*} [Fintype X] [Fintype Y] (f: X → ℝ) {g:Y → X} (hg: Function.Bijective g) : ∑ x, f x = ∑ y, f (g y) := by sorry
+theorem map_finite_series {X:Type*} [Fintype X] [Fintype Y] (f: X → ℝ) {g:Y → X}
+  (hg: Function.Bijective g) :
+    ∑ x, f x = ∑ y, f (g y) := by sorry
 
 -- Proposition 7.1.11(d) is `rfl` in our formalism and is therefore omitted.
 
 /-- Proposition 7.1.11(e) / Exercise 7.1.2 -/
-theorem finite_series_of_disjoint_union {Z:Type*} {X Y: Finset Z} (hdisj: Disjoint X Y) (f: Z → ℝ) : ∑ z ∈ X ∪ Y, f z = ∑ z ∈ X, f z + ∑ z ∈ Y, f z := by sorry
+theorem finite_series_of_disjoint_union {Z:Type*} {X Y: Finset Z} (hdisj: Disjoint X Y) (f: Z → ℝ) :
+    ∑ z ∈ X ∪ Y, f z = ∑ z ∈ X, f z + ∑ z ∈ Y, f z := by sorry
 
 /-- Proposition 7.1.11(f) / Exercise 7.1.2 -/
-theorem finite_series_of_add {X':Type*} (f g: X' → ℝ) (X: Finset X') : ∑ x ∈ X, (f + g) x = ∑ x ∈ X, f x + ∑ x ∈ X, g x := by sorry
+theorem finite_series_of_add {X':Type*} (f g: X' → ℝ) (X: Finset X') :
+    ∑ x ∈ X, (f + g) x = ∑ x ∈ X, f x + ∑ x ∈ X, g x := by sorry
 
 /-- Proposition 7.1.11(g) / Exercise 7.1.2 -/
-theorem finite_series_of_const_mul {X':Type*} (f: X' → ℝ) (X: Finset X') (c:ℝ) : ∑ x ∈ X, c * f x = c * ∑ x ∈ X, f x := by sorry
+theorem finite_series_of_const_mul {X':Type*} (f: X' → ℝ) (X: Finset X') (c:ℝ) :
+    ∑ x ∈ X, c * f x = c * ∑ x ∈ X, f x := by sorry
 
 /-- Proposition 7.1.11(h) / Exercise 7.1.2 -/
-theorem finite_series_of_le' {X':Type*} (f g: X' → ℝ) (X: Finset X') (h: ∀ x ∈ X, f x ≤ g x) : ∑ x ∈ X, f x ≤ ∑ x ∈ X, g x := by sorry
+theorem finite_series_of_le' {X':Type*} (f g: X' → ℝ) (X: Finset X') (h: ∀ x ∈ X, f x ≤ g x) :
+    ∑ x ∈ X, f x ≤ ∑ x ∈ X, g x := by sorry
 
 /-- Proposition 7.1.11(i) / Exercise 7.1.2 -/
-theorem abs_finite_series_le' {X':Type*} (f: X' → ℝ) (X: Finset X') : |∑ x ∈ X, f x| ≤ ∑ x ∈ X, |f x| := by sorry
+theorem abs_finite_series_le' {X':Type*} (f: X' → ℝ) (X: Finset X') :
+    |∑ x ∈ X, f x| ≤ ∑ x ∈ X, |f x| := by sorry
 
 /-- Lemma 7.1.13 --/
-theorem finite_series_of_finite_series {XX YY:Type*} (X: Finset XX) (Y: Finset YY) (f: XX × YY → ℝ) : ∑ x ∈ X, ∑ y ∈ Y, f (x, y) = ∑ z ∈ Finset.product X Y, f z := by
+theorem finite_series_of_finite_series {XX YY:Type*} (X: Finset XX) (Y: Finset YY)
+  (f: XX × YY → ℝ) :
+    ∑ x ∈ X, ∑ y ∈ Y, f (x, y) = ∑ z ∈ Finset.product X Y, f z := by
   generalize h: X.card = n
   revert X
   induction' n with n hn
@@ -238,7 +286,9 @@ theorem finite_series_of_finite_series {XX YY:Type*} (X: Finset XX) (Y: Finset Y
     _ = ∑ z ∈ Finset.product X' Y, f z + ∑ z ∈ Finset.product {x₀} Y, f z := by
       congr 1
       rw [finite_series_of_fintype, finite_series_of_fintype f]
-      set π : Finset.product {x₀} Y → Y := fun z ↦ ⟨ z.val.2, by obtain ⟨ z, hz ⟩ := z; simp at hz ⊢; obtain ⟨ a, ⟨ ha, rfl ⟩ ⟩ := hz; simp [ha] ⟩
+      set π : Finset.product {x₀} Y → Y :=
+        fun z ↦ ⟨ z.val.2, by obtain ⟨ z, hz ⟩ := z; simp at hz ⊢;
+        obtain ⟨ a, ⟨ ha, rfl ⟩ ⟩ := hz; simp [ha] ⟩
       have hπ : Function.Bijective π := by
         constructor
         . intro ⟨ ⟨ x, y ⟩, hz ⟩ ⟨ ⟨ x', y' ⟩, hz' ⟩ hzz'
@@ -255,9 +305,10 @@ theorem finite_series_of_finite_series {XX YY:Type*} (X: Finset XX) (Y: Finset Y
       sorry
 
 /-- Corollary 7.1.14 (Fubini's theorem for finite series)-/
-theorem finite_series_refl {XX YY:Type*} (X: Finset XX) (Y: Finset YY) (f: XX × YY → ℝ) : ∑ z ∈ Finset.product X Y, f z =
-∑ z ∈ Finset.product Y X, f (z.2, z.1) := by
-  set h : Finset.product Y X → Finset.product X Y := fun z ↦ ⟨ (z.val.2, z.val.1), by obtain ⟨ z, hz ⟩ := z; simp at hz ⊢; tauto ⟩
+theorem finite_series_refl {XX YY:Type*} (X: Finset XX) (Y: Finset YY) (f: XX × YY → ℝ) :
+    ∑ z ∈ Finset.product X Y, f z = ∑ z ∈ Finset.product Y X, f (z.2, z.1) := by
+  set h : Finset.product Y X → Finset.product X Y :=
+    fun z ↦ ⟨ (z.val.2, z.val.1), by obtain ⟨ z, hz ⟩ := z; simp at hz ⊢; tauto ⟩
   have hh : Function.Bijective h := by
     constructor
     . intro ⟨ ⟨ y, x ⟩, hz ⟩ ⟨ ⟨ y', x' ⟩, hz' ⟩ hzz'
@@ -270,21 +321,33 @@ theorem finite_series_refl {XX YY:Type*} (X: Finset XX) (Y: Finset YY) (f: XX ×
   nth_rewrite 2 [finite_series_of_fintype]
   convert map_finite_series _ hh with z
 
-theorem finite_series_comm {XX YY:Type*} (X: Finset XX) (Y: Finset YY) (f: XX × YY → ℝ) : ∑ x ∈ X, ∑ y ∈ Y, f (x, y) =
-∑ y ∈ Y, ∑ x ∈ X, f (x, y) := by
-  rw [finite_series_of_finite_series, finite_series_refl,  finite_series_of_finite_series _ _ (fun z ↦ f (z.2, z.1))]
+theorem finite_series_comm {XX YY:Type*} (X: Finset XX) (Y: Finset YY) (f: XX × YY → ℝ) :
+    ∑ x ∈ X, ∑ y ∈ Y, f (x, y) = ∑ y ∈ Y, ∑ x ∈ X, f (x, y) := by
+  rw [finite_series_of_finite_series, finite_series_refl,
+      finite_series_of_finite_series _ _ (fun z ↦ f (z.2, z.1))]
 
 
--- Exercise 7.1.3 : develop as many analogues as you can of the above theory for finite products instead of finite sums.
+-- Exercise 7.1.3 : develop as many analogues as you can of the above theory for finite products
+-- instead of finite sums.
 
 #check Nat.factorial_zero
 #check Nat.factorial_succ
 
-/-- Exercise 7.1.4.  Note: there may be some technicalities passing back and forth between natural numbers and integers.  Look into the tactics `zify`, `norm_cast`, and `omega` -/
-theorem binomial_theorem (x y:ℝ) (n:ℕ) : (x + y)^n = ∑ j ∈ Icc (0:ℤ) n, n.factorial / (j.toNat.factorial * (n-j).toNat.factorial) * x^k * y^(n - k) := by sorry
+/--
+  Exercise 7.1.4. Note: there may be some technicalities passing back and forth between natural
+  numbers and integers. Look into the tactics `zify`, `norm_cast`, and `omega`
+-/
+theorem binomial_theorem (x y:ℝ) (n:ℕ) :
+    (x + y)^n
+    = ∑ j ∈ Icc (0:ℤ) n,
+    n.factorial / (j.toNat.factorial * (n-j).toNat.factorial) * x^k * y^(n - k) := by
+  sorry
 
 /-- Exercise 7.1.5 -/
-theorem lim_of_finite_series {X:Type*} [Fintype X] (a: X → ℕ → ℝ) (L : X → ℝ) (h: ∀ x, Filter.Tendsto (a x) Filter.atTop (nhds (L x))) : Filter.Tendsto (fun n ↦ ∑ x, a x n) Filter.atTop (nhds (∑ x, L x)) := by sorry
+theorem lim_of_finite_series {X:Type*} [Fintype X] (a: X → ℕ → ℝ) (L : X → ℝ)
+  (h: ∀ x, Filter.Tendsto (a x) Filter.atTop (nhds (L x))) :
+    Filter.Tendsto (fun n ↦ ∑ x, a x n) Filter.atTop (nhds (∑ x, L x)) := by
+  sorry
 
 
 

--- a/analysis/Analysis/Section_7_2.lean
+++ b/analysis/Analysis/Section_7_2.lean
@@ -3,14 +3,22 @@ import Mathlib.Tactic
 /-!
 # Analysis I, Section 7.2
 
-I have attempted to make the translation as faithful a paraphrasing as possible of the original text.  When there is a choice between a more idiomatic Lean solution and a more faithful translation, I have generally chosen the latter.  In particular, there will be places where the Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided doing so.
+I have attempted to make the translation as faithful a paraphrasing as possible of the original
+text. When there is a choice between a more idiomatic Lean solution and a more faithful
+translation, I have generally chosen the latter. In particular, there will be places where the
+Lean code could be "golfed" to be more elegant and idiomatic, but I have consciously avoided
+doing so.
+
 -/
 
 namespace Chapter7
 
 open BigOperators
 
-/-- Definition 7.2.1 (Formal infinite series). This is similar to Chapter 6 sequence, but is manipulated differently.  As with Chapter 5, we will start series from 0 by default. -/
+/--
+  Definition 7.2.1 (Formal infinite series). This is similar to Chapter 6 sequence, but is
+  manipulated differently. As with Chapter 5, we will start series from 0 by default.
+-/
 @[ext]
 structure Series where
   m : ℤ
@@ -37,12 +45,14 @@ abbrev Series.mk' {m:ℤ} (a: { n // n ≥ m } → ℝ) : Series where
     intro n hn
     simp [hn]
 
-theorem Series.eval_mk' {m:ℤ} (a : { n // n ≥ m } → ℝ) {n : ℤ} (h:n ≥ m) : (Series.mk' a).seq n = a ⟨ n, h ⟩ := by simp [h] 
+theorem Series.eval_mk' {m:ℤ} (a : { n // n ≥ m } → ℝ) {n : ℤ} (h:n ≥ m) :
+    (Series.mk' a).seq n = a ⟨ n, h ⟩ := by simp [h]
 
 /-- Definition 7.2.2 (Convergence of series) -/
 abbrev Series.partial (s : Series) (N:ℤ) : ℝ := ∑ n ∈ Finset.Icc s.m N, s.seq n
 
-abbrev Series.convergesTo (s : Series) (L:ℝ) : Prop := Filter.Tendsto (s.partial) Filter.atTop (nhds L)
+abbrev Series.convergesTo (s : Series) (L:ℝ) : Prop :=
+  Filter.Tendsto (s.partial) Filter.atTop (nhds L)
 
 abbrev Series.converges (s : Series) : Prop := ∃ L, s.convergesTo L
 
@@ -52,7 +62,8 @@ open Classical in
 noncomputable abbrev Series.sum (s : Series) : ℝ :=
   if h : s.converges then h.choose else 0
 
-theorem Series.converges_of_convergesTo {s : Series} {L:ℝ} (h: s.convergesTo L) : s.converges := by use L
+theorem Series.converges_of_convergesTo {s : Series} {L:ℝ} (h: s.convergesTo L) :
+    s.converges := by use L
 
 /-- Remark 7.2.3 -/
 theorem Series.sum_of_converges {s : Series} {L:ℝ} (h: s.convergesTo L) : s.sum = L := by
@@ -62,7 +73,8 @@ theorem Series.sum_of_converges {s : Series} {L:ℝ} (h: s.convergesTo L) : s.su
 /-- Example 7.2.4 -/
 noncomputable abbrev Series.example_7_2_4 := mk' (m := 1) (fun n ↦ (2:ℝ)^(-n:ℤ))
 
-theorem Series.example_7_2_4a {N:ℤ} (hN: N ≥ 1) : example_7_2_4.partial N = 1 - (2:ℝ)^(-N) := by sorry
+theorem Series.example_7_2_4a {N:ℤ} (hN: N ≥ 1) : example_7_2_4.partial N = 1 - (2:ℝ)^(-N) := by
+  sorry
 
 theorem Series.example_7_2_4b : example_7_2_4.convergesTo 1 := by sorry
 
@@ -70,17 +82,24 @@ theorem Series.example_7_2_4c : example_7_2_4.sum = 1 := by sorry
 
 noncomputable abbrev Series.example_7_2_4' := mk' (m := 1) (fun n ↦ (2:ℝ)^(n:ℤ))
 
-theorem Series.example_7_2_4'a {N:ℤ} (hN: N ≥ 1) : example_7_2_4'.partial N = (2:ℝ)^(N+1) - 2 := by sorry
+theorem Series.example_7_2_4'a {N:ℤ} (hN: N ≥ 1) : example_7_2_4'.partial N = (2:ℝ)^(N+1) - 2 := by
+  sorry
 
 theorem Series.example_7_2_4'b : example_7_2_4'.diverges := by sorry
 
 /-- Proposition 7.2.5 / Exercise 7.2.2 -/
-theorem Series.converges_iff_tail_decay (s:Series) : s.converges ↔ ∀ ε > 0, ∃ N ≥ s.m, ∀ p ≥ N, ∀ q ≥ N, |∑ n ∈ Finset.Icc p q, s.seq n| ≤ ε := by sorry
+theorem Series.converges_iff_tail_decay (s:Series) :
+    s.converges ↔ ∀ ε > 0, ∃ N ≥ s.m, ∀ p ≥ N, ∀ q ≥ N, |∑ n ∈ Finset.Icc p q, s.seq n| ≤ ε := by
+  sorry
 
 /-- Corollary 7.2.6 (Zero test) / Exercise 7.2.3 -/
-theorem Series.decay_of_converges {s:Series} (h: s.converges) : Filter.Tendsto s.seq Filter.atTop (nhds 0) := by sorry
+theorem Series.decay_of_converges {s:Series} (h: s.converges) :
+    Filter.Tendsto s.seq Filter.atTop (nhds 0) := by
+  sorry
 
-theorem Series.diverges_of_nodecay {s:Series} (h: ¬ Filter.Tendsto s.seq Filter.atTop (nhds 0)) : s.diverges := by sorry
+theorem Series.diverges_of_nodecay {s:Series} (h: ¬ Filter.Tendsto s.seq Filter.atTop (nhds 0)) :
+    s.diverges := by
+  sorry
 
 /-- Example 7.2.7 -/
 theorem Series.example_7_2_7 : ((fun n:ℕ ↦ (1:ℝ)):Series).diverges := by
@@ -99,12 +118,17 @@ abbrev Series.absConverges (s:Series) : Prop := s.abs.converges
 abbrev Series.condConverges (s:Series) : Prop := s.converges ∧ ¬ s.absConverges
 
 /-- Proposition 7.2.9 (Absolute convergence test) / Example 7.2.4 -/
-theorem Series.converges_of_absConverges {s:Series} (h : s.absConverges) : s.converges := by sorry
+theorem Series.converges_of_absConverges {s:Series} (h : s.absConverges) : s.converges := by
+  sorry
 
-theorem Series.abs_le {s:Series} (h : s.absConverges) : |s.sum| ≤ s.abs.sum := by sorry
+theorem Series.abs_le {s:Series} (h : s.absConverges) : |s.sum| ≤ s.abs.sum := by
+  sorry
 
 /-- Proposition 7.2.12 (Alternating series test) -/
-theorem Series.converges_of_alternating {m:ℤ} {a: { n // n ≥ m} → ℝ} (ha: ∀ n, a n ≥ 0) (ha': Antitone a) : ((mk' (m:=m) (fun n ↦ (-1)^(n:ℤ) * a n)).converges ↔ Filter.Tendsto a Filter.atTop (nhds 0)) := by
+theorem Series.converges_of_alternating {m:ℤ} {a: { n // n ≥ m} → ℝ} (ha: ∀ n, a n ≥ 0)
+  (ha': Antitone a) :
+    ((mk' (m:=m) (fun n ↦ (-1)^(n:ℤ) * a n)).converges
+    ↔ Filter.Tendsto a Filter.atTop (nhds 0)) := by
   -- This proof is written to follow the structure of the original text.
   constructor
   . intro h
@@ -138,7 +162,8 @@ instance Series.inst_add : Add Series where
   }
 
 /-- Proposition 7.2.14 (a) (Series laws) / Exercise 7.2.5 -/
-theorem Series.add {s t:Series} (hs: s.converges) (ht: t.converges) : (s + t).converges ∧ (s+t).sum = s.sum + t.sum := by sorry
+theorem Series.add {s t:Series} (hs: s.converges) (ht: t.converges) :
+    (s + t).converges ∧ (s+t).sum = s.sum + t.sum := by sorry
 
 instance Series.inst.smul : SMul ℝ Series where
   smul c s := {
@@ -150,25 +175,40 @@ instance Series.inst.smul : SMul ℝ Series where
       simp [hn]
   }
 /-- Proposition 7.2.14 (b) (Series laws) / Exercise 7.2.5 -/
-theorem Series.smul {c:ℝ} {s:Series} (hs: s.converges) : (c • s).converges ∧ (c • s).sum = c * s.sum := by sorry
+theorem Series.smul {c:ℝ} {s:Series} (hs: s.converges) :
+    (c • s).converges ∧ (c • s).sum = c * s.sum := by sorry
 
-abbrev Series.from (s:Series) (m₁:ℤ) : Series := mk' (m := max s.m m₁) (fun n ↦ s.seq (n:ℤ))
+abbrev Series.from (s:Series) (m₁:ℤ) : Series :=
+  mk' (m := max s.m m₁) (fun n ↦ s.seq (n:ℤ))
 
 /-- Proposition 7.2.14 (c) (Series laws) / Exercise 7.2.5 -/
-theorem Series.converges_from (s:Series) (k:ℕ) : s.converges ↔ (s.from (s.m+k)).converges := by sorry
+theorem Series.converges_from (s:Series) (k:ℕ) : s.converges ↔ (s.from (s.m+k)).converges := by
+  sorry
 
-theorem Series.sum_from {s:Series} (k:ℕ) (h: s.converges) : s.sum = ∑ n ∈ Finset.Ico s.m (s.m+k), s.seq n + (s.from (s.m+k)).sum := by sorry
+theorem Series.sum_from {s:Series} (k:ℕ) (h: s.converges) :
+    s.sum = ∑ n ∈ Finset.Ico s.m (s.m+k), s.seq n + (s.from (s.m+k)).sum := by
+  sorry
 
 /-- Proposition 7.2.14 (d) (Series laws) / Exercise 7.2.5 -/
-theorem Series.shift {s:Series} {x:ℝ} (h: s.convergesTo x) (L:ℤ) : (mk' (m := s.m + L) (fun n ↦ s.seq (n - L))).convergesTo x := by sorry
+theorem Series.shift {s:Series} {x:ℝ} (h: s.convergesTo x) (L:ℤ) :
+    (mk' (m := s.m + L) (fun n ↦ s.seq (n - L))).convergesTo x := by
+  sorry
 
 /-- Lemma 7.2.15 (telescoping series) / Exercise 7.2.6 -/
-theorem Series.telescope {a:ℕ → ℝ} (ha: Filter.Tendsto a Filter.atTop (nhds 0)) : ((fun n:ℕ ↦ a (n+1) - a n):Series).convergesTo (a 0) := by sorry
+theorem Series.telescope {a:ℕ → ℝ} (ha: Filter.Tendsto a Filter.atTop (nhds 0)) :
+    ((fun n:ℕ ↦ a (n+1) - a n):Series).convergesTo (a 0) := by
+  sorry
 
 /- Exercise 7.2.1 : uncomment and prove one of the following statements, and delete the other. -/
 
--- theorem Series.exercise_7_2_1_convergent : (mk' (m := 1) (fun n ↦ (-1:ℝ)^(n:ℤ))).converges := by sorry
+/-
+theorem Series.exercise_7_2_1_convergent : (mk' (m := 1) (fun n ↦ (-1:ℝ)^(n:ℤ))).converges := by
+  sorry
+-/
 
--- theorem Series.exercise_7_2_1_divergent : (mk' (m := 1) (fun n ↦ (-1:ℝ)^(n:ℤ))).diverges := by sorry
+/-
+theorem Series.exercise_7_2_1_divergent : (mk' (m := 1) (fun n ↦ (-1:ℝ)^(n:ℤ))).diverges := by
+  sorry
+-/
 
 end Chapter7


### PR DESCRIPTION
Followup of [this issue](https://github.com/teorth/analysis/issues/66#issue-3152086079).

The [Mathlib style guide](https://leanprover-community.github.io/contribute/style.html#line-length) dictates that lines should not exceed 100 characters, for the sake of readability. This commit changes virtually no content (the occasional period is added, and some double spaces have been removed), but makes the files in `Analysis/` (mostly) compliant to this line length requirement.