### PR TITLE
Add theorem Nat.pow_zero?

### DIFF
--- a/analysis/Analysis/Section_2_3.lean
+++ b/analysis/Analysis/Section_2_3.lean
@@ -155,6 +155,9 @@ instance Nat.instPow : HomogeneousPow Nat where
   pow := Nat.pow
 
 /-- Definition 2.3.11 (Exponentiation for natural numbers) -/
+theorem Nat.pow_zero (m: Nat) : m ^ (0:Nat) = 1 := recurse_zero (fun _ prod ↦ prod * m) _
+
+/-- Definition 2.3.11 (Exponentiation for natural numbers) -/
 theorem Nat.zero_pow_zero : (0:Nat) ^ 0 = 1 := recurse_zero (fun _ prod ↦ prod * 0) _
 
 /-- Definition 2.3.11 (Exponentiation for natural numbers) -/


### PR DESCRIPTION
I might be missing something very basic, but the current definition of natural number exponentiation does not seem to have a way to explicitly compute `m ^ 0 = 1` (it has `0 ^ 0 = 1` but not the more general case):

https://github.com/teorth/analysis/blob/fd9450a76f6af5d48f574dc4879e08af9bcf9607/analysis/Analysis/Section_2_3.lean#L151-L162

In the textbook $m^0 = 1$ is explicitly stated in Definition 2.3.11.

I realize that it is possible to use tactics like `change` and `rfl` (which as far as I know just directly use `Nat.pow`) even without `Nat.pow_zero`, so adding a `theorem Nat.pow_zero` isn't strictly necessary, but it seemed to be in the spirit of the project to explicitly write down the recursive definition as theorems rather than relying on Lean's ability to understand recursion. This is what was done with addition/multiplication, and is also the approach taken in [NNG4](https://adam.math.hhu.de/#/g/leanprover-community/nng4/world/Power/level/0) where `pow_zero` is part of the definition of exponentiation.