### PR TITLE
Update Section_5_3.lean - Avoid linter warning

### DIFF
--- a/analysis/Analysis/Section_5_3.lean
+++ b/analysis/Analysis/Section_5_3.lean
@@ -80,7 +80,7 @@ instance CauchySequence.instSetoid : Setoid CauchySequence where
 theorem CauchySequence.equiv_iff (a b: CauchySequence) : a ≈ b ↔ Sequence.equiv a b := by rfl
 
 /-- Every constant sequence is Cauchy -/
-theorem Sequence.isCauchy_of_const (a:ℚ) : ((fun n:ℕ ↦ a):Sequence).isCauchy := by sorry
+theorem Sequence.isCauchy_of_const (a:ℚ) : ((fun _:ℕ ↦ a):Sequence).isCauchy := by sorry
 
 instance CauchySequence.instZero : Zero CauchySequence where
   zero := CauchySequence.mk' (a := fun _: ℕ ↦ 0) (Sequence.isCauchy_of_const (0:ℚ))


### PR DESCRIPTION
After providing a solution for  `Sequence.isCauchy_of_const`, the linter complains about an unused variable. I suggest replacing `n` with `_`.