### PR TITLE
Fill in a bit of SetTheory.Set.prod_equiv_prod

### DIFF
--- a/analysis/Analysis/Section_3_5.lean
+++ b/analysis/Analysis/Section_3_5.lean
@@ -138,10 +138,14 @@ noncomputable abbrev SetTheory.Set.prod_associator (X Y Z:Set) : (X ×ˢ Y) ×ˢ
   left_inv := sorry
   right_inv := sorry
 
-/-- Connections with the Mathlib set product -/
+/--
+  Connections with the Mathlib set product, which consists of Lean pairs like `(x, y)`
+  equipped with a proof that `x` is in the left set, and `y` is in the right set.
+  Lean pairs like `(x, y)` are similar to our `OrderedPair`, but more general.
+-/
 noncomputable abbrev SetTheory.Set.prod_equiv_prod (X Y:Set) :
     ((X ×ˢ Y):_root_.Set Object) ≃ (X:_root_.Set Object) ×ˢ (Y:_root_.Set Object) where
-  toFun := sorry
+  toFun := fun z ↦ ⟨(fst z, snd z), by simp⟩
   invFun := sorry
   left_inv := sorry
   right_inv := sorry


### PR DESCRIPTION
I think this is pretty difficult to guess because we're implicitly introducing several things at the same time:

- Lean pairs/product
- Casting stuff to objects before putting them in Lean pairs
- Need to include proofs of being in the corresponding sets

I couldn't understand even the desired shape because I didn't realize pairs are a thing.

I think it's fine to fill in `toFun` as a hint and to let the reader explore the types.