### PR TITLE
Open Classical for 3.3.8 (d) and add stub for (e)

### DIFF
--- a/analysis/Analysis/Section_3_3.lean
+++ b/analysis/Analysis/Section_3_3.lean
@@ -527,6 +527,11 @@ theorem Function.glue {X Y Z:Set} (hXY: Disjoint X Y) (f: Function X Z) (g: Func
     ∃! h: Function (X ∪ Y) Z, (h ○ Function.inclusion (SetTheory.Set.subset_union_left X Y) = f)
     ∧ (h ○ Function.inclusion (SetTheory.Set.subset_union_right X Y) = g) := by sorry
 
-
+open Classical in
+theorem Function.glue' {X Y Z:Set} (f: Function X Z) (g: Function Y Z)
+    (hfg : ∀ x : ((X ∩ Y): Set), f ⟨x.val, by aesop⟩ = g ⟨x.val, by aesop⟩)  :
+    ∃! h: Function (X ∪ Y) Z, (h ○ Function.inclusion (SetTheory.Set.subset_union_left X Y) = f)
+    ∧ (h ○ Function.inclusion (SetTheory.Set.subset_union_right X Y) = g) := by
+  sorry
 
 end Chapter3

--- a/analysis/Analysis/Section_3_3.lean
+++ b/analysis/Analysis/Section_3_3.lean
@@ -531,7 +531,6 @@ open Classical in
 theorem Function.glue' {X Y Z:Set} (f: Function X Z) (g: Function Y Z)
     (hfg : ∀ x : ((X ∩ Y): Set), f ⟨x.val, by aesop⟩ = g ⟨x.val, by aesop⟩)  :
     ∃! h: Function (X ∪ Y) Z, (h ○ Function.inclusion (SetTheory.Set.subset_union_left X Y) = f)
-    ∧ (h ○ Function.inclusion (SetTheory.Set.subset_union_right X Y) = g) := by
-  sorry
+    ∧ (h ○ Function.inclusion (SetTheory.Set.subset_union_right X Y) = g) := by sorry
 
 end Chapter3

--- a/analysis/Analysis/Section_3_3.lean
+++ b/analysis/Analysis/Section_3_3.lean
@@ -522,6 +522,7 @@ theorem Function.comp_inv {A B:Set} (f: Function A B) (hf: f.bijective) :
 theorem Function.inv_comp {A B:Set} (f: Function A B) (hf: f.bijective) :
     f.inverse hf ○ f = Function.id A := by sorry
 
+open Classical in
 theorem Function.glue {X Y Z:Set} (hXY: Disjoint X Y) (f: Function X Z) (g: Function Y Z) :
     ∃! h: Function (X ∪ Y) Z, (h ○ Function.inclusion (SetTheory.Set.subset_union_left X Y) = f)
     ∧ (h ○ Function.inclusion (SetTheory.Set.subset_union_right X Y) = g) := by sorry


### PR DESCRIPTION
For Exercise 3.3.8 (d), I couldn't figure out how to do it constructively.

Specifically, I was getting lost about why it wouldn't let me write

```lean
  · set fg: Function (X ∪ Y) Z := Function.mk_fn (fun xy ↦
      if hxy : xy.val ∈ X then f ⟨xy.val, hxy⟩
      else g ⟨xy.val, by aesop⟩)
    use fg
```

saying 

```
failed to synthesize
  Decidable (↑xy ∈ X)
```

This sent me on a long detour until I realized `open Classical in` allows membership checks in functions.

I suggest to put it there from the beginning to avoid sending others on the same detour.

## Playthrough

```lean
open Classical in
theorem Function.glue {X Y Z:Set} (hXY: Disjoint X Y) (f: Function X Z) (g: Function Y Z) :
    ∃! h: Function (X ∪ Y) Z, (h ○ Function.inclusion (SetTheory.Set.subset_union_left X Y) = f)
    ∧ (h ○ Function.inclusion (SetTheory.Set.subset_union_right X Y) = g) := by
  apply existsUnique_of_exists_of_unique
  · set fg: Function (X ∪ Y) Z := Function.mk_fn (fun xy ↦
      if hxy : xy.val ∈ X then f ⟨xy.val, hxy⟩
      else g ⟨xy.val, by aesop⟩)
    use fg
    constructor
    · rw [eq_iff]
      intro x
      have := x.property
      aesop
    rw [eq_iff]
    rw [disjoint_iff] at hXY
    change X ∩ Y = ∅ at hXY
    rw [SetTheory.Set.eq_empty_iff_forall_notMem] at hXY
    intro y
    specialize hXY y
    aesop
  intro fg1 fg2 ⟨hf1, hf2⟩ ⟨hg1, hg2⟩
  rw [eq_iff]
  intro xy
  have hX : X ⊆ (X ∪ Y) := by apply SetTheory.Set.subset_union_left
  have hY : Y ⊆ (X ∪ Y) := by apply SetTheory.Set.subset_union_right
  simp only [eq_iff, comp_eval] at *
  by_cases hxy : xy.val ∈ X
  · set x : X := ⟨xy.val, hxy⟩
    have : xy = inclusion hX x := by rw [Function.eval]
    rw [this, hf1, hg1]
  by_cases hxy : xy.val ∈ Y
  · set y : Y := ⟨xy.val, hxy⟩
    have : xy = inclusion hY y := by rw [Function.eval]
    rw [this, hf2, hg2]
  have := xy.property
  aesop
```