### PR TITLE
Add missing section 8_5 and correct README cd path

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ To build the project's web page after [installing Lean](https://lean-lang.org/do
 % lake exe cache get
 % lake -R -Kenv=dev build Analysis:docs
 % lake build
-% cd book/
+% cd ../book/
 % lake exe analysis-book
 % cd ../
 ```

--- a/book/AnalysisBook.lean
+++ b/book/AnalysisBook.lean
@@ -82,6 +82,7 @@ def demoSite : Site := site AnalysisBook.Home /
   "sec82" Book.Analysis.Section_8_2
   "sec83" Book.Analysis.Section_8_3
   "sec84" Book.Analysis.Section_8_4
+  "sec85" Book.Analysis.Section_8_5
   "sec91" Book.Analysis.Section_9_1
   "sec92" Book.Analysis.Section_9_2
   "sec93" Book.Analysis.Section_9_3


### PR DESCRIPTION
### Problem
1. The verso build configuration omitted `section 8_5`, causing Chapter 8.5 to not appear.  
2. In README.md under "Building the project's web page", the step `cd book/` should be `cd ../book/`.

### Changes
- Updated the verso build configuration to include `section 8_5`.  
- Modified README.md: changed `cd book/` to `cd ../book/` under the "Building the project's web page" section.