### PR TITLE
Add more lemmas for 3.5 and 3.6

### DIFF
--- a/analysis/Analysis/Section_3_1.lean
+++ b/analysis/Analysis/Section_3_1.lean
@@ -622,7 +622,11 @@ lemma SetTheory.Object.ofnat_eq' {n:ℕ} : (ofNat(n):Object) = (n:Object) := rfl
 
 @[simp]
 lemma SetTheory.Object.ofnat_eq'' {n:Nat} : ((n:ℕ):Object) = (n: Object) := by
-  unfold instNatCast Nat.cast Set.instNatCast; simp
+  simp [instNatCast, Nat.cast, Set.instNatCast]
+
+@[simp]
+lemma SetTheory.Object.ofnat_eq''' {n:ℕ} {hn} : ((⟨(n:Object), hn⟩: nat): ℕ) = n := by
+  simp [instNatCast, Nat.cast, Set.instNatCast]
 
 lemma SetTheory.Set.nat_coe_eq {n:ℕ} : (n:Nat) = OfNat.ofNat n := rfl
 

--- a/analysis/Analysis/Section_3_5.lean
+++ b/analysis/Analysis/Section_3_5.lean
@@ -270,7 +270,7 @@ theorem SetTheory.Set.mem_Fin (n:ℕ) (x:Object) : x ∈ Fin n ↔ ∃ m, m < n 
   . intro ⟨ h1, h2 ⟩; use ↑(⟨ x, h1 ⟩:nat); simp [h2]
   intro ⟨ m, hm, h ⟩
   use (by rw [h, ←Object.ofnat_eq]; exact (m:nat).property)
-  convert hm; simp [h, Equiv.symm_apply_eq]; rfl
+  convert hm; simp [h]
 
 abbrev SetTheory.Set.Fin_mk (n m:ℕ) (h: m < n): Fin n := ⟨ m, by rw [mem_Fin]; use m ⟩
 

--- a/analysis/Analysis/Section_3_5.lean
+++ b/analysis/Analysis/Section_3_5.lean
@@ -294,6 +294,25 @@ theorem SetTheory.Set.Fin.coe_toNat {n:ℕ} (i: Fin n) : ((i:ℕ):Object) = (i:O
   set j := (i:ℕ); obtain ⟨ h, h':i = Fin_mk n j h ⟩ := toNat_spec i; rw [h']
 
 @[simp]
+lemma SetTheory.Set.Fin.coe_inj {n:ℕ} {i j: Fin n} : i = j ↔ (i:ℕ) = (j:ℕ) := by
+  constructor
+  · simp_all
+  intro h
+  obtain ⟨_, hi⟩ := toNat_spec i
+  obtain ⟨_, hj⟩ := toNat_spec j
+  rw [hi, hj]
+  congr
+
+@[simp]
+theorem SetTheory.Set.Fin.coe_eq_iff {n:ℕ} (i: Fin n) {j:ℕ} : (i:Object) = (j:Object) ↔ i = j := by
+  constructor
+  · intro h
+    rw [Subtype.coe_eq_iff] at h
+    obtain ⟨_, rfl⟩ := h
+    simp [←Object.natCast_inj]
+  aesop
+
+@[simp]
 theorem SetTheory.Set.Fin.toNat_mk {n:ℕ} (m:ℕ) (h: m < n) : (Fin_mk n m h : ℕ) = m := by
   have := coe_toNat (Fin_mk n m h)
   rwa [Object.natCast_inj] at this

--- a/analysis/Analysis/Section_3_6.lean
+++ b/analysis/Analysis/Section_3_6.lean
@@ -60,6 +60,10 @@ instance SetTheory.Set.EqualCard.inst_setoid : Setoid SetTheory.Set := ⟨ Equal
 /-- Definition 3.6.5 -/
 abbrev SetTheory.Set.has_card (X:Set) (n:ℕ) : Prop := X ≈ Fin n
 
+theorem SetTheory.Set.has_card_iff (X:Set) (n:ℕ) :
+    X.has_card n ↔ ∃ f: X → Fin n, Function.Bijective f := by
+  simp [has_card, HasEquiv.Equiv, Setoid.r, EqualCard]
+
 /-- Remark 3.6.6 -/
 theorem SetTheory.Set.Remark_3_6_6 (n:ℕ) :
     (nat.specify (fun x ↦ 1 ≤ (x:ℕ) ∧ (x:ℕ) ≤ n)).has_card n := by sorry
@@ -69,10 +73,6 @@ theorem SetTheory.Set.Example_3_6_7a (a:Object) : ({a}:Set).has_card 1 := by sor
 
 theorem SetTheory.Set.Example_3_6_7b {a b c d:Object} (hab: a ≠ b) (hac: a ≠ c) (had: a ≠ d)
   (hbc: b ≠ c) (hbd: b ≠ d) (hcd: c ≠ d) : ({a,b,c,d}:Set).has_card 4 := by sorry
-
-theorem SetTheory.Set.has_card_iff (X:Set) (n:ℕ) :
-    X.has_card n ↔ ∃ f: X → Fin n, Function.Bijective f := by
-  simp [has_card, HasEquiv.Equiv, Setoid.r, EqualCard]
 
 /-- Lemma 3.6.9 -/
 theorem SetTheory.Set.pos_card_nonempty {n:ℕ} (h: n ≥ 1) {X:Set} (hX: X.has_card n) : X ≠ ∅ := by


### PR DESCRIPTION
I've added another `ofnat_eq'''` lemma which I found helpful for `Remark_3_6_6`. It also slightly simplified `mem_Fin`.

I've also added a few `Fin` lemmas. Notice that I'm turning `(i: Object) = (j: Object)` into `i = j`, but I'm turning `i = j` into `(i: ℕ) = (j: ℕ)`. I think this makes sense because comparing naturals is the "simplest" form of comparing Fins, and gives us a chance of progressing further (especially combined with existing lemma that reduces a roundtrip via `ℕ`).

I rely on these in `Example_3_6_7b` (where we have `(y:ℕ) = 0` but the goal is ` Fin_mk 4 0 ⋯ = y`) or `card_erase` (which has multiple places that need them, like when we have `(y: Object) = (m₀: Object)` but need `(y:ℕ) = m₀`, etc).

Unrelated, I've moved `has_card_iff` a bit up because it's needed to unwrap the goal in `Remark_3_6_6`.

## Playthrough

```lean
theorem SetTheory.Set.Remark_3_6_6 (n:ℕ) :
    (nat.specify (fun x ↦ 1 ≤ (x:ℕ) ∧ (x:ℕ) ≤ n)).has_card n := by
  rw [has_card_iff]
  use fun x ↦ Fin_mk _ (((⟨x.val, by aesop⟩: nat): ℕ) - (1:ℕ)) (by
    have := x.property
    rw [specification_axiom''] at this
    obtain ⟨_, ⟨h1, h2⟩⟩ := this
    use Nat.sub_one_lt_of_le h1 h2)
  constructor
  · intro x y hf
    simp only [Subtype.mk.injEq, Object.natCast_inj] at hf
    have := x.property
    have := y.property
    have := Nat.sub_one_cancel (by aesop) (by aesop) hf
    aesop
  intro ⟨y, hy⟩
  rw [mem_Fin] at hy
  obtain ⟨y', hy', rfl⟩ := hy
  use ⟨y' + (1:ℕ), by
    rw [specification_axiom'']
    use ((y' + (1:ℕ)): nat).property
    aesop⟩
  simp

theorem SetTheory.Set.Example_3_6_7b {a b c d:Object} (hab: a ≠ b) (hac: a ≠ c) (had: a ≠ d)
    (hbc: b ≠ c) (hbd: b ≠ d) (hcd: c ≠ d) : ({a,b,c,d}:Set).has_card 4 := by
  rw [has_card_iff]
  use open Classical in fun x ↦ Fin_mk _ (
    if x.val = a then 0 else if x.val = b then 1 else if x.val = c then 2 else 3
  ) (by aesop)
  constructor
  · intro x1 x2 hf; aesop
  intro y
  have : y = (0:ℕ) ∨ y = (1:ℕ) ∨ y = (2:ℕ) ∨ y = (3:ℕ) := by
    have := Fin.toNat_lt y
    omega
  rcases this with (_ | _ | _ | _)
  · use ⟨a, by aesop⟩; aesop
  · use ⟨b, by aesop⟩; aesop
  · use ⟨c, by aesop⟩; aesop
  · use ⟨d, by aesop⟩; aesop

-- ...

/-- Lemma 3.6.9 -/
theorem SetTheory.Set.card_erase {n:ℕ} (h: n ≥ 1) {X:Set} (hX: X.has_card n) (x:X) :
    (X \ {x.val}).has_card (n-1) := by
  -- This proof has been rewritten from the original text to try to make it friendlier to
  -- formalize in Lean.
  rw [has_card_iff] at hX; choose f hf using hX
  set X' : Set := X \ {x.val}
  set ι : X' → X := fun ⟨y, hy⟩ ↦ ⟨ y, by aesop ⟩
  have hι (x:X') : (ι x:Object) = x := rfl
  choose m₀ hm₀ hm₀f using (mem_Fin _ _).mp (f x).property
  set g : X' → Fin (n-1) := fun x' ↦
    if h' : f (ι x') < m₀ then
      Fin_mk _ (f (ι x')) (by have := Fin.toNat_lt (f (ι x')); omega)
    else
      Fin_mk _ (f (ι x') - 1) (by
        have := Fin.toNat_lt (f (ι x'))
        have : (f (ι x'):ℕ) ≠ m₀ := by
          have := x'.property
          simp [X'] at this; contrapose! this; intros; simp [←this, Subtype.val_inj, hf.1.eq_iff, ι] at hm₀f
          simp [hm₀f]
        omega)
  have hg_def (x':X') : if (f (ι x'):ℕ) < m₀ then (g x':ℕ) = f (ι x') else (g x':ℕ) = f (ι x') - 1 := by
    by_cases h' : f (ι x') < m₀ <;> simp [g, h']
  have hg : Function.Bijective g := by
    constructor
    · intro x1' x2' hgx
      let x1 : X := ⟨x1', by have := x1'.property; simp_all [X']⟩
      let x2 : X := ⟨x2', by have := x2'.property; simp_all [X']⟩
      suffices : x1 = x2
      · aesop
      apply hf.1
      have hgx1 := hg_def x1'
      have hgx2 := hg_def x2'
      set fx1 := (f (ι x1'):ℕ)
      set fx2 := (f (ι x2'):ℕ)
      let gx := ((g x1'):ℕ)
      rw [show ((g x1'):ℕ) = gx by rfl] at hgx1
      rw [show ((g x2'):ℕ) = gx by rw [←hgx]] at hgx2
      suffices : fx1 = fx2
      · simpa [fx1, fx2]
      have hfx : ∀ (x': X'), (f (ι x'):ℕ) ≠ m₀ := by
        intro x'
        by_contra h
        have hfeq : (f x) = f (ι x') := by simp [Subtype.eq_iff, ←h, hm₀f]
        have heq : (x': Object) = x := by subst h; simp_all [hf.1 hfeq]
        have hneq : (x': Object) ≠ x := by have := x'.property; simp_all [X']
        tauto
      have := hfx x1'
      have := hfx x2'
      by_cases gx < m₀ <;> by_cases fx1 < m₀ <;> grind
    intro y
    by_cases hy : y < m₀
    · choose x2 hx2 using hf.2 (Fin_mk _ y (by omega))
      have hneq : x2 ≠ x := by
        by_contra hx2
        subst hx2
        have : y = m₀ := by simpa [hx2] using hm₀f
        omega
      let x' : X' := ⟨x2, by aesop⟩
      use x'
      specialize hg_def x'
      aesop
    choose x2 hx2 using hf.2 (Fin_mk _ (y + 1) (by have := Fin.toNat_lt y; omega))
    have hneq : x2 ≠ x := by
      by_contra hx2
      subst hx2
      have : m₀ = y + 1 := by simp_rw [hx2, Object.natCast_inj] at hm₀f; tauto
      simp_all
    let x' : X' := ⟨x2, by aesop⟩
    use x'
    specialize hg_def x'
    have : ¬(f x2 < m₀) := by simp_rw [hx2, Fin.toNat_mk]; omega
    rw [if_neg this, hx2] at hg_def
    simp_all
  use g
```