### PR TITLE
Add another coercion lemma to 3.1

### DIFF
--- a/analysis/Analysis/Section_3_1.lean
+++ b/analysis/Analysis/Section_3_1.lean
@@ -669,6 +669,10 @@ lemma SetTheory.Set.nat_equiv_coe_of_coe (n:ℕ) : ((n:Nat):ℕ) = n :=
 lemma SetTheory.Set.nat_equiv_coe_of_coe' (n:Nat) : ((n:ℕ):Nat) = n :=
   Equiv.symm_apply_apply nat_equiv.symm n
 
+@[simp]
+lemma SetTheory.Set.nat_equiv_coe_of_coe'' (n:ℕ) : ((ofNat(n):Nat):ℕ) = n :=
+  nat_equiv_coe_of_coe n
+
 
 /-- Example 3.1.16 (simplified).  -/
 example : ({3, 5}:Set) ⊆ {1, 3, 5} := by


### PR DESCRIPTION
I got a bit stuck in 3.3 exercises without it. Maybe using `nat` wasn't the wisest approach but I did this:

```lean
example : ∃ (X Y Z:Set) (f: Function X Y) (g : Function Y Z),
    (g ○ f).one_to_one ∧ ¬g.one_to_one := by
  use nat, nat, nat
  use Function.mk_fn (fun x ↦ (x:ℕ) * (2:ℕ))
  use Function.mk_fn (fun x ↦ (x:ℕ) / (2:ℕ))
  constructor
  · simp
  rw [Function.one_to_one_iff]
  push_neg
  use (0: nat), (1: nat)
  simp
```

And then, without this lemma, the last `simp` would get stuck at

```
⊢ SetTheory.Set.nat_equiv.symm 0 / 2 = SetTheory.Set.nat_equiv.symm 1 / 2
```

whereas what I needed was

```
⊢ 0 / 2 = 1 / 2
```

which is true with `ℕ`.

I couldn't use the existing lemmas (I think?) because the inner `0` is actually a `Nat` itself. So I needed `((ofNat(n):Nat):ℕ)` to "catch" this pattern. Catching it here (rather than when it's less "nested") seems good because otherwise there's a risk of recursion. Whereas here we just eliminate two coercions that cancel out.

## Playthrough

This gets my proof working. I didn't see any `simp`s get stuck elsewhere. Applying this to @rkirov's fork also doesn't break it.