### PR TITLE
Remove unused junk variables

### DIFF
--- a/analysis/Analysis/Section_3_4.lean
+++ b/analysis/Analysis/Section_3_4.lean
@@ -21,7 +21,7 @@ namespace Chapter3
 
 export SetTheory (Set Object nat)
 
-variable [SetTheory] (X : Type) (S : _root_.Set X) (f : X → X)
+variable [SetTheory]
 
 /-- Definition 3.4.1.  Interestingly, the definition does not require S to be a subset of X. -/
 abbrev SetTheory.Set.image {X Y:Set} (f:X → Y) (S: Set) : Set :=


### PR DESCRIPTION
These show up in tactic state but are misleading.

They were originally added in https://github.com/teorth/analysis/pull/171. However, it doesn't work anyway because the docblock is currently *above* these variables. So it's already broken regardless on `main`: https://teorth.github.io/analysis/sec34/

I think these should be removed and this pattern should be avoided — it's not good to pollute tactic state. I've considered a few alternatives:

- Can replace `f '' S` and `f ⁻¹' S` with `Set.image` and `Set.preimage` in the docstring which would work fine.
- Can add a `variable` block above the docstring and nest them together in a `section`. Though it's a bit weird if only done on one page. Maybe could do it consistently. But the only other page that needs it so far is `7_1`. 
- Maybe there's some legit way to not try to resolve *some* of the docstring? I tried reading Verso docs and didn't find anything.

Regardless, section 3.1 [already has](https://teorth.github.io/analysis/sec31/) a lot of red squiggles, and generally it feels like there's no solid approach that we're sticking with, so at least I'd like to remove the tactic state pollution, and then reevaluate what to do (while avoiding polluting the scope again). Also, if there's some consistent approach to this, it would've been nice if breaking these failed the build in the future.