### PR TITLE
Add another coercion simp lemma

### DIFF
--- a/analysis/Analysis/Section_3_1.lean
+++ b/analysis/Analysis/Section_3_1.lean
@@ -614,6 +614,10 @@ lemma SetTheory.Object.ofnat_eq {n:ℕ} : ((n:Nat):Object) = (n:Object) := rfl
 
 lemma SetTheory.Object.ofnat_eq' {n:ℕ} : (ofNat(n):Object) = (n:Object) := rfl
 
+@[simp]
+lemma SetTheory.Object.ofnat_eq'' {n:Nat} : ((n:ℕ):Object) = (n: Object) := by
+  unfold instNatCast Nat.cast Set.instNatCast; simp
+
 lemma SetTheory.Set.nat_coe_eq {n:ℕ} : (n:Nat) = OfNat.ofNat n := rfl
 
 @[simp]

--- a/analysis/Analysis/Section_3_5.lean
+++ b/analysis/Analysis/Section_3_5.lean
@@ -262,9 +262,6 @@ abbrev SetTheory.Set.Fin (n:ℕ) : Set := nat.specify (fun m ↦ (m:ℕ) < n)
 theorem SetTheory.Set.mem_Fin (n:ℕ) (x:Object) : x ∈ Fin n ↔ ∃ m, m < n ∧ x = m := by
   rw [specification_axiom'']; constructor
   . intro ⟨ h1, h2 ⟩; use ↑(⟨ x, h1 ⟩:nat); simp [h2]
-    calc
-      x = (⟨ x, h1 ⟩:nat) := rfl
-      _ = _ := by congr; simp
   intro ⟨ m, hm, h ⟩
   use (by rw [h, ←Object.ofnat_eq]; exact (m:nat).property)
   convert hm; simp [h, Equiv.symm_apply_eq]; rfl


### PR DESCRIPTION
We already have `SetTheory.Object.ofnat_eq` which simplifies `((n:ℕ):Nat):Object` to `n:Object`.

This is similar but it simplifies `((n:Nat):ℕ):Object` to `n:Object`. It should be fine to make it a `simp` lemma (like `ofnat_eq`) because the expression on the right is strictly simpler.

In the existing code, this led to removal of one `calc` (see below). I'm also finding it useful for at least one of the 3.6 exercises. It doesn't seem to break any of the 3.1–3.5 solutions so far, though I don't have 3.6 solutions yet.