### PR TITLE
Add equality lemma for mk_cartesian

### DIFF
--- a/analysis/Analysis/Section_3_5.lean
+++ b/analysis/Analysis/Section_3_5.lean
@@ -120,7 +120,7 @@ theorem SetTheory.Set.snd_of_mk_cartesian {X Y:Set} (x:X) (y:Y) :
   simp [z, mk_cartesian, Subtype.val_inj] at hx ⊢; rw [←hx.2]
 
 @[simp]
-theorem SetTheory.Set.mk_cartesian_eq {X Y: Set} (z: X ×ˢ Y) :
+theorem SetTheory.Set.mk_cartesian_fst_snd_eq {X Y: Set} (z: X ×ˢ Y) :
     (mk_cartesian (fst z) (snd z)) = z := by
   rw [mk_cartesian, Subtype.mk.injEq, pair_eq_fst_snd]
 


### PR DESCRIPTION
Taken from @rkirov's [work](https://github.com/rkirov/analysis/blob/main/analysis/Analysis/Section_3_5.lean).

Without it, equivalences below can get gnarly.
I figured it's fine to add because it's equivalent to `pair_eq_fst_snd`.

## Playthrough

These work now:

```lean
noncomputable abbrev SetTheory.Set.prod_commutator (X Y:Set) : X ×ˢ Y ≃ Y ×ˢ X where
  toFun := fun z ↦ mk_cartesian (snd z) (fst z)
  invFun := fun z ↦ mk_cartesian (snd z) (fst z)
  left_inv := by intro p; simp
  right_inv := by intro p; simp

noncomputable abbrev SetTheory.Set.prod_associator (X Y Z:Set) : (X ×ˢ Y) ×ˢ Z ≃ X ×ˢ (Y ×ˢ Z) where
  toFun := fun p ↦
    let x := fst (fst p)
    let y := snd (fst p)
    let z := snd p
    mk_cartesian x (mk_cartesian y z)
  invFun := fun p ↦
    let x := fst p
    let y := fst (snd p)
    let z := snd (snd p)
    mk_cartesian (mk_cartesian x y) z
  left_inv := by intro p; simp
  right_inv := by intro p; simp
```