### PR TITLE
Remove Exercise 3.4.6(ii), fix Exercise 3.5.11

### DIFF
--- a/analysis/Analysis/Section_3_4.lean
+++ b/analysis/Analysis/Section_3_4.lean
@@ -186,6 +186,7 @@ instance SetTheory.Set.inst_coe_of_fun {X Y:Set} : CoeOut (X → Y) Object where
 theorem SetTheory.Set.coe_of_fun_inj {X Y:Set} (f g:X → Y) : (f:Object) = (g:Object) ↔ f = g := by
   simp [coe_of_fun]
 
+/-- Axiom 3.11 (Power set axiom) --/
 theorem SetTheory.Set.powerset_axiom {X Y:Set} (F:Object) :
     F ∈ (X ^ Y) ↔ ∃ f: Y → X, f = F := SetTheory.powerset_axiom X Y F
 
@@ -232,7 +233,12 @@ open Classical in
 theorem SetTheory.Set.mem_powerset {X:Set} (x:Object) :
     x ∈ powerset X ↔ ∃ Y:Set, x = Y ∧ Y ⊆ X := by sorry
 
-/-- Exercise 3.4.6(ii): the spirit of this exercise is to prove this result using `SetTheory.Set.mem_powerset` rather than using the power set axiom directly.-/
+theorem SetTheory.Set.exists_powerset {X:Set} (x:Object) :
+   ∃ (P: Set), x ∈ P ↔ ∃ Y:Set, x = Y ∧ Y ⊆ X := by
+  use powerset X
+  apply mem_powerset
+
+/-- Exercise 3.4.6(ii): the spirit of this exercise is to prove this result using `SetTheory.Set.exists_powerset` rather than using the power set axiom directly.-/
 theorem SetTheory.Set.powerset_axiom' {X Y:Set} : ∃ Z:Set, ∀ F:Object, F ∈ Z ↔ ∃ f: Y → X, f = F :=  by sorry
 
 /-- Remark 3.4.11 -/

--- a/analysis/Analysis/Section_3_4.lean
+++ b/analysis/Analysis/Section_3_4.lean
@@ -225,7 +225,7 @@ theorem SetTheory.Set.example_3_4_9 (F:Object) :
   · use f_3_4_9_c; exact h.symm
   · use f_3_4_9_d; exact h.symm
 
-/-- Lemma 3.4.10 / Exercise 3.4.6 (i).  One needs to provide a suitable definition of the power set here. -/
+/-- Exercise 3.4.6 (i).  One needs to provide a suitable definition of the power set here. -/
 abbrev SetTheory.Set.powerset (X:Set) : Set :=
   (({0,1} ^ X): Set).replace (P := sorry) (by sorry)
 
@@ -233,13 +233,17 @@ open Classical in
 theorem SetTheory.Set.mem_powerset {X:Set} (x:Object) :
     x ∈ powerset X ↔ ∃ Y:Set, x = Y ∧ Y ⊆ X := by sorry
 
+/-- Lemma 3.4.10 -/
 theorem SetTheory.Set.exists_powerset {X:Set} (x:Object) :
-   ∃ (P: Set), x ∈ P ↔ ∃ Y:Set, x = Y ∧ Y ⊆ X := by
+   ∃ (Z: Set), x ∈ Z ↔ ∃ Y:Set, x = Y ∧ Y ⊆ X := by
   use powerset X
   apply mem_powerset
 
-/-- Exercise 3.4.6(ii): the spirit of this exercise is to prove this result using `SetTheory.Set.exists_powerset` rather than using the power set axiom directly.-/
-theorem SetTheory.Set.powerset_axiom' {X Y:Set} : ∃ Z:Set, ∀ F:Object, F ∈ Z ↔ ∃ f: Y → X, f = F :=  by sorry
+/--
+  Exercise 3.4.6(ii): the spirit of this exercise is to prove this result using
+  `SetTheory.Set.exists_powerset` rather than using the power set axiom directly.
+-/
+theorem SetTheory.Set.powerset_axiom' {X Y:Set} : ∃ Z:Set, ∀ F:Object, F ∈ Z ↔ ∃ f: Y → X, f = F := by sorry
 
 /-- Remark 3.4.11 -/
 theorem SetTheory.Set.powerset_of_triple (a b c x:Object) :

--- a/analysis/Analysis/Section_3_4.lean
+++ b/analysis/Analysis/Section_3_4.lean
@@ -225,25 +225,16 @@ theorem SetTheory.Set.example_3_4_9 (F:Object) :
   · use f_3_4_9_c; exact h.symm
   · use f_3_4_9_d; exact h.symm
 
-/-- Exercise 3.4.6 (i).  One needs to provide a suitable definition of the power set here. -/
+/-- Exercise 3.4.6 (i). One needs to provide a suitable definition of the power set here. -/
 abbrev SetTheory.Set.powerset (X:Set) : Set :=
   (({0,1} ^ X): Set).replace (P := sorry) (by sorry)
 
 open Classical in
+/-- Lemma 3.4.10 / Exercise 3.4.6 (i) -/
 theorem SetTheory.Set.mem_powerset {X:Set} (x:Object) :
     x ∈ powerset X ↔ ∃ Y:Set, x = Y ∧ Y ⊆ X := by sorry
 
-/-- Lemma 3.4.10 -/
-theorem SetTheory.Set.exists_powerset {X:Set} (x:Object) :
-   ∃ (Z: Set), x ∈ Z ↔ ∃ Y:Set, x = Y ∧ Y ⊆ X := by
-  use powerset X
-  apply mem_powerset
-
-/--
-  Exercise 3.4.6(ii): the spirit of this exercise is to prove this result using
-  `SetTheory.Set.exists_powerset` rather than using the power set axiom directly.
--/
-theorem SetTheory.Set.powerset_axiom' {X Y:Set} : ∃ Z:Set, ∀ F:Object, F ∈ Z ↔ ∃ f: Y → X, f = F := by sorry
+/- As noted in errata, Exercise 3.4.6 (ii) is replaced by Exercise 3.5.11. -/
 
 /-- Remark 3.4.11 -/
 theorem SetTheory.Set.powerset_of_triple (a b c x:Object) :

--- a/analysis/Analysis/Section_3_4.lean
+++ b/analysis/Analysis/Section_3_4.lean
@@ -230,9 +230,15 @@ abbrev SetTheory.Set.powerset (X:Set) : Set :=
   (({0,1} ^ X): Set).replace (P := sorry) (by sorry)
 
 open Classical in
-/-- Lemma 3.4.10 / Exercise 3.4.6 (i) -/
+/-- Exercise 3.4.6 (i) -/
 theorem SetTheory.Set.mem_powerset {X:Set} (x:Object) :
     x ∈ powerset X ↔ ∃ Y:Set, x = Y ∧ Y ⊆ X := by sorry
+
+/-- Lemma 3.4.10 -/
+theorem SetTheory.Set.exists_powerset {X:Set} (x:Object) :
+   ∃ (Z: Set), x ∈ Z ↔ ∃ Y:Set, x = Y ∧ Y ⊆ X := by
+  use powerset X
+  apply mem_powerset
 
 /- As noted in errata, Exercise 3.4.6 (ii) is replaced by Exercise 3.5.11. -/
 

--- a/analysis/Analysis/Section_3_5.lean
+++ b/analysis/Analysis/Section_3_5.lean
@@ -431,12 +431,6 @@ theorem SetTheory.Set.is_graph {X Y G:Set} (hG: G ⊆ X ×ˢ Y)
   (hvert: ∀ x:X, ∃! y:Y, ((⟨x,y⟩:OrderedPair):Object) ∈ G) :
     ∃! f: X → Y, G = graph f := by sorry
 
-/-- Used by Exercise 3.5.11 -/
-lemma SetTheory.Set.exists_powerset {X:Set} (x:Object) :
-   ∃ (Z: Set), x ∈ Z ↔ ∃ Y:Set, x = Y ∧ Y ⊆ X := by
-  use powerset X
-  apply mem_powerset
-
 /--
   Exercise 3.5.11. This trivially follows from `SetTheory.Set.powerset_axiom`, but the
   exercise is to derive it from `SetTheory.Set.exists_powerset` instead.

--- a/analysis/Analysis/Section_3_5.lean
+++ b/analysis/Analysis/Section_3_5.lean
@@ -431,11 +431,17 @@ theorem SetTheory.Set.is_graph {X Y G:Set} (hG: G ⊆ X ×ˢ Y)
   (hvert: ∀ x:X, ∃! y:Y, ((⟨x,y⟩:OrderedPair):Object) ∈ G) :
     ∃! f: X → Y, G = graph f := by sorry
 
+/-- Used by Exercise 3.5.11 -/
+lemma SetTheory.Set.exists_powerset {X:Set} (x:Object) :
+   ∃ (Z: Set), x ∈ Z ↔ ∃ Y:Set, x = Y ∧ Y ⊆ X := by
+  use powerset X
+  apply mem_powerset
+
 /--
-  Exercise 3.5.11. This trivially follows from `SetTheory.Set.powerset_axiom'`, but the
-  exercise is to derive it from `SetTheory.Set.mem_powerset` instead.
+  Exercise 3.5.11. This trivially follows from `SetTheory.Set.powerset_axiom`, but the
+  exercise is to derive it from `SetTheory.Set.exists_powerset` instead.
 -/
-theorem SetTheory.Set.powerset_axiom'' (X Y:Set) :
+theorem SetTheory.Set.powerset_axiom' (X Y:Set) :
     ∃! S:Set, ∀(F:Object), F ∈ S ↔ ∃ f: Y → X, f = F := sorry
 
 /-- Exercise 3.5.12, with errata from web site incorporated -/


### PR DESCRIPTION
I don't think exercise 3.4.6 (ii) can be completed via `mem_powerset` because `mem_powerset` depends on the definition of `powerset` in its signature, which depends on `^` / `pow`, which we don't have any useful lemmas about (except `powerset_axiom`). So I think we can't actually use `mem_powerset` while avoiding `powerset_axiom` right now.

*Edit: I've removed 3.4.6 (ii) altogether as errata suggests, but I think the same problem applies to 3.5.11. [See below.](https://github.com/teorth/analysis/pull/200#issuecomment-3084762343)*

To fix this, I introduce `exists_powerset` whose signature doesn't rely on `powerset` being defined:

```js
/-- Lemma 3.4.10 -/
theorem SetTheory.Set.exists_powerset {X:Set} (x:Object) :
   ∃ (Z: Set), x ∈ Z ↔ ∃ Y:Set, x = Y ∧ Y ⊆ X := by
  use powerset X
  apply mem_powerset
```

which matches how Lemma 3.4.10 is formulated in the book:

<img width="1028" height="400" alt="Screenshot 2025-07-17 at 15 32 21" src="https://github.com/user-attachments/assets/a2a40079-4d1e-4fc5-8627-8546b63746c2" />

Then I reword Exercise 3.4.6(ii) to suggest using `exists_powerset` which isn't expressed through `powerset` or `pow`.