### PR TITLE
Fix universe levels for CoeSort instance

### DIFF
--- a/analysis/Analysis/Section_3_1.lean
+++ b/analysis/Analysis/Section_3_1.lean
@@ -390,7 +390,7 @@ example (A: Set) (x': A.toSubtype) : x'.val ∈ A := x'.property
 example (A B: Set) (x: Object) (hx: x ∈ A) : x ∈ A ∪ B := by simp; left; exact hx
 example (A B: Set) (x': A.toSubtype) : x'.val ∈ A ∪ B := by simp; left; exact x'.property
 
-instance : CoeSort (Set.{u}) (Type v) where
+instance : CoeSort (Set) (Type v) where
   coe A := A.toSubtype
 
 -- Now instead of writing `x': A.toSubtype`, we can just write `x': A`.

--- a/analysis/Analysis/Section_3_1.lean
+++ b/analysis/Analysis/Section_3_1.lean
@@ -390,7 +390,7 @@ example (A: Set) (x': A.toSubtype) : x'.val ∈ A := x'.property
 example (A B: Set) (x: Object) (hx: x ∈ A) : x ∈ A ∪ B := by simp; left; exact hx
 example (A B: Set) (x': A.toSubtype) : x'.val ∈ A ∪ B := by simp; left; exact x'.property
 
-instance : CoeSort (Set) (Type) where
+instance : CoeSort (Set.{u}) (Type v) where
   coe A := A.toSubtype
 
 -- Now instead of writing `x': A.toSubtype`, we can just write `x': A`.


### PR DESCRIPTION
This seems necessary for solving `not_mem_self` from 3.2.
I presume it worked before but got broken by the epilogue-related changes.

## Test case

```js
theorem SetTheory.Set.not_mem_self (A:Set) : (A:Object) ∉ A := by
  let B: Set := {(A: Object)}
  have hB : B ≠ ∅ := by sorry
  have := axiom_of_regularity hB
  sorry
```

This exercise (from 3.2) breaks on `main` if you try to use `axiom_of_regularity` because it couldn't infer `SetTheory`.
With this fix, it works.

## Why

It seems like `CoeSort` was always producing `Type 0` (which `Type` stands for):

```js
instance : CoeSort (Set) Type where -- same as instance : CoeSort (Set) (Type 0)
  coe A := A.toSubtype
```

Which is visible here for example:

<img width="869" alt="Screenshot 2025-07-08 at 22 33 07" src="https://github.com/user-attachments/assets/748c40cc-3c99-4772-9edb-4a0e9a06d51b" />

But we want `Type v` because we want a type applicable to objects:

```js
class SetTheory where
  -- ...
  Object : Type v
```

I'm not sure why it works with `0` in other cases but not this one.

## Before

<img width="1404" alt="Screenshot 2025-07-08 at 22 01 52" src="https://github.com/user-attachments/assets/4bcb370c-26e1-47b0-8d3d-10c10e1d9349" />

## After

<img width="1355" alt="Screenshot 2025-07-08 at 22 02 47" src="https://github.com/user-attachments/assets/41a5d232-4097-4b3e-9856-8521a4259379" />

I also verified that @rkirov's [solutions](https://raw.githubusercontent.com/rkirov/analysis/refs/heads/main/analysis/Analysis/Section_3_2.lean) to this section fully pass with this change applied on top of `main` (their fork is behind so it doesn't exhibit the problem on its own).

