### PR TITLE
Fix 3.5.12 and stub out 3.5.13

### DIFF
--- a/analysis/Analysis/Section_3_5.lean
+++ b/analysis/Analysis/Section_3_5.lean
@@ -465,7 +465,7 @@ theorem SetTheory.Set.powerset_axiom' (X Y:Set) :
     ∃! S:Set, ∀(F:Object), F ∈ S ↔ ∃ f: Y → X, f = F := sorry
 
 /-- Exercise 3.5.12, with errata from web site incorporated -/
-theorem SetTheory.Set.recursion (X: Type) (f: nat → X → X) (c:X) :
+theorem SetTheory.Set.recursion (X: Set) (f: nat → X → X) (c:X) :
     ∃! a: nat → X, a 0 = c ∧ ∀ n, a (n + 1:ℕ) = f n (a n) := by sorry
 
 /-- Exercise 3.5.13 -/
@@ -473,7 +473,21 @@ theorem SetTheory.Set.nat_unique (nat':Set) (zero:nat') (succ:nat' → nat')
   (succ_ne: ∀ n:nat', succ n ≠ zero) (succ_of_ne: ∀ n m:nat', n ≠ m → succ n ≠ succ m)
   (ind: ∀ P: nat' → Prop, P zero → (∀ n, P n → P (succ n)) → ∀ n, P n) :
     ∃! f : nat → nat', Function.Bijective f ∧ f 0 = zero
-    ∧ ∀ (n:nat) (n':nat'), f n = n' ↔ f (n+1:ℕ) = succ n' := by sorry
+    ∧ ∀ (n:nat) (n':nat'), f n = n' ↔ f (n+1:ℕ) = succ n' := by
+  have nat_coe_eq {m:nat} {n} : (m:ℕ) = n → m = n := by aesop
+  have nat_coe_eq_zero {m:nat} : (m:ℕ) = 0 → m = 0 := nat_coe_eq
+  obtain ⟨f, hf⟩ := recursion nat' sorry sorry
+  apply existsUnique_of_exists_of_unique
+  · use f
+    constructor
+    · constructor
+      · intro x1 x2 heq
+        induction' hx1: (x1:ℕ) with i ih generalizing x1 x2
+        · sorry
+        sorry
+      sorry
+    sorry
+  sorry
 
 
 end Chapter3


### PR DESCRIPTION
Two things:

- Changes `(X: Type)` to `(X: Set)` in the definition of `SetTheory.Set.recursion`. Otherwise it seems impossible to use it from `SetTheory.Set.nat_unique`. An alternative would be to change it to `(X: Type u)` which works. However, I wasn't sure if that's too esoteric since we only ever call it with a set, and the original text also only talks about sets.

- I think Exercise 3.5.13 is too hard, and for bad reasons:
  - I couldn't find any way to do the induction until I saw the `induction' hx1: (x1:ℕ) with i ih generalizing x1 x2` syntax in @rkirov's solutions. Note the `hx1:` technique which I've never seen before and that doesn't even seem to be documented. Without it, you don't have the hypothesis for the zero case, and so the induction is useless.
  - Also, `generalizing x1 x2` is not obvious and can be difficult to guess (I actually got stuck on this for a few days).
  - And finally, there's more obnoxious casting required.

So I just filled in the annoying parts.

## Playthrough

```lean
/-- Exercise 3.5.12, with errata from web site incorporated -/
theorem SetTheory.Set.recursion (X: Set) (f: nat → X → X) (c:X) :
    ∃! a: nat → X, a 0 = c ∧ ∀ n, a (n + 1:ℕ) = f n (a n) := by
  apply existsUnique_of_exists_of_unique
  · let a : ℕ → X := Nat.rec c fun n x ↦ f n x
    use fun n ↦ a n
    simp_all [a]
  intro f1 f2 ⟨h1z, h1s⟩ ⟨h2z, h2s⟩
  ext x
  rw [show x = (x:ℕ) by simp]
  induction' (x:ℕ) with n hn
  · rw [show ((0:ℕ):nat) = 0 by rfl]
    cc
  rw [←Subtype.eq_iff] at hn
  rw [h1s, h2s, hn]

/-- Exercise 3.5.13 -/
theorem SetTheory.Set.nat_unique (nat':Set) (zero:nat') (succ:nat' → nat')
  (succ_ne: ∀ n:nat', succ n ≠ zero) (succ_of_ne: ∀ n m:nat', n ≠ m → succ n ≠ succ m)
  (ind: ∀ P: nat' → Prop, P zero → (∀ n, P n → P (succ n)) → ∀ n, P n) :
    ∃! f : nat → nat', Function.Bijective f ∧ f 0 = zero
    ∧ ∀ (n:nat) (n':nat'), f n = n' ↔ f (n+1:ℕ) = succ n' := by
  have nat_coe_eq {m:nat} {n} : (m:ℕ) = n → m = n := by aesop
  have nat_coe_eq_zero {m:nat} : (m:ℕ) = 0 → m = 0 := nat_coe_eq
  obtain ⟨f, ⟨⟨hz, hs⟩, hu⟩⟩ := recursion nat' (fun _ n' ↦ succ n') zero
  apply existsUnique_of_exists_of_unique
  · use f
    constructor
    · constructor
      · intro x1 x2 heq
        induction' hx1: (x1:ℕ) with i ih generalizing x1 x2
        · apply nat_coe_eq_zero at hx1
          subst hx1
          rcases hx2: (x2: ℕ) with _ | j
          · apply nat_coe_eq at hx2
            exact hx2.symm
          apply nat_coe_eq at hx2
          rw [hx2, hz, hs j] at heq
          tauto
        apply nat_coe_eq at hx1
        subst hx1
        rcases hx2: (x2: ℕ) with _ | j
        · apply nat_coe_eq_zero at hx2
          rw [hx2, hz, hs i] at heq
          tauto
        apply nat_coe_eq at hx2
        subst hx2
        rw [hs, hs j] at heq
        specialize ih ((succ_of_ne _ _).mtr heq) (by simp)
        rwa [nat_equiv_inj, ←Nat.add_right_cancel_iff, ←nat_equiv_inj] at ih
      apply ind
      · use 0
      rintro y ⟨x, rfl⟩
      use ((x:ℕ) + 1:ℕ)
      rw [hs, nat_equiv_coe_of_coe']
    constructor
    · exact hz
    intro x x'
    constructor
    · intro h
      rw [hs, nat_equiv_coe_of_coe', h]
    intro h
    rw [hs] at h
    contrapose! h
    apply succ_of_ne
    rwa [nat_equiv_coe_of_coe']
  have hind : ∀ g : nat → nat',
      g 0 = zero →
      (∀ n n', g n = n' ↔ g (n+1:ℕ) = succ n') →
      ∀ n, g ((n + 1): ℕ) = succ (g n) := by
    intro g hz hs n
    induction' n with i hi
    · rw [show (0:nat) = (0:ℕ) by rfl] at hz
      rwa [hz, ←nat_equiv_coe_of_coe 0, ←hs]
    rw [←nat_equiv_coe_of_coe (i+1), ←hs]
    simp
  intro f1 f2 ⟨_, ⟨hz1, hs1⟩⟩ ⟨_, ⟨hz2, hs2⟩⟩
  rw [hu f1 ⟨hz1, hind f1 hz1 hs1⟩]
  rw [hu f2 ⟨hz2, hind f2 hz2 hs2⟩]
```