### PR TITLE
Change PeanoAxioms to structure so zero/succ are qualified with P/Q in goals

### DIFF
--- a/analysis/Analysis/Section_2_epilogue.lean
+++ b/analysis/Analysis/Section_2_epilogue.lean
@@ -74,7 +74,7 @@ lemma Chapter2.Nat.pow_eq_pow (n m : Chapter2.Nat) :
 
 /-- The Peano axioms for an abstract type `Nat` -/
 @[ext]
-class PeanoAxioms where
+structure PeanoAxioms where
   Nat : Type
   zero : Nat -- Axiom 2.1
   succ : Nat → Nat -- Axiom 2.2


### PR DESCRIPTION
We're not using the typeclass system here so `structure` seems simpler.

The benefit is that we see `P.zero` / `Q.zero` instead of just `zero` in goals, and same for `succ`. Otherwise proving things about `Equiv.symm` further below gets very confusing.

I verified that a fully solved file still passes with this change.

## Before

Notice just `zero` and `succ` everywhere.

This makes it very difficult to tell what each step needs to prove.

![Screenshot 2025-07-02 at 16 16 43](https://github.com/user-attachments/assets/41b14156-2d7f-4312-99d5-d284976c0c1c)
![Screenshot 2025-07-02 at 16 16 50](https://github.com/user-attachments/assets/359bb0d5-bcaf-4a0a-a8a3-a24fe72949f0)
![Screenshot 2025-07-02 at 16 16 54](https://github.com/user-attachments/assets/f7e0f3ff-6a9c-4e79-97db-c7fc4d24aac8)
![Screenshot 2025-07-02 at 16 16 58](https://github.com/user-attachments/assets/28873ad6-ca3a-4ad3-9f08-35f2dee2eb51)


## After

Notice they are qualified by `P.` or `Q.` which is important for this part.

![Screenshot 2025-07-02 at 16 17 52](https://github.com/user-attachments/assets/762e908c-c297-484c-8522-3ac155b1bfdb)
![Screenshot 2025-07-02 at 16 17 56](https://github.com/user-attachments/assets/d4530607-b035-4c99-bf79-2ff48088ea8d)
![Screenshot 2025-07-02 at 16 18 03](https://github.com/user-attachments/assets/476f97a7-8089-40ac-b210-8095a38dcb4e)
![Screenshot 2025-07-02 at 16 18 10](https://github.com/user-attachments/assets/bcc08a6e-77fe-4fec-90f3-b36bb49998cd)
