### PR TITLE
Use dedicated coercion function

### DIFF
--- a/analysis/Analysis/Section_5_1.lean
+++ b/analysis/Analysis/Section_5_1.lean
@@ -108,7 +108,7 @@ namespace Chapter5
 5.1.3 - definition of ε-steadiness for a sequence starting at 0
 -/
 lemma Rat.isSteady_of_coe (ε : ℚ) (a:ℕ → ℚ) :
-    ε.steady (a:Sequence) ↔ ∀ n m : ℕ, ε.close (a n) (a m) := by
+    ε.steady a ↔ ∀ n m : ℕ, ε.close (a n) (a m) := by
   constructor
   · intro h n m
     specialize h n (by simp) m (by simp)

--- a/analysis/Analysis/Section_5_1.lean
+++ b/analysis/Analysis/Section_5_1.lean
@@ -124,7 +124,7 @@ Not in textbook: the sequence 2, 2 ... is 1-steady
 Intended as a demonstration of `isSteady_of_coe`
 -/
 example : (1:ℚ).steady ((fun _:ℕ ↦ (3:ℚ)):Sequence) := by
-  rw [Rat.isSteady_of_coe 1 (fun _:ℕ ↦ (3:ℚ))]
+  rw [Rat.isSteady_of_coe]
   unfold Rat.close
   intro n m
   simp
@@ -135,7 +135,7 @@ Compare: if you need to work with `Rat.steady` on the coercion directly, there w
 example : (1:ℚ).steady ( (fun _:ℕ ↦ (3:ℚ)):Sequence) := by
   unfold Rat.steady Rat.close
   intro n hn m hm
-  simp only [Sequence.n0_coe, Sequence.eval_coe_at_int, ge_iff_le] at *
+  simp only [Sequence.n0_coe, Sequence.eval_coe_at_int] at hn hm
   simp [hn, hm]
 
 /-- Example 5.1.5 -/

--- a/analysis/Analysis/Section_5_3.lean
+++ b/analysis/Analysis/Section_5_3.lean
@@ -53,6 +53,7 @@ instance CauchySequence.instCoeFun : CoeFun CauchySequence (fun _ ↦ ℕ → �
 theorem CauchySequence.coe_to_sequence (a: CauchySequence) :
     ((a:ℕ → ℚ):Sequence) = a.toSequence := by
   apply Sequence.ext
+  simp only [Sequence.n0_coe]
   . rw [a.zero]
   ext n
   by_cases h:n ≥ 0

--- a/analysis/Analysis/Section_5_5.lean
+++ b/analysis/Analysis/Section_5_5.lean
@@ -99,6 +99,10 @@ theorem Real.upperBound_discrete_unique {E: Set Real} {n:ℕ} {m m':ℤ}
 theorem Real.LIM_of_Cauchy {q:ℕ → ℚ} (hq: ∀ M, ∀ n ≥ M, ∀ n' ≥ M, |q n - q n'| ≤ 1 / (M+1)) :
     (q:Sequence).isCauchy ∧ ∀ M, |q M - LIM q| ≤ 1 / (M+1) := by sorry
 
+/--
+The sequence m₁, m₂ … is well-defined
+This proof uses a different indexing convention than the text
+-/
 lemma Real.LUB_claim1 (n : ℕ) {E: Set Real} (hE: Set.Nonempty E) (hbound: BddAbove E)
 :  ∃! m:ℤ,
       (((m:ℚ) / (n+1):ℚ):Real) ∈ upperBounds E

--- a/analysis/Analysis/Section_5_5.lean
+++ b/analysis/Analysis/Section_5_5.lean
@@ -99,63 +99,64 @@ theorem Real.upperBound_discrete_unique {E: Set Real} {n:ℕ} {m m':ℤ}
 theorem Real.LIM_of_Cauchy {q:ℕ → ℚ} (hq: ∀ M, ∀ n ≥ M, ∀ n' ≥ M, |q n - q n'| ≤ 1 / (M+1)) :
     (q:Sequence).isCauchy ∧ ∀ M, |q M - LIM q| ≤ 1 / (M+1) := by sorry
 
-/-- Theorem 5.5.9 (Existence of least upper bound)-/
-theorem Real.LUB_exist {E: Set Real} (hE: Set.Nonempty E) (hbound: BddAbove E): ∃ S, IsLUB E S := by
-  -- This proof is written to follow the structure of the original text.
-  set x₀ := Set.Nonempty.some hE
-  have hx₀ : x₀ ∈ E := Set.Nonempty.some_mem hE
-  have claim1 (n:ℕ) : ∃! m:ℤ,
+lemma Real.LUB_claim1 (n : ℕ) {E: Set Real} (hE: Set.Nonempty E) (hbound: BddAbove E)
+:  ∃! m:ℤ,
       (((m:ℚ) / (n+1):ℚ):Real) ∈ upperBounds E
       ∧ ¬ (((m:ℚ) / (n+1) - 1 / (n+1):ℚ):Real) ∈ upperBounds E := by
-    set ε := ((1/(n+1):ℚ):Real)
-    have hpos : ε.isPos := by
-      simp [isPos_iff, ε, ←lt_of_coe]
-      positivity
-    apply existsUnique_of_exists_of_unique
-    . rw [bddAbove_def] at hbound
-      obtain ⟨ M, hbound ⟩ := hbound
-      obtain ⟨ K, _, hK ⟩ := le_mul hpos M
-      obtain ⟨ L', _, hL ⟩ := le_mul hpos (-x₀)
-      set L := -(L':ℤ)
-      have claim1_1 : L * ε < x₀ := by
-        simp [L]; linarith
-      have claim1_2 : L * ε ∉ upperBounds E := by
-        contrapose! claim1_1
-        rw [upperBound_def] at claim1_1
-        exact claim1_1 _ hx₀
-      have claim1_3 : (K:Real) > (L:Real) := by
-        contrapose! claim1_2
-        replace claim1_2 := mul_le_mul_left claim1_2 hpos
-        simp_rw [mul_comm] at claim1_2
-        replace claim1_2 := lt_of_lt_of_le hK claim1_2
-        exact upperBound_upper (le_of_lt claim1_2) hbound
-      have claim1_4 : ∃ m:ℤ, L < m ∧ m ≤ K ∧ m*ε ∈ upperBounds E ∧ (m-1)*ε ∉ upperBounds E := by
-        convert Real.upperBound_between (n := n) ?_ ?_ claim1_2
-        . qify
-          rw [←gt_iff_lt, gt_of_coe]
-          convert claim1_3
-        apply upperBound_upper (le_of_lt _) hbound
-        rw [←gt_iff_lt]
-        convert hK
-      obtain ⟨ m, _, _, hm, hm' ⟩ := claim1_4
-      use m
-      have : (m/(n+1):ℚ) = m*ε := by
-        simp [ε,mul_of_ratCast]
-        field_simp
-      constructor
-      . convert hm
-      convert hm'
-      simp [sub_of_ratCast, this, sub_mul, ε]
-    -- Exercise 5.5.3
-    intro m m' ⟨ hm1, hm2 ⟩ ⟨ hm'1, hm'2 ⟩
-    exact upperBound_discrete_unique hm1 hm2 hm'1 hm'2
-  set m : ℕ → ℤ := fun n ↦ (claim1 n).exists.choose
-  set a : ℕ → ℚ := fun n ↦ (m n:ℚ) / (n+1)
-  set b : ℕ → ℚ := fun n ↦ 1 / (n+1)
-  have hb : (b:Sequence).isCauchy := Cauchy_of_harmonic
-  have hm1 (n:ℕ) : (a n:Real) ∈ upperBounds E := (claim1 n).exists.choose_spec.1
-  have hm2 (n:ℕ) : ¬ ((a - b) n: Real) ∈ upperBounds E := (claim1 n).exists.choose_spec.2
-  have claim2 (N:ℕ) : ∀ n ≥ N, ∀ n' ≥ N, |a n - a n'| ≤ 1 / (N+1) := by
+  set x₀ := Set.Nonempty.some hE
+  have hx₀ : x₀ ∈ E := Set.Nonempty.some_mem hE
+
+  set ε := ((1/(n+1):ℚ):Real)
+  have hpos : ε.isPos := by
+    simp [isPos_iff, ε, ←lt_of_coe]
+    positivity
+  apply existsUnique_of_exists_of_unique
+  . rw [bddAbove_def] at hbound
+    obtain ⟨ M, hbound ⟩ := hbound
+    obtain ⟨ K, _, hK ⟩ := le_mul hpos M
+    obtain ⟨ L', _, hL ⟩ := le_mul hpos (-x₀)
+    set L := -(L':ℤ)
+    have claim1_1 : L * ε < x₀ := by
+      simp [L]; linarith
+    have claim1_2 : L * ε ∉ upperBounds E := by
+      contrapose! claim1_1
+      rw [upperBound_def] at claim1_1
+      exact claim1_1 _ hx₀
+    have claim1_3 : (K:Real) > (L:Real) := by
+      contrapose! claim1_2
+      replace claim1_2 := mul_le_mul_left claim1_2 hpos
+      simp_rw [mul_comm] at claim1_2
+      replace claim1_2 := lt_of_lt_of_le hK claim1_2
+      exact upperBound_upper (le_of_lt claim1_2) hbound
+    have claim1_4 : ∃ m:ℤ, L < m ∧ m ≤ K ∧ m*ε ∈ upperBounds E ∧ (m-1)*ε ∉ upperBounds E := by
+      convert Real.upperBound_between (n := n) ?_ ?_ claim1_2
+      . qify
+        rw [←gt_iff_lt, gt_of_coe]
+        convert claim1_3
+      apply upperBound_upper (le_of_lt _) hbound
+      rw [←gt_iff_lt]
+      convert hK
+    obtain ⟨ m, _, _, hm, hm' ⟩ := claim1_4
+    use m
+    have : (m/(n+1):ℚ) = m*ε := by
+      simp [ε,mul_of_ratCast]
+      field_simp
+    constructor
+    . convert hm
+    convert hm'
+    simp [sub_of_ratCast, this, sub_mul, ε]
+  -- Exercise 5.5.3
+  intro m m' ⟨ hm1, hm2 ⟩ ⟨ hm'1, hm'2 ⟩
+  exact upperBound_discrete_unique hm1 hm2 hm'1 hm'2
+
+lemma Real.LUB_claim2
+  (E : Set Real)
+  (N:ℕ)
+  (a b: ℕ → ℚ)
+  (hb : ∀ n, b n = 1 / (↑n + 1))
+  (hm1 : ∀ (n : ℕ), ↑(a n) ∈ upperBounds E)
+  (hm2 : ∀ (n : ℕ), ↑((a - b) n) ∉ upperBounds E)
+: ∀ n ≥ N, ∀ n' ≥ N, |a n - a n'| ≤ 1 / (N+1) := by
     intro n hn n' hn'
     rw [abs_le]
     constructor
@@ -164,20 +165,36 @@ theorem Real.LUB_exist {E: Set Real} (hE: Set.Nonempty E) (hbound: BddAbove E): 
         rw [lt_of_coe]
         contrapose! hm2
         exact upperBound_upper hm2 hm1
-      have bound2 : ((a-b) n') = a n' - 1 / (n'+1) := by simp [b]
       have bound3 : 1/((n':ℚ)+1) ≤ 1/(N+1) := by gcongr
-      linarith
+      rw [←neg_le_neg_iff] at bound3
+      rw [Pi.sub_apply] at bound1
+      linarith [hb n']
     specialize hm1 n'; specialize hm2 n
     have bound1 : ((a-b) n) < a n' := by
       rw [lt_of_coe]
       contrapose! hm2
       exact upperBound_upper hm2 hm1
-    have bound2 : ((a-b) n) = a n - 1 / (n+1) := by simp [b]
+    have bound2 : ((a-b) n) = a n - 1 / (n+1) := by
+      simp [hb n]
     have bound3 : 1/((n+1):ℚ) ≤ 1/(N+1) := by gcongr
     -- weirdly, `linarith` times out here, so we proceed manually
     rw [bound2] at bound1
     apply le_of_lt (lt_of_lt_of_le _ bound3)
     rwa [sub_lt_comm]
+
+/-- Theorem 5.5.9 (Existence of least upper bound)-/
+theorem Real.LUB_exist {E: Set Real} (hE: Set.Nonempty E) (hbound: BddAbove E): ∃ S, IsLUB E S := by
+  -- This proof is written to follow the structure of the original text.
+  set x₀ := Set.Nonempty.some hE
+  have hx₀ : x₀ ∈ E := Set.Nonempty.some_mem hE
+  set m : ℕ → ℤ := fun n ↦ (Real.LUB_claim1 n hE hbound).exists.choose
+  set a : ℕ → ℚ := fun n ↦ (m n:ℚ) / (n+1)
+  set b : ℕ → ℚ := fun n ↦ 1 / (n+1)
+  have claim1 (n: ℕ) := Real.LUB_claim1 n hE hbound
+  have hb : (b:Sequence).isCauchy := Cauchy_of_harmonic
+  have hm1 (n:ℕ) : (a n:Real) ∈ upperBounds E := (claim1 n).exists.choose_spec.1
+  have hm2 (n:ℕ) : ¬ ((a - b) n: Real) ∈ upperBounds E := (claim1 n).exists.choose_spec.2
+  have claim2 (N:ℕ) := Real.LUB_claim2 E N a b (fun n ↦ rfl) (fun n ↦ hm1 n) (fun n ↦ hm2 n)
   have claim3 : (a:Sequence).isCauchy := (LIM_of_Cauchy claim2).1
   set S := LIM a
   have claim4 : S = LIM (a - b) := by


### PR DESCRIPTION
Prevent the coercion of `ℕ → ℚ` to `Sequence` from being eagerly unfolded; I believe most of the time you should rewrite with `isCauchy_of_coe`, `isSteady_of_coe` etc instead. This also avoids the fields being printed out in the intermediate proof states.

(I learned about how to do this from this [Zulip thread](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Cannot.20pattern.20match.20.60fun.60.20expressions.3F))