### PR TITLE
Add custom ext lemma for 3.5.2

### DIFF
--- a/analysis/Analysis/Section_3_5.lean
+++ b/analysis/Analysis/Section_3_5.lean
@@ -353,7 +353,11 @@ structure SetTheory.Set.Tuple (n:ℕ) where
   x: SetTheory.Set.Fin n → X
   surj: Function.Surjective x
 
-/-- A helper lemma so the `ext` tactic doesn't get stuck on dependent types. -/
+/--
+  Custom extensionality lemma for Exercise 3.5.2.
+  Placing `@[ext]` on the structure would generate a lemma requiring proof of `t.x = t'.x`,
+  but these functions have different types when `t.X ≠ t'.X`. This lemma handles that part.
+-/
 @[ext]
 lemma SetTheory.Set.Tuple.ext {n:ℕ} {t t':Tuple n}
     (hX : t.X = t'.X)


### PR DESCRIPTION
See discussion in [#Analysis I > Getting stuck with a HEq goal in 3.5.2 @ 💬](https://leanprover.zulipchat.com/#narrow/channel/514017-Analysis-I/topic/Getting.20stuck.20with.20a.20HEq.20goal.20in.203.2E5.2E2/near/533672105).

In the absence of this lemma, `ext` would get you into a corner with ` ⊢ HEq t.x t'.x`. This lemma avoids dependent types hell by hiding the necessary substitution, leaving the reader with just the mathematical content.

## Playthrough

```lean
theorem SetTheory.Set.Tuple.eq {n:ℕ} (t t':Tuple n) :
    t = t' ↔ ∀ n : Fin n, ((t.x n):Object) = ((t'.x n):Object) := by
  constructor
  · rintro rfl
    simp
  intro h
  ext o
  · constructor
    · intro ho
      let x : t.X := ⟨o, ho⟩
      have ⟨m, hm⟩ := t.surj x
      have : (t.x m) = o := by simp_all only [x]
      rw [← this, h m]
      use (t'.x m).property
    intro ho
    let x' : t'.X := ⟨o, ho⟩
    have ⟨m, hm⟩ := t'.surj x'
    have : (t'.x m) = o := by simp_all only [x']
    rw [← this, (h m).symm]
    use (t.x m).property
  apply h
```