### PR TITLE
Add another helper lemma for 3.4.7

### DIFF
--- a/analysis/Analysis/Section_3_4.lean
+++ b/analysis/Analysis/Section_3_4.lean
@@ -397,6 +397,14 @@ lemma SetTheory.Set.mem_powerset' {S S' : Set} : (S': Object) ∈ S.powerset ↔
   rw [mem_powerset]
   simp
 
+/-- Another helper lemma for Exercise 3.4.7. -/
+@[simp]
+lemma SetTheory.Set.mem_union_powerset_replace_iff {S : Set} {P : S.powerset → Object → Prop} {hP : _} {x : Object} :
+    x ∈ union (S.powerset.replace (P := P) hP) ↔
+    ∃ (S' : S.powerset) (U : Set), P S' U ∧ x ∈ U := by
+  simp only [union_axiom, replacement_axiom]
+  tauto
+
 /-- Exercise 3.4.7 -/
 theorem SetTheory.Set.partial_functions {X Y:Set} :
     ∃ Z:Set, ∀ F:Object, F ∈ Z ↔ ∃ X' Y':Set, X' ⊆ X ∧ Y' ⊆ Y ∧ ∃ f: X' → Y', F = f := by

--- a/analysis/Analysis/Section_3_4.lean
+++ b/analysis/Analysis/Section_3_4.lean
@@ -398,7 +398,6 @@ lemma SetTheory.Set.mem_powerset' {S S' : Set} : (S': Object) ∈ S.powerset ↔
   simp
 
 /-- Another helper lemma for Exercise 3.4.7. -/
-@[simp]
 lemma SetTheory.Set.mem_union_powerset_replace_iff {S : Set} {P : S.powerset → Object → Prop} {hP : _} {x : Object} :
     x ∈ union (S.powerset.replace (P := P) hP) ↔
     ∃ (S' : S.powerset) (U : Set), P S' U ∧ x ∈ U := by


### PR DESCRIPTION
Follow-up to https://github.com/teorth/analysis/pull/242.

Without this lemma, I couldn't figure out how to avoid repeating the `union` construction in the proof.

In #242, I've managed avoiding repetition with `rw [mem_iUnion]` but that felt like cheating. Relying on `iUnion` explicitly felt like a slight tangent compared to the book exercise, it only worked for the outer layer, and it was still very difficult to know what the goal is when proving the inverse direction. (I wouldn't "see" it without Claude.)

So I've extracted the essence of the "parse the union of a powerset replacement" which seems like the most natural way to solve this exercise. This lemma also makes the goal easy to follow when proving the inverse.

It also hints a bit stronger at how to solve the exercise (which seems fine because the book also hints at it).

## Playthrough

There's a nice rhythm to extraction now, and the inverse direction is straightforward.

```lean
/-- Exercise 3.4.7 -/
theorem SetTheory.Set.partial_functions {X Y:Set} :
    ∃ Z:Set, ∀ F:Object, F ∈ Z ↔ ∃ X' Y':Set, X' ⊆ X ∧ Y' ⊆ Y ∧ ∃ f: X' → Y', F = f := by
  use union (Y.powerset.replace (P := fun oY' outer ↦
    outer = union (X.powerset.replace (P := fun oX' inner ↦
      ∃ (X' Y' : Set), oX'.val = X' ∧ oY'.val = Y' ∧ inner = (Y' ^ X': Set)
    ) (by simp_all))
  ) (by simp_all))
  intro F
  constructor
  · intro hF
    simp only [mem_union_powerset_replace_iff, EmbeddingLike.apply_eq_iff_eq] at hF
    obtain ⟨⟨oY', hY'⟩, _, rfl, hF⟩ := hF
    simp only [mem_union_powerset_replace_iff, EmbeddingLike.apply_eq_iff_eq] at hF
    obtain ⟨⟨oX', hY'⟩, _, hF, _⟩ := hF
    simp only [EmbeddingLike.apply_eq_iff_eq] at hF
    obtain ⟨X', Y', rfl, rfl, rfl⟩ := hF
    simp_all only [mem_powerset', powerset_axiom]
    tauto
  rintro ⟨X', Y', hX', hY', f, rfl⟩
  simp_all [mem_union_powerset_replace_iff, EmbeddingLike.apply_eq_iff_eq,
    exists_eq_left, Subtype.exists]
  use Y', by simp_all
  use X', by simp_all
  use Y' ^ X', by simp_all
  rw [powerset_axiom]
  use f
```