### PR TITLE
Add a stub for 3.4.10 based on the hint from the book

### DIFF
--- a/analysis/Analysis/Section_3_4.lean
+++ b/analysis/Analysis/Section_3_4.lean
@@ -202,6 +202,7 @@ theorem SetTheory.Set.example_3_4_9 (F:Object) :
  -/
 abbrev SetTheory.Set.powerset (X:Set) : Set := sorry
 
+open Classical in
 theorem SetTheory.Set.mem_powerset {X:Set} (x:Object) :
     x ∈ powerset X ↔ ∃ Y:Set, x = Y ∧ Y ⊆ X := by sorry
 

--- a/analysis/Analysis/Section_3_4.lean
+++ b/analysis/Analysis/Section_3_4.lean
@@ -196,11 +196,9 @@ theorem SetTheory.Set.example_3_4_9 (F:Object) :
     F ∈ ({0,1}:Set) ^ ({4,7}:Set) ↔ F = object_of f_3_4_9_a
     ∨ F = object_of f_3_4_9_b ∨ F = object_of f_3_4_9_c ∨ F = object_of f_3_4_9_d := by sorry
 
-/--
-  Lemma 3.4.10.  One needs to provide a suitable definition of the power set here.
-  See Exercise 3.4.6 (i) for a hint on how to construct it.
- -/
-abbrev SetTheory.Set.powerset (X:Set) : Set := sorry
+/-- Lemma 3.4.10.  One needs to provide a suitable definition of the power set here. -/
+abbrev SetTheory.Set.powerset (X:Set) : Set :=
+  (({0,1} ^ X): Set).replace (P := sorry) (by sorry)
 
 open Classical in
 theorem SetTheory.Set.mem_powerset {X:Set} (x:Object) :

--- a/analysis/Analysis/Section_3_4.lean
+++ b/analysis/Analysis/Section_3_4.lean
@@ -196,7 +196,10 @@ theorem SetTheory.Set.example_3_4_9 (F:Object) :
     F ∈ ({0,1}:Set) ^ ({4,7}:Set) ↔ F = object_of f_3_4_9_a
     ∨ F = object_of f_3_4_9_b ∨ F = object_of f_3_4_9_c ∨ F = object_of f_3_4_9_d := by sorry
 
-/-- Lemma 3.4.10.  One needs to provide a suitable definition of the power set here. -/
+/--
+  Lemma 3.4.10.  One needs to provide a suitable definition of the power set here.
+  See Exercise 3.4.6 (i) for a hint on how to construct it.
+ -/
 abbrev SetTheory.Set.powerset (X:Set) : Set := sorry
 
 theorem SetTheory.Set.mem_powerset {X:Set} (x:Object) :


### PR DESCRIPTION
This one is pretty difficult with no hints.

I forgot that it needs to use replacement, defined it as `{0, 1} ^ X`, and then got stuck on `mem_powerset` right after. It's not obvious when getting stuck that you're actually *stuck* due to a bad definition — an exercise without a solid definition to rely on felt disorienting.

The book handles this more gracefully — by the time you start filling it out, you've probably seen the hint:

<img width="1020" height="488" alt="Screenshot 2025-07-16 at 19 22 36" src="https://github.com/user-attachments/assets/26aa88c1-e2db-4d9b-a206-2f4a6483bd84" />
<img width="1242" height="266" alt="Screenshot 2025-07-16 at 19 22 46" src="https://github.com/user-attachments/assets/c134c896-5451-41b2-b626-0b46c1e44c9e" />

So I think at least surfacing the existence of this hint (if not downright spoiling it) is very useful here.