### PR TITLE
Prevent to_fn from always expanding in 3.3

### DIFF
--- a/analysis/Analysis/Section_3_3.lean
+++ b/analysis/Analysis/Section_3_3.lean
@@ -57,10 +57,11 @@ structure Function (X Y: Set) where
   The Chapter 3 definition of a function was nonconstructive, so we have to use the
   axiom of choice here.
 -/
-noncomputable instance Function.inst_coefn (X Y: Set)  : CoeFun (Function X Y) (fun _ ↦ X → Y) where
-  coe := fun f x ↦ Classical.choose (f.unique x)
+noncomputable def Function.to_fn {X Y: Set} (f: Function X Y) : X → Y :=
+  fun x ↦ Classical.choose (f.unique x)
 
-noncomputable abbrev Function.to_fn {X Y: Set} (f: Function X Y) (x:X) : Y := f x
+noncomputable instance Function.inst_coefn (X Y: Set) : CoeFun (Function X Y) (fun _ ↦ X → Y) where
+  coe := Function.to_fn
 
 theorem Function.to_fn_eval {X Y: Set} (f: Function X Y) (x:X) : f.to_fn x = f x := rfl
 
@@ -453,7 +454,7 @@ theorem Function.bijective_incorrect_def :
   rw [Function.one_to_one_iff]
   push_neg
   use 0, 1
-  simp
+  simp [f]
 
 /--
   We cannot use the notation `f⁻¹` for the inverse because in Mathlib's `Inv` class, the inverse
@@ -483,7 +484,7 @@ theorem Function.inverse_eq {X Y: Set} [Nonempty X] {f: Function X Y} (h: f.bije
   ext y
   congr
   symm
-  rw [inverse_eval, ←to_fn]
+  rw [inverse_eval]
   apply Function.rightInverse_invFun
   have ⟨_, hf⟩ := f.bijective_iff.mp h
   exact hf


### PR DESCRIPTION
Follows suggestion from @plp127 from this [Zulip thread](https://leanprover.zulipchat.com/#narrow/channel/514017-Analysis-I/topic/Tao's.20Analysis.20Ch3.2E3/near/528497422).

This changes `to_fn` to be `def` so that it doesn't get eagerly expanded when doing unrelated changes. This prevents the `Classical.choose` guts from spilling into the goal when we're just trying to `rw` some inverses or compositions.

As an example, you can see `rw [inverse_eval, ←to_fn]` in `inverse_eq` can now just be `rw [inverse_eval]`. Previously, `rw [inverse_eval]` would've expanded the lambda, setting the reader on a wrong path.

## Playthrough

I've only needed to do minimal changes in the existing proofs (included in the PR).

I haven't gone through exercises yet so I took @rkirov's [solutions to 3.3](https://raw.githubusercontent.com/rkirov/analysis/refs/heads/main/analysis/Analysis/Section_3_3.lean). After applying this patch, I've needed to slightly tweak a few of them, with the last change being a good motivating example:

```diff
diff --git a/analysis/Analysis/Section_3_3.lean b/analysis/Analysis/Section_3_3.lean
index 07c6f78..6cebfb4 100644
--- a/analysis/Analysis/Section_3_3.lean
+++ b/analysis/Analysis/Section_3_3.lean
@@ -105,8 +105,8 @@ theorem Function.to_fn_eq {X Y: Set} (f g: Function X Y): f.to_fn = g.to_fn ↔
   constructor
   . intro h
     ext x y
-    congr!
+    rw [h]
   . intro h
     rw [h]
 
@@ -715,6 +715,7 @@ example : ∃ X Y Z:Set, ∃ f: Function X Y, ∃ g g': Function Y Z, g ○ f =
   use Function.mk_fn (fun n ↦ n)
   constructor
   . ext x
+    simp only [Function.eval_of]
     repeat rw [← Function.eval]
   . intro h
     simp at h
@@ -736,7 +737,7 @@ theorem Function.comp_injective {X Y Z:Set} {f: Function X Y} {g : Function Y Z}
   by_contra hn
   have := hinj hn
   rw [comp_eval] at this
-  simp_all only [Subtype.forall, ne_eq, not_false_eq_true, forall_eq, not_true_eq_false, imp_false]
+  simp_all only [ne_eq, not_false_eq_true, eval_of, not_true_eq_false, imp_false]
 
 example : ∃ X Y Z:Set, ∃ f : Function X Y, ∃ g : Function Y Z, (g ○ f).one_to_one ∧ ¬ g.one_to_one := by
   use {0}
@@ -878,8 +879,7 @@ theorem Function.inclusion_comp (X Y Z:Set) (hXY: X ⊆ Y) (hYZ: Y ⊆ Z) :
 
 theorem Function.comp_id {A B:Set} (f: Function A B) : f ○ Function.id A = f := by
   ext x
-  repeat rw [← eval]
-  repeat rw [id_eval]
+  repeat rw [← eval, eval_of]
 
 theorem Function.id_comp {A B:Set} (f: Function A B) : Function.id B ○ f = f := by
   ext x
@@ -904,6 +904,7 @@ theorem Function.inv_comp {A B:Set} (f: Function A B) (hf: f.bijective) :
   rw [inverse_comp_self]
 
 open Classical
 theorem Function.glue {X Y Z:Set} (hXY: Disjoint X Y) (f: Function X Z) (g: Function Y Z) :
     ∃! h: Function (X ∪ Y) Z, (h ○ Function.inclusion (SetTheory.Set.subset_union_left X Y) = f)
     ∧ (h ○ Function.inclusion (SetTheory.Set.subset_union_right X Y) = g) := by
@@ -926,7 +927,7 @@ theorem Function.glue {X Y Z:Set} (hXY: Disjoint X Y) (f: Function X Z) (g: Func
       have F_at_x : F ⟨x.val, hunion⟩ = f x := by
         rw [hF, Function.eval_of, dif_pos x.property]
       rw [comp_eval]
-      have inc_eval : (fun x ↦ choose ((inclusion (SetTheory.Set.subset_union_left X Y)).unique x)) x =
+      have inc_eval : (inclusion (SetTheory.Set.subset_union_left X Y)) x =
          ⟨x, ((SetTheory.Set.subset_union_left X Y) x) x.property⟩  := by
         rw [eval_of]
       rw [inc_eval, F_at_x]
@@ -945,7 +946,7 @@ theorem Function.glue {X Y Z:Set} (hXY: Disjoint X Y) (f: Function X Z) (g: Func
           contradiction
         rw [hF, Function.eval_of, dif_neg hneqx]
       rw [comp_eval]
-      have inc_eval : (fun x ↦ choose ((inclusion (SetTheory.Set.subset_union_right X Y)).unique x)) x =
+      have inc_eval : (inclusion (SetTheory.Set.subset_union_right X Y)) x =
          ⟨x, ((SetTheory.Set.subset_union_right X Y) x) x.property⟩  := by
         rw [eval_of]
       rw [inc_eval, F_at_x]
```

So this seems better overall.