### PR TITLE
Add more scaffolding to equivNat_ordered_ring exercise

### DIFF
--- a/analysis/Analysis/Section_2_epilogue.lean
+++ b/analysis/Analysis/Section_2_epilogue.lean
@@ -51,6 +51,9 @@ abbrev Chapter2.Nat.equivNat_ordered_ring : Chapter2.Nat ≃+*o ℕ where
   map_add' := by
     intro n m
     simp [equivNat]
+    induction' n with n hn
+    · rw [show zero = 0 from rfl]
+      rw [zero_add, _root_.Nat.zero_add]
     sorry
   map_mul' := by
     intro n m


### PR DESCRIPTION
I was essentially stuck here because nothing earlier in the text prepared me for it.

There were two issues in particular:

- I couldn't figure out how to `rw [Chapter2.Nat.zero_add]` because it [only matches `0` rather than `zero`](https://leanprover.zulipchat.com/#narrow/channel/113489-new-members/topic/.E2.9C.94.20Why.20doesn't.20rw.20match.20my.20pattern.3F/near/526652981).
- Later, I wasn't sure how to refer to Mathlib theorems and had to guess `_root_.Nat.zero_add` based on some comment.

This makes these techniques explicit to the reader and leaves the rest as an exercise.

Unrelated to the change, I find it very annoying to follow that `Nat` means `Chapter2.Nat` here already but each `toNat` means "convert to Mathlib `Nat`" instead. I don't know if there's any way to avoid this naming collision here though.