### PR TITLE
Remove `hε` in Exercise 5.2.2

### DIFF
--- a/analysis/Analysis/Section_5_2.lean
+++ b/analysis/Analysis/Section_5_2.lean
@@ -126,7 +126,7 @@ theorem Sequence.equiv_of_cauchy {a b: ℕ → ℚ} (hab: Sequence.equiv a b) :
     (a:Sequence).isCauchy ↔ (b:Sequence).isCauchy := by sorry
 
 /-- Exercise 5.2.2 -/
-theorem Sequence.close_of_bounded {ε:ℚ} (hε: ε>0) {a b: ℕ → ℚ} (hab: ε.eventually_close a b) :
+theorem Sequence.close_of_bounded {ε:ℚ} {a b: ℕ → ℚ} (hab: ε.eventually_close a b) :
     (a:Sequence).isBounded ↔ (b:Sequence).isBounded := by sorry
 
 end Chapter5


### PR DESCRIPTION
Remove `(hε: ε>0)` from Exercise 5.2.2 as it is implied by `(hab: ε.eventually_close a b)`.

After providing a proof, lean complained in a message that `hε` was unused in the proof.