### PR TITLE
Remove explicit SetTheory.Set.toObject

### DIFF
--- a/analysis/Analysis/Section_3_1.lean
+++ b/analysis/Analysis/Section_3_1.lean
@@ -49,8 +49,8 @@ Some technical notes:
 - In Analysis I, we chose to work with an "impure" set theory, in which there could be more
   `Object`s than just `Set`s.  In the type theory of Lean, this requires treating `Chapter3.Set`
   and `Chapter3.Object` as distinct types. Occasionally this means we have to use a coercion
-  `X.toObject` of a `Chapter3.Set` `X` to make into a `Chapter3.Object`: this is mostly needed
-  when manipulating sets of sets.
+  `(X: Chapter3.Object)` of a `Chapter3.Set` `X` to make into a `Chapter3.Object`: this is
+  mostly needed when manipulating sets of sets.
 - After this chapter is concluded, the notion of a `Chapter3.SetTheory.Set` will be deprecated in
   favor of the standard Mathlib notion of a `Set` (or more precisely of the type `Set X` of a set
   in a given type `X`).  However, due to various technical incompatibilities between set theory
@@ -109,15 +109,13 @@ instance objects_mem_sets : Membership Object Set where
 instance sets_are_objects : Coe Set Object where
   coe X := SetTheory.set_to_object X
 
-abbrev SetTheory.Set.toObject (X:Set) : Object := X
-
 /-- Axiom 3.1 (Sets are objects)-/
-theorem SetTheory.Set.coe_eq {X Y:Set} (h: X.toObject = Y.toObject) : X = Y :=
+theorem SetTheory.Set.coe_eq {X Y:Set} (h: (X: Object) = (Y: Object)) : X = Y :=
   SetTheory.set_to_object.inj' h
 
 /-- Axiom 3.1 (Sets are objects)-/
 @[simp]
-theorem SetTheory.Set.coe_eq_iff (X Y:Set) : X.toObject = Y.toObject ↔  X = Y := by
+theorem SetTheory.Set.coe_eq_iff (X Y:Set) : (X: Object) = (Y: Object) ↔  X = Y := by
   constructor
   . exact coe_eq
   intro h; subst h; rfl
@@ -217,8 +215,8 @@ theorem SetTheory.Set.pair_eq_pair {a b c d:Object} (h: ({a,b}:Set) = {c,d}) :
   sorry
 
 abbrev SetTheory.Set.empty : Set := ∅
-abbrev SetTheory.Set.singleton_empty : Set := {empty.toObject}
-abbrev SetTheory.Set.pair_empty : Set := {empty.toObject, singleton_empty.toObject}
+abbrev SetTheory.Set.singleton_empty : Set := {(empty: Object)}
+abbrev SetTheory.Set.pair_empty : Set := {(empty: Object), (singleton_empty: Object)}
 
 /-- Exercise 3.1.2-/
 theorem SetTheory.Set.emptyset_neq_singleton : empty ≠ singleton_empty := by


### PR DESCRIPTION
Related to discussion [here](https://leanprover.zulipchat.com/#narrow/channel/113489-new-members/topic/Can.20this.20proof.20related.20to.20Set.20replacement.20be.20shorter.3F/with/527286239). I still find this file somewhat difficult to navigate. So I'm starting from the top again now and looking through the things that confused me on the initial read.

The first thing that jumped to mind is the `toObject` indirection so I wanted to float removing it. It's a more explicit version of the cast to `Object` but it works the same way (and is implemented via that cast anyway).

I think it reduces the mental overhead if we're taught to just always use the cast syntax.

## Playthrough

I haven't done all exercises yet but I've had to make these changes in my solutions.

```diff
--- a/analysis/Analysis/Section_3_1.lean
+++ b/analysis/Analysis/Section_3_1.lean
@@ -275,27 +275,27 @@ abbrev SetTheory.Set.pair_empty : Set := {(empty: Object), (singleton_empty: Obj
 theorem SetTheory.Set.emptyset_neq_singleton : empty ≠ singleton_empty := by
   intro h
   rw [ext_iff] at h
-  have hes : empty.toObject ∈ singleton_empty := by simp only [mem_singleton]
-  have := (h empty.toObject).mpr hes
-  have := not_mem_empty empty.toObject
+  have hes : (empty: Object) ∈ singleton_empty := by simp only [mem_singleton]
+  have := (h (empty: Object)).mpr hes
+  have := not_mem_empty (empty: Object)
   contradiction
 
 /-- Exercise 3.1.2-/
 theorem SetTheory.Set.emptyset_neq_pair : empty ≠ pair_empty := by
   intro h
   rw [ext_iff] at h
-  have hep : empty.toObject ∈ pair_empty := by simp only [mem_pair, true_or]
-  have := (h empty.toObject).mpr hep
-  have := not_mem_empty empty.toObject
+  have hep : (empty: Object) ∈ pair_empty := by simp only [mem_pair, true_or]
+  have := (h (empty: Object)).mpr hep
+  have := not_mem_empty (empty: Object)
   contradiction
 
 /-- Exercise 3.1.2-/
 theorem SetTheory.Set.singleton_empty_neq_pair : singleton_empty ≠ pair_empty := by
   intro h
   rw [ext_iff] at h
-  have hsp : singleton_empty.toObject ∈ pair_empty := by simp only [mem_pair, or_true]
-  have hss := (h singleton_empty.toObject).mpr hsp
-  have := (mem_singleton singleton_empty.toObject empty.toObject).mp hss
+  have hsp : (singleton_empty: Object) ∈ pair_empty := by simp only [mem_pair, or_true]
+  have hss := (h (singleton_empty: Object)).mpr hsp
+  have := (mem_singleton (singleton_empty: Object) (empty: Object)).mp hss
   rw [coe_eq_iff] at this
   have := emptyset_neq_singleton.symm
   contradiction
```

Seems reasonable IMO.

It doesn't seem to be used in any other sections.