### PR TITLE
Add "by" to some "sorry"s

### DIFF
--- a/analysis/Analysis/Section_3_1.lean
+++ b/analysis/Analysis/Section_3_1.lean
@@ -290,7 +290,8 @@ theorem SetTheory.Set.triple_eq (a b c:Object) : {a,b,c} = ({a}:Set) ∪ {b,c} :
 
 /-- Example 3.1.10 -/
 theorem SetTheory.Set.pair_union_pair (a b c:Object) :
-    ({a,b}:Set) ∪ {b,c} = {a,b,c} := sorry
+    ({a,b}:Set) ∪ {b,c} = {a,b,c} := by
+  sorry
 
 /-- Definition 3.1.14.   -/
 instance SetTheory.Set.instSubset : HasSubset Set where
@@ -450,11 +451,13 @@ theorem SetTheory.Set.inter_assoc (A B C:Set) : (A ∩ B) ∩ C = A ∩ (B ∩ C
 
 /-- Proposition 3.1.27(f) -/
 theorem  SetTheory.Set.inter_union_distrib_left (A B C:Set) :
-    A ∩ (B ∪ C) = (A ∩ B) ∪ (A ∩ C) := sorry
+    A ∩ (B ∪ C) = (A ∩ B) ∪ (A ∩ C) := by
+  sorry
 
 /-- Proposition 3.1.27(f) -/
 theorem  SetTheory.Set.union_inter_distrib_left (A B C:Set) :
-    A ∪ (B ∩ C) = (A ∪ B) ∩ (A ∪ C) := sorry
+    A ∪ (B ∩ C) = (A ∪ B) ∩ (A ∪ C) := by
+  sorry
 
 /-- Proposition 3.1.27(f) -/
 theorem SetTheory.Set.union_compl {A X:Set} (hAX: A ⊆ X) : A ∪ (X \ A) = X := by sorry


### PR DESCRIPTION
This is a tiny thing but:

- People who don't pay attention to distinction might miss it (and then get confused why they can't write tactics)
- People who do pay attention might misinterpret it as a hint to write the proof as a single term (but I don't think it's particularly easy for these?)

When there is no intent to ask the reader to write it in a single term, I think it's worth adding `by`.