### PR TITLE
Consolidate IsCauchy.harmonic theorems

### DIFF
--- a/analysis/Analysis/Section_5_1.lean
+++ b/analysis/Analysis/Section_5_1.lean
@@ -327,7 +327,7 @@ theorem Sequence.ex_5_1_10_b : (0.1:ℚ).Steady (sqrt_two.from 1) := by sorry
 theorem Sequence.ex_5_1_10_c : (0.1:ℚ).EventuallySteady sqrt_two := by sorry
 
 
-/-- Proposition 5.1.11 -/
+/-- Proposition 5.1.11. The harmonic sequence, defined as a₁ = 1, a₂ = 1/2, ... is a Cauchy sequence. -/
 theorem Sequence.IsCauchy.harmonic : (mk' 1 (fun n ↦ (1:ℚ)/n)).IsCauchy := by
   rw [IsCauchy.mk]
   intro ε hε

--- a/analysis/Analysis/Section_5_3.lean
+++ b/analysis/Analysis/Section_5_3.lean
@@ -482,8 +482,18 @@ theorem Real.mul_right_nocancel : ¬ ∀ (x y z:Real), (hz: z = 0) → (x * z = 
 theorem Real.IsBounded.equiv {a b:ℕ → ℚ} (ha: (a:Sequence).IsBounded) (hab: Sequence.Equiv a b) :
     (b:Sequence).IsBounded := by sorry
 
-/-- Exercise 5.3.5 -/
-theorem IsCauchy.harmonic : ((fun n ↦ 1/((n:ℚ)+1): ℕ → ℚ):Sequence).IsCauchy := by sorry
+/--
+  Same as `Sequence.IsCauchy.harmonic` but reindexing the sequence as a₀ = 1, a₁ = 1/2, ...
+  This form is more convenient for the upcoming proof of Theorem 5.5.9.
+-/
+theorem Sequence.IsCauchy.harmonic' : ((fun n ↦ 1/((n:ℚ)+1): ℕ → ℚ):Sequence).IsCauchy := by
+  rw [coe]
+  intro ε hε
+  obtain ⟨ N, h1, h2 ⟩ := (Sequence.IsCauchy.mk _).mp Sequence.IsCauchy.harmonic ε hε
+  use N.toNat
+  intro j _ k _
+  specialize h2 (j+1) (by omega) (k+1) (by omega)
+  simp_all
 
 /-- Exercise 5.3.5 -/
 theorem Real.LIM.harmonic : LIM (fun n ↦ 1/((n:ℚ)+1)) = 0 := by sorry

--- a/analysis/Analysis/Section_5_5.lean
+++ b/analysis/Analysis/Section_5_5.lean
@@ -168,7 +168,7 @@ theorem Real.LUB_exist {E: Set Real} (hE: Set.Nonempty E) (hbound: BddAbove E): 
   set a : ℕ → ℚ := fun n ↦ (m n:ℚ) / (n+1)
   set b : ℕ → ℚ := fun n ↦ 1 / (n+1)
   have claim1 (n: ℕ) := Real.LUB_claim1 n hE hbound
-  have hb : (b:Sequence).IsCauchy := IsCauchy.harmonic
+  have hb : (b:Sequence).IsCauchy := Sequence.IsCauchy.harmonic'
   have hm1 (n:ℕ) : (a n:Real) ∈ upperBounds E := (claim1 n).exists.choose_spec.1
   have hm2 (n:ℕ) : ¬ ((a - b) n: Real) ∈ upperBounds E := (claim1 n).exists.choose_spec.2
   have claim2 (N:ℕ) := Real.LUB_claim2 N (by aesop) hm1 hm2


### PR DESCRIPTION
The harmonic sequence is defined in two different ways (as a sequence starting at 1 in Proposition 5.1.11 and as a sequence starting at 0 in Exercise 5.3.5). Both seem needed - the former allows the proof to follow the textbook, and the later is needed for an upcoming proof.

This PR unifies the naming and fills in the proof of `Sequence.IsCauchy.harmonic'` as a short consequence of `Sequence.IsCauchy.harmonic`.