### PR TITLE
Replace `Quot.ind` → `Quotient.ind`

### DIFF
--- a/analysis/Analysis/Section_4_2.lean
+++ b/analysis/Analysis/Section_4_2.lean
@@ -68,9 +68,9 @@ theorem Rat.eq (a c:ℤ) {b d:ℤ} (hb: b ≠ 0) (hd: d ≠ 0): a // b = c // d 
 
 /-- Definition 4.2.1 (Rationals) -/
 theorem Rat.eq_diff (n:Rat) : ∃ a b, b ≠ 0 ∧ n = a // b := by
-  apply Quot.ind _ n; intro ⟨ a, b, h ⟩
+  apply Quotient.ind _ n; intro ⟨ a, b, h ⟩
   refine ⟨ a, b, h, ?_ ⟩
-  simp [formalDiv, h]; rfl
+  simp [formalDiv, h]
 
 /--
   Decidability of equality. Hint: modify the proof of `DecidableEq Int` from the previous

--- a/analysis/Analysis/Section_4_2.lean
+++ b/analysis/Analysis/Section_4_2.lean
@@ -57,7 +57,7 @@ theorem PreRat.eq (a b c d:ℤ) (hb: b ≠ 0) (hd: d ≠ 0) :
 abbrev Rat := Quotient PreRat.instSetoid
 
 /-- We give division a "junk" value of 0//1 if the denominator is zero -/
-abbrev Rat.formalDiv (a b:ℤ)  : Rat :=
+abbrev Rat.formalDiv (a b:ℤ) : Rat :=
   Quotient.mk PreRat.instSetoid (if h:b ≠ 0 then ⟨ a,b,h ⟩ else ⟨ 0, 1, by decide ⟩)
 
 infix:100 " // " => Rat.formalDiv

--- a/analysis/Analysis/Section_5_3.lean
+++ b/analysis/Analysis/Section_5_3.lean
@@ -102,7 +102,7 @@ theorem LIM_def {a:ℕ → ℚ} (ha: (a:Sequence).IsCauchy) :
 /-- Definition 5.3.1 (Real numbers) -/
 theorem Real.eq_lim (x:Real) : ∃ (a:ℕ → ℚ), (a:Sequence).IsCauchy ∧ x = LIM a := by
   -- I had a lot of trouble with this proof; perhaps there is a more idiomatic way to proceed
-  apply Quot.ind _ x; intro a; use (a:ℕ → ℚ)
+  apply Quotient.ind _ x; intro a; use (a:ℕ → ℚ)
   observe : ((a:ℕ → ℚ):Sequence) = a.toSequence
   rw [this, LIM_def (by convert a.cauchy)]
   refine ⟨ a.cauchy, ?_ ⟩


### PR DESCRIPTION
Rationale:

- According to the [Lean Language Reference](https://lean-lang.org/doc/reference/latest/The-Type-System/Quotients/#quotient-model), "When the relation is already an equivalence relation, Quotient should be used instead of Quot"
- I used `Quot.ind` in the proof of `equivRat`, which led to some problems