### PR TITLE
chore: check dependency version consistency

### DIFF
--- a/.github/workflows/check-version-consistency.yml
+++ b/.github/workflows/check-version-consistency.yml
@@ -1,0 +1,86 @@
+name: Validate Subverso Package Hashes
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  validate-json:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      
+    - name: Validate subverso package hashes
+      run: |
+        set -e
+        
+        echo "Checking expected version from book/lake-manifest.json..."
+        
+        # Get expected version from the primary file
+        if ! expected_version=$(jq -r '.packages[] | select(.name == "subverso") | .rev' book/lake-manifest.json 2>/dev/null); then
+          echo "::error::Failed to extract SubVerso hash from book/lake-manifest.json"
+          echo "::error::This means the respository structure has changed and this script needs updating."
+          exit 1
+        fi
+        
+        # Check if the result is non-empty
+        if [[ -z "$expected_version" || "$expected_version" == "null" ]]; then
+          echo "::error::No subverso package found or empty hash in book/lake-manifest.json"
+          echo "::error::This means the respository structure has changed and this script needs updating."
+          exit 1
+        fi
+        
+        echo "Expected version: $expected_version"
+        
+        echo "Finding all lake-manifest.json files..."
+        manifest_files=$(find . -name "lake-manifest.json" -type f)
+        
+        if [[ -z "$manifest_files" ]]; then
+          echo "::error::No lake-manifest.json files found in repository"
+          echo "::error::This means the respository structure has changed and this script needs updating."
+          exit 1
+        fi
+        
+        echo "Found files:"
+        echo "$manifest_files"
+        echo ""
+        
+        # Check each manifest file
+        exit_code=0
+        
+        while IFS= read -r file; do
+          echo "Checking $file..."
+          
+          if ! current_hash=$(jq -r '.packages[] | select(.name == "subverso") | .rev' "$file" 2>/dev/null); then
+            echo "::error::Failed to extract subverso hash from $file"
+            exit_code=1
+            continue
+          fi
+          
+          if [[ -z "$current_hash" || "$current_hash" == "null" ]]; then
+            echo "::error::No subverso package found or empty hash in $file"
+            exit_code=1
+            continue
+          fi
+          
+          if [[ "$current_hash" != "$expected_version" ]]; then
+            echo "::error::Hash mismatch in $file"
+            echo "::error::Expected: $expected_version"
+            echo "::error::Found: $current_hash"
+            exit_code=1
+          else
+            echo "✓ Hash matches: $current_hash"
+          fi
+        done <<< "$manifest_files"
+        
+        if [[ $exit_code -ne 0 ]]; then
+          echo ""
+          echo "::error::Mismatched versions of SubVerso. Please run ./sync-versions.sh in the respository"
+          echo "::error::root to fix the situation."
+          exit 1
+        fi
+        
+        echo ""
+        echo "✓ All SubVerso package hashes match across all lake-manifest.json files"

--- a/sync-versions.sh
+++ b/sync-versions.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+set -e
+
+# This repository uses the library `SubVerso` to extract information
+# from the code respository and use it in the website. SubVerso is
+# compatible with every Lean release, allowing the book to use a
+# different version than the Mathlib development. The versions of the
+# library must match, however.
+#
+# The CI script '.github/workflows/check-version-consistency.yml' makes
+# sure that the versions match. If they do not, this script can be used
+# to fix the situation.
+
+echo "Extracting SubVerso version from book/lake-manifest.json..."
+if ! expected_version=$(jq -r '.packages[] | select(.name == "subverso") | .rev' book/lake-manifest.json 2>/dev/null); then
+    echo "Error: Failed to extract 'subverso' hash from book/lake-manifest.json"
+    exit 1
+fi
+
+if [[ -z "$expected_version" || "$expected_version" == "null" ]]; then
+    echo "Error: No 'subverso' package found or empty hash in book/lake-manifest.json"
+    exit 1
+fi
+
+echo "Version: $expected_version"
+
+# Check if analysis/lake-manifest.json exists
+if [[ ! -f "analysis/lake-manifest.json" ]]; then
+    echo "Error: analysis/lake-manifest.json does not exist"
+    exit 1
+fi
+
+# Get current version from analysis/lake-manifest.json
+if ! current_version=$(jq -r '.packages[] | select(.name == "subverso") | .rev' analysis/lake-manifest.json 2>/dev/null); then
+    echo "Error: Failed to extract 'subverso' hash from analysis/lake-manifest.json"
+    exit 1
+fi
+
+if [[ -z "$current_version" || "$current_version" == "null" ]]; then
+    echo "Error: No 'subverso' package found in analysis/lake-manifest.json"
+    exit 1
+fi
+
+echo "Version in analysis/lake-manifest.json: $current_version"
+
+# Check if versions already match
+if [[ "$current_version" == "$expected_version" ]]; then
+    echo "Versions already match. No changes needed."
+    exit 0
+fi
+
+
+# Use sed to replace the current hash with the expected hash
+echo "Updating subverso version in analysis/lake-manifest.json..."
+if ! sed -i.tmp "s/$current_version/$expected_version/g" analysis/lake-manifest.json; then
+    echo "Error: sed replacement failed"
+    # Restore from sed's backup if it exists
+    if [[ -f "analysis/lake-manifest.json.tmp" ]]; then
+        mv analysis/lake-manifest.json.tmp analysis/lake-manifest.json
+    fi
+    exit 1
+fi
+
+# Verify the change was made correctly
+if ! updated_version=$(jq -r '.packages[] | select(.name == "subverso") | .rev' analysis/lake-manifest.json 2>/dev/null); then
+    echo "Error: Failed to verify updated hash"
+    mv analysis/lake-manifest.json.backup analysis/lake-manifest.json
+    exit 1
+fi
+
+if [[ "$updated_version" != "$expected_version" ]]; then
+    echo "Error: Hash update verification failed"
+    echo "Expected: $expected_version"
+    echo "Found: $updated_version"
+    # Restore from sed's backup if it exists
+    if [[ -f "analysis/lake-manifest.json.tmp" ]]; then
+        mv analysis/lake-manifest.json.tmp analysis/lake-manifest.json
+    fi
+    exit 1
+fi
+
+# Count the number of changes made using sed's backup
+changes=$(diff -u analysis/lake-manifest.json.tmp analysis/lake-manifest.json | grep "^[-+]" | grep -v "^[-+][-+][-+]" | wc -l)
+if [[ $changes -ne 2 ]]; then
+    echo "Warning: Expected exactly 2 diff lines (one removal, one addition), but found $changes"
+    echo "This might indicate multiple occurrences of the hash were replaced - is there a dependency hash collision?"
+fi
+
+# Clean up sed's backup file
+rm -f analysis/lake-manifest.json.tmp
+
+echo "✓ Successfully updated subverso version in analysis/lake-manifest.json"
+echo "  From: $current_version"
+echo "  To:   $expected_version"


### PR DESCRIPTION
This PR adds a check that the versions of SubVerso used in the two source directories are the same, and a script to remedy the situation if they are not.