### PR TITLE
Add helper lemmas for zero cardinality

### DIFF
--- a/analysis/Analysis/Section_3_6.lean
+++ b/analysis/Analysis/Section_3_6.lean
@@ -181,8 +181,29 @@ theorem SetTheory.Set.EquivCard_to_card_eq {X Y:Set} (h: X ≈ Y): X.card = Y.ca
   simp [card, hX, hY]
 
 /-- Exercise 3.6.2 -/
-theorem SetTheory.Set.card_eq_zero {X:Set} (hX: X.finite) :
-    X.card = 0 ↔ X = ∅ := by sorry
+theorem SetTheory.Set.empty_iff_card_eq_zero {X:Set} : X = ∅ ↔ X.finite ∧ X.card = 0 := by
+  sorry
+
+lemma SetTheory.Set.empty_of_card_eq_zero {X:Set} (hX : X.finite) : X.card = 0 → X = ∅ := by
+  intro h
+  rw [empty_iff_card_eq_zero]
+  exact ⟨hX, h⟩
+
+lemma SetTheory.Set.finite_of_empty {X:Set} : X = ∅ → X.finite := by
+  intro h
+  rw [empty_iff_card_eq_zero] at h
+  exact h.1
+
+lemma SetTheory.Set.card_eq_zero_of_empty {X:Set} : X = ∅ → X.card = 0 := by
+  intro h
+  rw [empty_iff_card_eq_zero] at h
+  exact h.2
+
+@[simp]
+lemma SetTheory.Set.empty_finite : (∅: Set).finite := finite_of_empty rfl
+
+@[simp]
+lemma SetTheory.Set.empty_card_eq_zero : (∅: Set).card = 0 := card_eq_zero_of_empty rfl
 
 /-- Proposition 3.6.14 (a) / Exercise 3.6.4 -/
 theorem SetTheory.Set.card_insert {X:Set} (hX: X.finite) {x:Object} (hx: x ∉ X) :

--- a/analysis/Analysis/Section_3_6.lean
+++ b/analysis/Analysis/Section_3_6.lean
@@ -180,6 +180,10 @@ theorem SetTheory.Set.EquivCard_to_card_eq {X Y:Set} (h: X ≈ Y): X.card = Y.ca
   . choose nY hYn using hY; rw [←EquivCard_to_has_card_eq _ h] at hYn; tauto
   simp [card, hX, hY]
 
+/-- Exercise 3.6.2 -/
+theorem SetTheory.Set.card_eq_zero {X:Set} (hX: X.finite) :
+    X.card = 0 ↔ X = ∅ := by sorry
+
 /-- Proposition 3.6.14 (a) / Exercise 3.6.4 -/
 theorem SetTheory.Set.card_insert {X:Set} (hX: X.finite) {x:Object} (hx: x ∉ X) :
     (X ∪ {x}).finite ∧ (X ∪ {x}).card = X.card + 1 := by sorry
@@ -215,10 +219,6 @@ theorem SetTheory.Set.card_prod {X Y:Set} (hX: X.finite) (hY: Y.finite) :
 /-- Proposition 3.6.14 (f) / Exercise 3.6.4 -/
 theorem SetTheory.Set.card_pow {X Y:Set} (hX: X.finite) (hY: Y.finite) :
     (X ^ Y).finite ∧ (X ^ Y).card = X.card ^ Y.card := by sorry
-
-/-- Exercise 3.6.2 -/
-theorem SetTheory.Set.card_eq_zero {X:Set} (hX: X.finite) :
-    X.card = 0 ↔ X = ∅ := by sorry
 
 /-- Exercise 3.6.5. You might find `SetTheory.Set.prod_commutator` useful. -/
 theorem SetTheory.Set.prod_EqualCard_prod (A B:Set) :

--- a/analysis/Analysis/Section_3_6.lean
+++ b/analysis/Analysis/Section_3_6.lean
@@ -148,7 +148,7 @@ theorem SetTheory.Set.nat_infinite : infinite nat := by
 
 open Classical in
 /-- It is convenient for Lean purposes to give infinite sets the ``junk`` cardinality of zero. -/
-noncomputable abbrev SetTheory.Set.card (X:Set) : ℕ := if h:X.finite then h.choose else 0
+noncomputable def SetTheory.Set.card (X:Set) : ℕ := if h:X.finite then h.choose else 0
 
 theorem SetTheory.Set.has_card_card {X:Set} (hX: X.finite) : X.has_card (SetTheory.Set.card X) := by
   simp [card, hX, hX.choose_spec]
@@ -157,7 +157,7 @@ theorem SetTheory.Set.has_card_to_card (X:Set) (n: ℕ): X.has_card n → X.card
   intro h; simp [card, card_uniq (⟨ n, h ⟩:X.finite).choose_spec h]; aesop
 
 theorem SetTheory.Set.card_to_has_card (X:Set) {n: ℕ} (hn: n ≠ 0): X.card = n → X.has_card n
-  := by grind [has_card_card]
+  := by grind [card, has_card_card]
 
 theorem SetTheory.Set.card_fin_eq (n:ℕ): (Fin n).has_card n := (has_card_iff _ _).mp ⟨ id, Function.bijective_id ⟩
 


### PR DESCRIPTION
As discussed in [#Analysis I > Zero in 3.6.14 cardinality exercises @ 💬](https://leanprover.zulipchat.com/#narrow/channel/514017-Analysis-I/topic/Zero.20in.203.2E6.2E14.20cardinality.20exercises/near/536675910), `card` is annoying to deal with because `.card = 0` can mean both infinite and zero cardinality. I've played with a few ways to simplify my proofs and found these lemmas useful. There are a few changes:

- I changed `card` to `def` so that simp doesn't try to unwrap it (which I've noticed causing havoc before).
- I've moved the second part of Exercise 3.6.2 (currently called `card_eq_zero`) a bit up so that it's before all the Proposition 3.6.14 proofs. I've renamed it to `empty_iff_card_eq_zero` and changed its signature to `X = ∅ ↔ X.finite ∧ X.card = 0`. I think this is closer in spirit to the book (there's no reason to "ask" for finite cardinality here).
- I've then added a few convenience lemmas for the scenarios I've encountered. By itself, `empty_iff_card_eq_zero` is inconvenient to use because of the conjunction in my new signature. In practice, I've found that the common case is when we want to intentionally go from a broader goal (like "show cardinality is zero") to a narrower goal ("I'll just show it's actually empty") because we can often actually show that in the base case of induction. So I've added  `finite_of_empty` and `card_eq_zero_of_empty` for these purposes. I've also added a couple of simp lemmas to resolve `∅.finite` and `∅.card` directly.

## Playthrough

I haven't done all of them yet but this is how it's looking so far. I've marked the places where we rely on these new lemmas with a `-- here` comment inline.

```lean
/-- Exercise 3.6.2 -/
theorem SetTheory.Set.empty_iff_card_eq_zero {X:Set} : X = ∅ ↔ X.finite ∧ X.card = 0 := by
  constructor
  · intro h
    rw [←has_card_zero] at h
    constructor
    · use 0
    exact has_card_to_card _ _ h
  intro ⟨h1, h2⟩
  rw [←has_card_zero]
  have := has_card_card h1
  rwa [h2] at this

-- ...

/-- Proposition 3.6.14 (b) / Exercise 3.6.4 -/
theorem SetTheory.Set.card_union_disjoint {X Y:Set} (hX: X.finite) (hY: Y.finite)
    (hdisj: Disjoint X Y) : (X ∪ Y).card = X.card + Y.card := by
  obtain ⟨n, hXn⟩ := hX
  obtain ⟨m, hXm⟩ := hY
  induction' n with n ih generalizing X
  · rw [has_card_zero] at hXn
    aesop -- here
  have hxne := pos_card_nonempty (by omega) hXn
  let x := nonempty_choose hxne
  have hX'n := card_erase (by omega) hXn x
  simp only [add_tsub_cancel_right] at hX'n
  set X' := X \ {↑x}
  have : Disjoint X' Y := by
    rw [disjoint_iff] at *; ext
    simp_rw [eq_empty_iff_forall_notMem, mem_inter] at hdisj
    simp_all [X']
  specialize ih this hX'n
  replace hX'n := has_card_to_card _ _ hX'n
  replace hXn := has_card_to_card _ _ hXn
  have : (X ∪ Y).card = (X' ∪ Y).card + 1 := by
    have hf : (X' ∪ Y).finite := by
      have hX'f : X'.finite := by
        by_cases X = {↑x}
        · have : X' = ∅ := by ext; grind [not_mem_empty, mem_sdiff] -- here
          simp_all
        have := card_to_has_card _ (by omega) hXn
        have := card_erase (by omega) this x
        tauto
      have hYf : Y.finite := ⟨m, hXm⟩
      have := card_union hX'f hYf
      tauto
    have hx : ↑x ∉ X' ∪ Y := by
      simp only [mem_union, not_or, X']
      constructor
      · simp
      have := x.property
      simp only [disjoint_iff, eq_empty_iff_forall_notMem, mem_inter] at hdisj
      tauto
    have : X ∪ Y = X' ∪ Y ∪ {↑x} := by
      rw [union_assoc, union_comm Y, ←union_assoc]
      have := x.property
      have : X \ {↑x} ∪ {↑x} = X := by ext; grind [mem_union, mem_sdiff, mem_singleton]
      tauto
    have := card_insert hf hx
    simp_all
  grind

/-- Proposition 3.6.14 (c) / Exercise 3.6.4 -/
theorem SetTheory.Set.card_subset {X Y:Set} (hX: X.finite) (hY: Y ⊆ X) :
    Y.finite ∧ Y.card ≤ X.card := by
  have finite_subset : ∀ {A B: Set}, A.finite → B ⊆ A → B.finite := by
    intro A B hA hB
    have ⟨n, hAn⟩ := hA
    induction' n with n ih generalizing A B
    · apply finite_of_empty  -- here
      rw [has_card_zero] at hAn
      rw [subset_def] at hB
      aesop
    by_cases hAB : A \ B = ∅
    · have : A = B := by ext a; rw [eq_empty_iff_forall_notMem] at hAB; aesop
      rwa [←this]
    have := pos_card_nonempty (by omega) hAn
    let a := nonempty_choose hAB
    let A' := A \ {↑a}
    have hA'n := card_erase (by omega) hAn ⟨a, by have := a.property; simp_all⟩
    simp only [add_tsub_cancel_right] at hA'n
    have ha : ↑a ∉ B := by have := a.property; simp_all
    have hBA' : B ⊆ A' := by simp only [subset_def]; aesop
    aesop
  let X' := X \ Y
  have hX' : X' ⊆ X := by simp only [subset_def]; aesop
  have hX'f : X'.finite := finite_subset hX hX'
  have hYf : Y.finite := finite_subset hX hY
  use hYf
  have hd : Disjoint X' Y := by
    have := inter_compl hY
    rwa [←disjoint_iff, disjoint_comm] at this
  obtain hc := card_union_disjoint hX'f hYf hd
  have hu : X' ∪ Y = X := by
    ext a
    simp only [X', mem_union, mem_sdiff]
    constructor <;> tauto
  rw [hu] at hc
  omega

/-- Proposition 3.6.14 (c) / Exercise 3.6.4 -/
theorem SetTheory.Set.card_ssubset {X Y:Set} (hX: X.finite) (hY: Y ⊂ X) :
    Y.card < X.card := by
  have hY' : Y ⊆ X := by grind [subset_def, ssubset_def]
  let X' := (X \ Y)
  have hX'X : X' ⊆ X := by simp only [subset_def]; aesop
  have hX'f : X'.finite := (card_subset hX hX'X).1
  have hYf : Y.finite := (card_subset hX hY').1
  have hd : Disjoint X' Y := by simp [disjoint_iff, Set.ext_iff, X']
  have hc := card_union_disjoint hX'f hYf hd
  have hu : X' ∪ Y = X := by
    ext a
    simp only [X', mem_union, mem_sdiff]
    constructor <;> tauto
  rw [hu] at hc
  have : X' ≠ ∅ := by
    simp only [ssubset_def, subset_def, ne_eq, Set.ext_iff] at hY
    simp only [ne_eq, X', eq_empty_iff_forall_notMem, mem_sdiff]
    grind
  have : X'.card > 0 := by
    apply Nat.zero_lt_of_ne_zero
    intro h
    have := empty_of_card_eq_zero hX'f h -- here
    contradiction
  omega

/-- Proposition 3.6.14 (d) / Exercise 3.6.4 -/
theorem SetTheory.Set.card_image {X Y:Set} (hX: X.finite) (f: X → Y) :
    (image f X).finite ∧ (image f X).card ≤ X.card := by
  obtain ⟨n, hXn⟩ := hX
  induction' n with n ih generalizing X
  · rw [has_card_zero] at hXn
    constructor
    · apply finite_of_empty; aesop -- here
    apply le_of_eq
    simp_rw [hXn, empty_card_eq_zero] -- here
    apply card_eq_zero_of_empty
    aesop
  have hxne := pos_card_nonempty (by omega) hXn
  let x := nonempty_choose hxne
  have hX'n := card_erase (by omega) hXn x
  simp only [add_tsub_cancel_right] at hX'n
  set X' := X \ {↑x}
  let f' (x' : X') := f ⟨x', by have := x'.property; aesop⟩
  obtain ⟨hif, hic⟩ := ih f' hX'n
  have hi : image f X = (image f' X') ∪ {↑(f x)} := by
    simp only [f', X']
    ext y
    constructor
    · intro hy; rw [mem_image] at hy; obtain ⟨x2, ⟨_, rfl⟩⟩ := hy
      by_cases x = x2
      · aesop
      · rw [mem_union, mem_image]
        left; use ⟨x2, by grind [mem_sdiff, mem_singleton]⟩; grind
    intro hy; rw [mem_union] at hy; rcases hy
    · rw [mem_image] at *; grind
    · rw [mem_image]; use x, x.property; simp_all
  have hs : finite {↑(f x)} ∧ card {↑(f x)} = 1 := by
    have := card_insert empty_finite (not_mem_empty (f x)) -- here
    simp_all
  have hu := card_union hif hs.1
  rw [←hi, hs.2] at hu
  use hu.1
  have := has_card_to_card _ _ hX'n
  have := has_card_to_card _ _ hXn
  omega

/-- Proposition 3.6.14 (d) / Exercise 3.6.4 -/
theorem SetTheory.Set.card_image_inj {X Y:Set} (hX: X.finite) {f: X → Y}
    (hf: Function.Injective f) : (image f X).card = X.card := by
  obtain ⟨n, hXn⟩ := hX
  induction' n with n ih generalizing X
  · rw [has_card_to_card _ _ hXn]
    rw [has_card_zero] at hXn
    apply card_eq_zero_of_empty -- here
    simp_all [eq_empty_iff_forall_notMem]
  have hxne := pos_card_nonempty (by omega) hXn
  let x := nonempty_choose hxne
  have hX'n := card_erase (by omega) hXn x
  simp only [add_tsub_cancel_right] at hX'n
  set X' := X \ {↑x}
  let f' (x' : X') := f ⟨x', by have := x'.property; aesop⟩
  have hf' : Function.Injective f' := by intro x1 x2 heq; have := hf heq; grind
  obtain hc := ih hf' hX'n
  have hi : (image f X) = (image f' X') ∪ {↑(f x)} := by
    simp only [f', X']
    ext y
    constructor
    · intro hy; rw [mem_image] at hy; obtain ⟨x2, ⟨_, rfl⟩⟩ := hy
      by_cases x = x2
      · aesop
      · rw [mem_union, mem_image]
        left; use ⟨x2, by grind [mem_sdiff, mem_singleton]⟩; grind
    intro hy; rw [mem_union] at hy; rcases hy
    · rw [mem_image] at *; grind
    · rw [mem_image]; use x, x.property; simp_all
  have hif : (image f' X').finite := by
    use n
    by_cases hn : n = 0
    · simp_all [has_card_zero, eq_empty_iff_forall_notMem]
    · apply card_to_has_card _ hn (by simp_all [has_card_to_card _ _ hX'n])
  have hfx : ↑(f x) ∉ (image f' X') := by
    intro h; simp only [mem_image, f', X'] at h
    obtain ⟨x2, ⟨hx2, hx2'⟩⟩ := h
    have : f ⟨x2, by aesop⟩ = f x := by grind
    have : x2.val = x := by have := hf this; grind
    have : x2.val ≠ x := by rw [mem_sdiff] at hx2; simp_all
    grind
  have hic := card_insert hif hfx
  rw [hi]
  have := has_card_to_card _ _ hX'n
  have := has_card_to_card _ _ hXn
  omega

/-- Proposition 3.6.14 (e) / Exercise 3.6.4 -/
theorem SetTheory.Set.card_prod {X Y:Set} (hX: X.finite) (hY: Y.finite) :
    (X ×ˢ Y).finite ∧ (X ×ˢ Y).card = X.card * Y.card := by
  induction' hXc: X.card with n ih generalizing X
  · rw [zero_mul]
    have := has_card_card hX
    rw [hXc] at this
    have : (X ×ˢ Y).has_card 0 := by rw [has_card_zero] at *; aesop
    constructor
    · use 0
    apply has_card_to_card
    exact this
  have hXn := card_to_has_card X (by omega) hXc
  have hxne := pos_card_nonempty (by omega) hXn
  let x := nonempty_choose hxne
  have hX'n := card_erase (by omega) hXn x
  simp only [add_tsub_cancel_right] at hX'n
  set X' := X \ {↑x}
  have hX : X = X' ∪ {↑x} := by
    symm; rw [union_comm]
    apply union_compl
    simp [subset_def, x.property]
  by_cases hYz : Y = ∅
  · constructor
    · apply finite_of_empty; simp_all [Set.ext_iff] -- here
    have : Y.card = 0 := by simp_all
    rw [this, mul_zero]
    apply card_eq_zero_of_empty -- here
    simp_all [Set.ext_iff]
  have hYc : Y.card ≠ 0 := by
    rw [←has_card_zero] at hYz
    contrapose! hYz
    rw [has_card_zero]
    exact empty_of_card_eq_zero hY hYz -- here
  have hX'f: X'.finite := ⟨n, hX'n⟩
  have hX'c := has_card_to_card _ _ hX'n
  obtain ⟨hpf, hpc⟩ := ih hX'f hX'c
  simp only [hX, union_prod, add_mul, one_mul]
  have hspc : card (({↑x}: Set) ×ˢ Y) = Y.card := by
    apply EquivCard_to_card_eq
    use fun z ↦ snd z
    constructor
    · intro z1 z2 heq; ext
      rw [pair_eq_fst_snd, pair_eq_fst_snd]
      grind [mem_singleton]
    intro y
    use mk_cartesian ⟨x, by simp⟩ y
    simp
  have hspf : (({↑x}: Set) ×ˢ Y).finite := by
    use Y.card
    exact card_to_has_card _ hYc hspc
  have hdisj : Disjoint (X' ×ˢ Y) (({↑x}: Set) ×ˢ Y) := by
    simp [disjoint_iff, inter_of_prod, Set.ext_iff, X']
  have hc := card_union_disjoint hpf hspf hdisj
  rw [hpc, hspc] at hc
  constructor
  · have := card_to_has_card _ (by omega) hc
    use n * Y.card + Y.card
  exact hc
```