### PR TITLE
Add more scaffolding to Equiv.uniq exercise

### DIFF
--- a/analysis/Analysis/Section_2_epilogue.lean
+++ b/analysis/Analysis/Section_2_epilogue.lean
@@ -155,6 +155,10 @@ noncomputable abbrev Equiv.mk' (P Q : PeanoAxioms) : Equiv P Q := by sorry
 /-- There is only one equivalence between any two structures obeying the Peano axioms. -/
 theorem Equiv.uniq {P Q : PeanoAxioms} (equiv1 equiv2 : PeanoAxioms.Equiv P Q) :
     equiv1 = equiv2 := by
+  obtain ⟨equiv1, equiv_zero1, equiv_succ1⟩ := equiv1
+  obtain ⟨equiv2, equiv_zero2, equiv_succ2⟩ := equiv2
+  congr
+  ext n
   sorry
 
 /-- A sample result: recursion is well-defined on any structure obeying the Peano axioms-/


### PR DESCRIPTION
By this point in the exercises, we've never seen `congr` or `ext`.

So it's difficult to guess that they're going to be helpful. You just kind of stare at `=` with no idea what to try. Naïvely matching up each structure's member also doesn't work due to different dependent types.

Let's add some scaffolding so that the exercise is more focused on the math part.