### PR TITLE
Section 3.1: Fix statement of specification_from_replacement, B ⊆ A

### DIFF
--- a/analysis/Analysis/Section_3_1.lean
+++ b/analysis/Analysis/Section_3_1.lean
@@ -658,7 +658,7 @@ theorem SetTheory.Set.union_eq_partition (A B:Set) : A ∪ B = (A \ B) ∪ (A �
   or `Set.specification_axiom'`.
 -/
 theorem SetTheory.Set.specification_from_replacement {A:Set} {P: A → Prop} :
-    ∃ B, A ⊆ B ∧ ∀ x, x.val ∈ B ↔ P x := by sorry
+    ∃ B, B ⊆ A ∧ ∀ x, x.val ∈ B ↔ P x := by sorry
 
 /-- Exercise 3.1.12.-/
 theorem SetTheory.Set.subset_union_subset {A B A' B':Set} (hA'A: A' ⊆ A) (hB'B: B' ⊆ B) :


### PR DESCRIPTION
Changed A ⊆ B to B ⊆ A. The specification axiom constructs a subset containing exactly those elements where P holds, not a superset.

Otherwise we would be required to show P holds for every element in A.