### PR TITLE
Some adjustments to 3.4

### DIFF
--- a/analysis/Analysis/Section_3_1.lean
+++ b/analysis/Analysis/Section_3_1.lean
@@ -673,6 +673,16 @@ lemma SetTheory.Set.nat_equiv_coe_of_coe' (n:Nat) : ((n:ℕ):Nat) = n :=
 lemma SetTheory.Set.nat_equiv_coe_of_coe'' (n:ℕ) : ((ofNat(n):Nat):ℕ) = n :=
   nat_equiv_coe_of_coe n
 
+@[simp]
+lemma SetTheory.Set.nat_coe_eq_iff' {m: Nat} {n : ℕ} : (m:Object) = (ofNat(n):Object) ↔ (m:ℕ) = ofNat(n) := by
+  constructor
+  · intro h
+    rw [show m = n by obtain ⟨val, property⟩ := m; subst h; rfl, nat_equiv_coe_of_coe]
+    rfl
+  intro h
+  rw [show m = n by subst h; rw [nat_equiv_coe_of_coe']]
+  rfl
+
 
 /-- Example 3.1.16 (simplified).  -/
 example : ({3, 5}:Set) ⊆ {1, 3, 5} := by

--- a/analysis/Analysis/Section_3_4.lean
+++ b/analysis/Analysis/Section_3_4.lean
@@ -48,7 +48,14 @@ theorem SetTheory.Set.image_eq_specify {X Y:Set} (f:X → Y) (S: Set) :
   to make everything type consistent.
 -/
 theorem SetTheory.Set.image_eq_image {X Y:Set} (f:X → Y) (S: Set):
-    (image f S: _root_.Set Object) = Subtype.val '' (f '' {x | x.val ∈ S}) := by sorry
+    (image f S: _root_.Set Object) = Subtype.val '' (f '' {x | x.val ∈ S}) := by
+  ext y
+  simp only [_root_.Set.mem_setOf, _root_.Set.mem_image, Set.mem_image]
+  constructor
+  · rintro ⟨x, hx, rfl⟩
+    use f x, ⟨x, hx, rfl⟩
+  rintro ⟨_, ⟨x, hx, rfl⟩, rfl⟩
+  use x, hx
 
 theorem SetTheory.Set.image_in_codomain {X Y:Set} (f:X → Y) (S: Set) :
     image f S ⊆ Y := by
@@ -61,10 +68,22 @@ theorem SetTheory.Set.image_in_codomain {X Y:Set} (f:X → Y) (S: Set) :
 /-- Example 3.4.2 -/
 abbrev f_3_4_2 : nat → nat := fun n ↦ (2*n:ℕ)
 
-theorem SetTheory.Set.image_f_3_4_2 : image f_3_4_2 {1,2,3} = {2,4,6} := by sorry
+theorem SetTheory.Set.image_f_3_4_2 : image f_3_4_2 {1,2,3} = {2,4,6} := by
+  apply ext
+  intro x
+  simp only [mem_image, mem_triple, f_3_4_2]
+  constructor
+  · rintro ⟨_, (h | h | h), rfl⟩
+    · left; simp_all
+    · right; left; simp_all
+    · right; right; simp_all
+  rintro (h | h | h)
+  · use 1; simp_all
+  · use 2; simp_all
+  · use 3; simp_all
 
 /-- Example 3.4.3 is written using Mathlib's notion of image. -/
-example : (fun n:ℤ ↦ n^2) '' {-1,0,1,2} = {0,1,4} := by sorry
+example : (fun n:ℤ ↦ n^2) '' {-1,0,1,2} = {0,1,4} := by aesop
 
 theorem SetTheory.Set.mem_image_of_eval {X Y:Set} (f:X → Y) (S: Set) (x:X) :
     x.val ∈ S → (f x).val ∈ image f S := by sorry
@@ -101,7 +120,16 @@ theorem SetTheory.Set.mem_preimage' {X Y:Set} (f:X → Y) (U: Set) (x:Object) :
 
 /-- Connection with Mathlib's notion of preimage. -/
 theorem SetTheory.Set.preimage_eq {X Y:Set} (f:X → Y) (U: Set) :
-    ((preimage f U): _root_.Set Object) = Subtype.val '' (f⁻¹' {y | y.val ∈ U}) := by sorry
+    ((preimage f U): _root_.Set Object) = Subtype.val '' (f⁻¹' {y | y.val ∈ U}) := by
+  ext x
+  simp only [_root_.Set.mem_setOf, _root_.Set.mem_image]
+  simp only [Set.mem_preimage', _root_.Set.mem_preimage]
+  constructor
+  · rintro ⟨x', rfl, hy⟩
+    use x', hy
+  rintro ⟨x', hy, rfl⟩
+  simp only [_root_.Set.mem_setOf] at hy
+  use x'
 
 theorem SetTheory.Set.preimage_in_domain {X Y:Set} (f:X → Y) (U: Set) :
     (preimage f U) ⊆ X := by
@@ -109,13 +137,25 @@ theorem SetTheory.Set.preimage_in_domain {X Y:Set} (f:X → Y) (U: Set) :
   rw [preimage] at h
   exact specification_axiom h
 
-/-- Example 3.4.5 -/
-theorem SetTheory.Set.preimage_f_3_4_2 : preimage f_3_4_2 {2,4,6} = {1,2,3} := by sorry
+/-- Example 3.4.6 -/
+theorem SetTheory.Set.preimage_f_3_4_2 : preimage f_3_4_2 {2,4,6} = {1,2,3} := by
+  apply ext
+  intro x
+  simp only [mem_preimage', mem_triple, f_3_4_2]
+  constructor
+  · rintro ⟨x, rfl, (h | h | h)⟩
+    · left; simp_all
+    · right; left; simp_all; omega
+    · right; right; simp_all; omega
+  rintro (h | h | h)
+  · use 1; simp_all
+  · use 2; simp_all
+  · use 3; simp_all
 
 theorem SetTheory.Set.image_preimage_f_3_4_2 :
     image f_3_4_2 (preimage f_3_4_2 {1,2,3}) ≠ {1,2,3} := by sorry
 
-/-- Example 3.4.6 (using the Mathlib notion of preimage) -/
+/-- Example 3.4.7 (using the Mathlib notion of preimage) -/
 example : (fun n:ℤ ↦ n^2) ⁻¹' {0,1,4} = {-2,-1,0,1,2} := by sorry
 
 example : (fun n:ℤ ↦ n^2) ⁻¹' ((fun n:ℤ ↦ n^2) '' {-1,0,1,2}) ≠ {-1,0,1,2} := by sorry
@@ -129,30 +169,30 @@ abbrev SetTheory.Set.object_of {X Y:Set} (f: X → Y) : Object := function_to_ob
 theorem SetTheory.Set.power_set_axiom {X Y:Set} (F:Object) :
     F ∈ (X ^ Y) ↔ ∃ f: Y → X, object_of f = F := SetTheory.power_set_axiom X Y F
 
-/-- Example 3.4.8 -/
-abbrev f_3_4_8_a : ({4,7}:Set) → ({0,1}:Set) := fun x ↦ ⟨ 0, by simp ⟩
+/-- Example 3.4.9 -/
+abbrev f_3_4_9_a : ({4,7}:Set) → ({0,1}:Set) := fun x ↦ ⟨ 0, by simp ⟩
 
 open Classical in
-noncomputable abbrev f_3_4_8_b : ({4,7}:Set) → ({0,1}:Set) :=
+noncomputable abbrev f_3_4_9_b : ({4,7}:Set) → ({0,1}:Set) :=
   fun x ↦ if x.val = 4 then ⟨ 0, by simp ⟩ else ⟨ 1, by simp ⟩
 
 open Classical in
-noncomputable abbrev f_3_4_8_c : ({4,7}:Set) → ({0,1}:Set) :=
+noncomputable abbrev f_3_4_9_c : ({4,7}:Set) → ({0,1}:Set) :=
   fun x ↦ if x.val = 4 then ⟨ 1, by simp ⟩ else ⟨ 0, by simp ⟩
 
-abbrev f_3_4_8_d : ({4,7}:Set) → ({0,1}:Set) := fun x ↦ ⟨ 1, by simp ⟩
+abbrev f_3_4_9_d : ({4,7}:Set) → ({0,1}:Set) := fun x ↦ ⟨ 1, by simp ⟩
 
 theorem SetTheory.Set.example_3_4_8 (F:Object) :
-    F ∈ ({0,1}:Set) ^ ({4,7}:Set) ↔ F = object_of f_3_4_8_a
-    ∨ F = object_of f_3_4_8_b ∨ F = object_of f_3_4_8_c ∨ F = object_of f_3_4_8_d := by sorry
+    F ∈ ({0,1}:Set) ^ ({4,7}:Set) ↔ F = object_of f_3_4_9_a
+    ∨ F = object_of f_3_4_9_b ∨ F = object_of f_3_4_9_c ∨ F = object_of f_3_4_9_d := by sorry
 
-/-- Lemma 3.4.9.  One needs to provide a suitable definition of the power set here. -/
+/-- Lemma 3.4.10.  One needs to provide a suitable definition of the power set here. -/
 abbrev SetTheory.Set.powerset (X:Set) : Set := sorry
 
 theorem SetTheory.Set.mem_powerset {X:Set} (x:Object) :
     x ∈ powerset X ↔ ∃ Y:Set, x = Y ∧ Y ⊆ X := by sorry
 
-/-- Remark 3.4.10 -/
+/-- Remark 3.4.11 -/
 theorem SetTheory.Set.powerset_of_triple (a b c x:Object) :
     x ∈ powerset {a,b,c}
     ↔ x = (∅:Set)
@@ -164,11 +204,11 @@ theorem SetTheory.Set.powerset_of_triple (a b c x:Object) :
     ∨ x = ({b,c}:Set)
     ∨ x = ({a,b,c}:Set) := by sorry
 
-/-- Axiom 3.11 (Union) -/
+/-- Axiom 3.12 (Union) -/
 theorem SetTheory.Set.union_axiom (A: Set) (x:Object) :
     x ∈ union A ↔ ∃ (S:Set), x ∈ S ∧ (S:Object) ∈ A := SetTheory.union_axiom A x
 
-/-- Example 3.4.11 -/
+/-- Example 3.4.12 -/
 theorem SetTheory.Set.example_3_4_11 :
     union { (({2,3}:Set):Object), (({3,4}:Set):Object), (({4,5}:Set):Object) } = {2,3,4,5} := by
   sorry


### PR DESCRIPTION
- Fixed numbering to match the 4th edition
- Filled in some non-"why" examples and remarks
- Added another coercion lemma that makes `simp_all` in them work (I couldn't figure out a simpler one)