### PR TITLE
Section 3.3: positive example for 3.3.3 should be NNReal → NNReal

### DIFF
--- a/analysis/Analysis/Section_3_3.lean
+++ b/analysis/Analysis/Section_3_3.lean
@@ -171,7 +171,7 @@ example : ¬ ∃ f: ℝ → ℝ, ∀ x y, y = f x ↔ y^2 = x := by sorry
 
 example : ¬ ∃ f: NNReal → ℝ, ∀ x y, y = f x ↔ y^2 = x := by sorry
 
-example : ∃ f: NNReal → ℝ, ∀ x y, y = f x ↔ y^2 = x := by sorry
+example : ∃ f: NNReal → NNReal, ∀ x y, y = f x ↔ y^2 = x := by sorry
 
 
 /-- Example 3.3.4. The unused variable `_x` is underscored to avoid triggering a linter. -/


### PR DESCRIPTION
In the previous example we showed there does not exist such a function NNReal → ℝ, since functions should be single-valued.

By the way, would you be interested in a pull-request that adds proofs for these examples, and perhaps other examples currently using sorry that were not exercises in the original text?

When working through this section, I was not sure if the intention was for me to use `NNReal.sqrt` as the witness, which has the required properties already proved in Mathlib, or to somehow define the function implicitly.