### PR TITLE
Fix exists_powerset definition

### DIFF
--- a/analysis/Analysis/Section_3_4.lean
+++ b/analysis/Analysis/Section_3_4.lean
@@ -235,8 +235,8 @@ theorem SetTheory.Set.mem_powerset {X:Set} (x:Object) :
     x ∈ powerset X ↔ ∃ Y:Set, x = Y ∧ Y ⊆ X := by sorry
 
 /-- Lemma 3.4.10 -/
-theorem SetTheory.Set.exists_powerset {X:Set} (x:Object) :
-   ∃ (Z: Set), x ∈ Z ↔ ∃ Y:Set, x = Y ∧ Y ⊆ X := by
+theorem SetTheory.Set.exists_powerset (X:Set) :
+   ∃ (Z: Set), ∀ x, x ∈ Z ↔ ∃ Y:Set, x = Y ∧ Y ⊆ X := by
   use powerset X
   apply mem_powerset
 


### PR DESCRIPTION
Leftover from https://github.com/teorth/analysis/pull/200.

I think I made a mistake in copypasting the definition too closely from `mem_powerset`.

In this case we're not gonna have any particular element — the claim is that we can produce a powerset for any given set.

So it seems like "for all" should go inside and the set itself should become an explicit parameter.

This is the definition from the book:

<img width="974" height="406" alt="Screenshot 2025-07-17 at 21 00 59" src="https://github.com/user-attachments/assets/edca4345-0c78-40c3-8053-c091d081300d" />


I have not playtested yet but this is the first thing I ran into trying to.