### PR TITLE
There no Nat.succ_ne_zero in Mathlib

### DIFF
--- a/analysis/Analysis/Section_2_1.lean
+++ b/analysis/Analysis/Section_2_1.lean
@@ -71,7 +71,7 @@ lemma Nat.two_succ : 2++ = 3 := by rfl
 
 /--
   Axiom 2.3 (0 is not the successor of any natural number).
-  Compare with Mathlib's `Nat.succ_ne_zero`.
+  Compare with Lean's `Nat.succ_ne_zero`.
 -/
 theorem Nat.succ_ne (n:Nat) : n++ ≠ 0 := by
   by_contra h


### PR DESCRIPTION
Looking at the 

https://github.com/teorth/analysis/blob/d03c4afbffee2d993d7109275d8975c6dd5cf0e9/analysis/Analysis/Section_2_1.lean#L72-L76

I did try to find definition of `Nat.succ_ne_zero` at MathLib repo using this search https://github.com/search?q=repo%3Aleanprover-community%2Fmathlib4%20path%3A%2F%5EMathlib%5C%2FData%5C%2FNat%5C%2F%2F%20succ_ne_zero&type=code and it founds nothing to me.

Then I look at the Lean4 repo, and found it. https://github.com/search?q=repo%3Aleanprover%2Flean4%20succ_ne_zero&type=code

Maybe a bit pedantic, but should this be changed to Lean?