### PR TITLE
Change Exercise 3.2.3 to match the book

### DIFF
--- a/analysis/Analysis/Section_3_2.lean
+++ b/analysis/Analysis/Section_3_2.lean
@@ -117,8 +117,8 @@ theorem SetTheory.Set.not_mem_self (A:Set) : (A:Object) ∉ A := by sorry
 theorem SetTheory.Set.not_mem_mem (A B:Set) : (A:Object) ∉ B ∨ (B:Object) ∉ A := by sorry
 
 /-- Exercise 3.2.3 -/
-theorem SetTheory.Set.univ_imp (U: Set) (hU: ∀ x, x ∈ U) :
-    axiom_of_universal_specification := by sorry
+theorem SetTheory.Set.univ_iff : axiom_of_universal_specification ↔
+  ∃ (U:Set), ∀ x, x ∈ U := by sorry
 
 /-- Exercise 3.2.3 -/
 theorem SetTheory.Set.no_univ : ¬ ∃ (U:Set), ∀ (x:Object), x ∈ U := by sorry


### PR DESCRIPTION
From the book:

<img width="772" alt="Screenshot 2025-07-09 at 22 42 21" src="https://github.com/user-attachments/assets/87b23983-f343-4ad6-8048-05967220425f" />

I think this version is missing the other direction. Not sure if this is intentional, but assuming it's not, this should be the change in the signature.

## Playthrough

Seems to work fine for me.

```lean
theorem SetTheory.Set.univ_iff : axiom_of_universal_specification ↔
  ∃ (U:Set), ∀ x, x ∈ U := by
  constructor
  · intro h
    set P : Object → Prop := fun x ↦ True
    obtain ⟨U, hU⟩ := h P
    use U
    intro x
    rw [hU]
    tauto
  rintro ⟨U, hU⟩
  unfold axiom_of_universal_specification
  intro P
  use specify U fun x ↦ P x
  intro x
  rw [specification_axiom'']
  aesop
```