### PR TITLE
feat: suppress warnings about 'sorry' on the command line

### DIFF
--- a/analysis/lakefile.lean
+++ b/analysis/lakefile.lean
@@ -6,6 +6,10 @@ package «Analysis» where
   leanOptions := #[
     ⟨`pp.unicode.fun, true⟩ -- pretty-prints `fun a ↦ b`
   ]
+  -- Settings applied only to command line builds
+  moreLeanArgs := #[
+    "-Dwarn.sorry=false" -- suppress warnings about `sorry` on the command line; remove when project is complete
+  ]
   -- add any additional package configuration options here
 
 -- Require Mathlib (the comprehensive library of mathematics in Lean)


### PR DESCRIPTION
This allows us to see the interesting warnings about deprecations and linter suggestions, which previously were obscured by the deluge of `sorry` warnings.