### PR TITLE
Fix broken build due to wrong repo url

### DIFF
--- a/analysis/lake-manifest.json
+++ b/analysis/lake-manifest.json
@@ -1,7 +1,7 @@
 {"version": "1.1.0",
  "packagesDir": ".lake/packages",
  "packages":
- [{"url": "https://github.com/acmepjz/md4lean",
+ [{"url": "https://github.com/leanprover/doc-gen4",
    "type": "git",
    "subDir": null,
    "scope": "",


### PR DESCRIPTION
I'm not actually sure what broke but I was getting 

```
warning: manifest out of date: git url of dependency '«doc-gen4»' changed; use `lake update «doc-gen4»` to update it
info: doc-gen4: checking out revision '05a43fcf9c484d69252bbc3556ca0fdb2417048a'
```

both locally [and on CI](https://github.com/gaearon/analysis-solutions/actions/runs/17078118431/job/48426381566) after rebasing on the current `main`.

So I did `lake update` in the `analysis` folder and this changeset is what I got.

With this commit, my fork [no longer fails early on CI](https://github.com/gaearon/analysis-solutions/actions/runs/17078695472/job/48426708123). (The job isn't finished yet but at least it doesn't die immediately).

I don't know why it isn't failing on the origin `main`. Maybe the package moved overnight?