### PR TITLE
Disable wavy red underline for errors

### DIFF
--- a/book/static_files/style.css
+++ b/book/static_files/style.css
@@ -59,3 +59,8 @@ div.declaration {
     margin-top: 1em;
     margin-bottom: 1em;
 }
+
+/* HACK: disable wavy red underline for errors, because they are quite common in docstrings */
+.hl.lean .has-info.error :not(.tactic-state):not(.tactic-state *) {
+    text-decoration: none !important;
+}

--- a/serve.py
+++ b/serve.py
@@ -23,7 +23,7 @@ if __name__ == '__main__':
     PORT = 8000
     handler = CustomHTTPRequestHandler
     with HTTPServer(("", PORT), handler) as httpd:
-        print(f"Serving at http://localhost:{PORT}/analysis")
+        print(f"Serving at http://localhost:{PORT}/analysis/")
         print(f"/analysis: {BOOK_SITE}")
         print(f"/analysis/docs: {DOCS_SITE}")
         httpd.serve_forever()


### PR DESCRIPTION
No more red underlines here

<img width="584" height="128" alt="image" src="https://github.com/user-attachments/assets/59e48ad8-84a3-40c8-975a-af2d470e1ffd" />
