### PR TITLE
Move pos_mul_pos before mul_eq_zero_iff

### DIFF
--- a/analysis/Analysis/Section_2_3.lean
+++ b/analysis/Analysis/Section_2_3.lean
@@ -61,11 +61,12 @@ lemma Nat.mul_comm (n m: Nat) : n * m = m * n := by
 theorem Nat.mul_one (m: Nat) : m * 1 = m := by
   rw [mul_comm, one_mul]
 
-/-- Lemma 2.3.3 (Positive natural numbers have no zero divisors) / Exercise 2.3.2 -/
-lemma Nat.mul_eq_zero_iff (n m: Nat) : n * m = 0 ↔ n = 0 ∨ m = 0 := by
+/-- This lemma will be useful to prove Lemma 2.3.3. -/
+lemma Nat.pos_mul_pos {n m: Nat} (h₁: n.isPos) (h₂: m.isPos) : (n * m).isPos := by
   sorry
 
-lemma Nat.pos_mul_pos {n m: Nat} (h₁: n.isPos) (h₂: m.isPos) : (n * m).isPos := by
+/-- Lemma 2.3.3 (Positive natural numbers have no zero divisors) / Exercise 2.3.2 -/
+lemma Nat.mul_eq_zero_iff (n m: Nat) : n * m = 0 ↔ n = 0 ∨ m = 0 := by
   sorry
 
 /-- Proposition 2.3.4 (Distributive law)-/


### PR DESCRIPTION
The diff is a bit confusing but I just swapped their definition order.

This is based on this hint in the original text:

>Exercise 2.3.2. Prove Lemma 2.3.3. **(Hint: prove the second statement first.)**

Where the second statement is:

>Lemma 2.3.3 (Positive natural numbers have no zero divisors). Let n,m be natural numbers. Then n×m = 0 if and only if at least one of n,m is equal to zero. **In particular, if n and m are both positive, then nm is also positive.**

So the book suggests we prove `pos_mul_pos` first.

## Playthrough

Not sure if there are simpler solutions or some different strategy is intended. But here is what I did:

```lean
lemma Nat.pos_mul_pos {n m: Nat} (h₁: n.isPos) (h₂: m.isPos) : (n * m).isPos := by
  obtain ⟨a, ⟨rfl⟩⟩ := uniq_succ_eq _ h₁
  obtain ⟨b, ⟨rfl⟩⟩ := uniq_succ_eq _ h₂
  rw [mul_succ, add_succ]
  tauto

/-- Lemma 2.3.3 (Positive natural numbers have no zero divisors) / Exercise 2.3.2 -/
lemma Nat.mul_eq_zero_iff (n m: Nat) : n * m = 0 ↔ n = 0 ∨ m = 0 := by
  constructor
  · intro h
    by_cases hpos : n ≠ 0 ∧ m ≠ 0
    · have := pos_mul_pos hpos.left hpos.right
      contradiction
    tauto
  intro h
  rcases h with case1 | case2
  · rw [case1, zero_mul]
  rw [case2, mul_zero]
```

This shows I can use `pos_mul_pos` to prove `mul_eq_zero_iff`.