### PR TITLE
chore: replace `cc` with `grind`

### DIFF
--- a/analysis/Analysis/Section_5_3.lean
+++ b/analysis/Analysis/Section_5_3.lean
@@ -401,7 +401,7 @@ theorem Real.inv_of_equiv {a b:ℕ → ℚ} (ha: BoundedAwayZero a)
   have claim2 : P = LIM a⁻¹ := by
     simp only [P, hlim, LIM_mul hainv_cauchy hb_cauchy, LIM_mul habinv_cauchy hbinv_cauchy]
     rcongr n; simp [hb' n]
-  cc
+  grind
 
 open Classical in
 /--

--- a/analysis/Analysis/Section_7_1.lean
+++ b/analysis/Analysis/Section_7_1.lean
@@ -262,11 +262,11 @@ theorem finite_series_of_finite_series {XX YY:Type*} (X: Finset XX) (Y: Finset Y
         constructor
         . intro ⟨ ⟨ x, y ⟩, hz ⟩ ⟨ ⟨ x', y' ⟩, hz' ⟩ hzz'
           simp [π] at hz hz' hzz' ⊢
-          cc
+          grind
         intro ⟨ y, hy ⟩; use ⟨ (x₀, y), by simp [hy] ⟩
       convert map_finite_series _ hπ with z
       obtain ⟨⟨x, y⟩, hz ⟩ := z
-      simp at hz ⊢; cc
+      simp at hz ⊢; grind
     _ = _ := by
       symm; convert finite_series_of_disjoint_union _ _
       . sorry


### PR DESCRIPTION
We're hoping to deprecate the `cc` tactic, replacing it with `grind` (`cc` was a port of an ancient precursor to `grind` written, also by Leo, for Lean 3 --- it's a maintenance burden to keep it alive if we don't need it).

This PR removes all but one call to `cc`. (I'll investigate that remaining case, which isn't immediately replaceable by `grind`, elsewhere.)