### PR TITLE
Section 3.1: Fix statement of exercise 3.1.13, singleton_iff

### DIFF
--- a/analysis/Analysis/Section_3_1.lean
+++ b/analysis/Analysis/Section_3_1.lean
@@ -678,7 +678,7 @@ theorem SetTheory.Set.subset_diff_subset_counter :
 -/
 
 /-- Exercise 3.1.13 -/
-theorem SetTheory.Set.singleton_iff (A:Set) (hA: A ≠ ∅) : ¬ ∃ B, B ⊂ A ↔ ∃ x, A = {x} := by sorry
+theorem SetTheory.Set.singleton_iff (A:Set) (hA: A ≠ ∅) : (¬∃ B ⊂ A, B ≠ ∅) ↔ ∃ x, A = {x} := by sorry
 
 
 /-


### PR DESCRIPTION
- The empty set is a proper subset of singleton sets, so require B ≠ ∅.
- Added parentheses. Otherwise, Lean parses as: ¬∃ B ⊂ A, (B ≠ ∅ ↔ ∃ x, A = {x})
- Lean's pretty printer prefers `¬∃ B ⊂ A,` over `¬ ∃ B, B ⊂ A ∧`.