### PR TITLE
Add SetTheory.Set.mem_insert and mark it as simp

### DIFF
--- a/analysis/Analysis/Section_3_1.lean
+++ b/analysis/Analysis/Section_3_1.lean
@@ -204,7 +204,7 @@ instance SetTheory.Set.instInsert : Insert Object Set where
   insert x X := {x} ∪ X
 
 @[simp]
-theorem SetTheory.Set.mem_insert (x y: Object) (X: Set) : x ∈ insert y X ↔ x = y ∨ x ∈ X := by
+theorem SetTheory.Set.mem_insert (a b: Object) (X: Set) : a ∈ insert b X ↔ a = b ∨ a ∈ X := by
   simp [instInsert]
 
 /-- Axiom 3.3(b) (pair).  Note: in some applications one may have to cast {a,b}


### PR DESCRIPTION
I've noticed there's no helper lemma for unwrapping >3 item sets in examples without referring to the insert instance.
Let's add one.

This will also be useful for stating Example 3.5.5 in https://github.com/teorth/analysis/pull/267.