### PR TITLE
Hint at the shape in iProd_equiv_pi.toFun

### DIFF
--- a/analysis/Analysis/Section_3_5.lean
+++ b/analysis/Analysis/Section_3_5.lean
@@ -236,7 +236,8 @@ noncomputable abbrev SetTheory.Set.iProd_equiv_prod_triple (X: ({0,1,2}:Set) →
 /-- Connections with Mathlib's `Set.pi` -/
 noncomputable abbrev SetTheory.Set.iProd_equiv_pi (I:Set) (X: I → Set) :
     iProd X ≃ Set.pi .univ (fun i:I ↦ ((X i):_root_.Set Object)) where
-  toFun := sorry
+  toFun := fun t ↦
+    ⟨sorry, by sorry⟩
   invFun := sorry
   left_inv := sorry
   right_inv := sorry


### PR DESCRIPTION
I'm not sure what's a good way to describe `Set.pi` so I didn't touch the comment. But the shape itself was non-obvious.

In particular, the goal is `⊢ ↑(Set.univ.pi fun i ↦ {x | x ∈ X i})` and it's just tricky to guess what actually needs to happen. I've only figured it out with Claude's help. I guess you can always unfold definitions but this one is still confusing with multiple levels of transformation and notation.

Anyway, just seeing this shape gives you enough to put the cursor in and have a sense of what's actually needed (an `I.toSubtype → Object` and a `sorry ∈ Set.univ.pi fun i ↦ {x | x ∈ X i}` for it). So from that point I think the reader can figure it out.

## Playthrough

```lean
noncomputable abbrev SetTheory.Set.iProd_equiv_pi (I:Set) (X: I → Set) :
    iProd X ≃ Set.pi .univ (fun i:I ↦ ((X i):_root_.Set Object)) where
  toFun := fun t ↦
    have h := (mem_iProd _).mp t.property
    have x := h.choose
    ⟨fun i ↦ x i, by simp⟩
  invFun := fun x ↦ ⟨tuple fun i ↦
    ⟨x.val i, by have := x.property i; aesop⟩
  , by apply tuple_mem_iProd⟩
  left_inv := by
    intro t
    have h := (mem_iProd _).mp t.property
    have ht := h.choose_spec
    ext
    rw [ht, tuple_inj]
  right_inv := by
    intro x
    ext ⟨i, hi⟩
    dsimp only []
    generalize_proofs _ h
    have ht := h.choose_spec
    rw [tuple_inj] at ht
    rw [←ht]
```