### PR TITLE
Add SetTheory.Set.pow_fun_equiv

### DIFF
--- a/analysis/Analysis/Section_3_6.lean
+++ b/analysis/Analysis/Section_3_6.lean
@@ -237,6 +237,12 @@ theorem SetTheory.Set.card_image_inj {X Y:Set} (hX: X.finite) {f: X → Y}
 theorem SetTheory.Set.card_prod {X Y:Set} (hX: X.finite) (hY: Y.finite) :
     (X ×ˢ Y).finite ∧ (X ×ˢ Y).card = X.card * Y.card := by sorry
 
+noncomputable def SetTheory.Set.pow_fun_equiv {X Y : Set} : ↑(Y ^ X) ≃ (X → Y) where
+  toFun := sorry
+  invFun := sorry
+  left_inv := sorry
+  right_inv := sorry
+
 /-- Proposition 3.6.14 (f) / Exercise 3.6.4 -/
 theorem SetTheory.Set.card_pow {X Y:Set} (hX: X.finite) (hY: Y.finite) :
     (Y ^ X).finite ∧ (Y ^ X).card = Y.card ^ X.card := by sorry
@@ -245,7 +251,10 @@ theorem SetTheory.Set.card_pow {X Y:Set} (hX: X.finite) (hY: Y.finite) :
 theorem SetTheory.Set.prod_EqualCard_prod (A B:Set) :
     EqualCard (A ×ˢ B) (B ×ˢ A) := by sorry
 
-/-- Exercise 3.6.6 -/
+noncomputable def SetTheory.Set.pow_fun_equiv' (X Y : Set) : ↑(Y ^ X) ≃ (X → Y) :=
+  pow_fun_equiv (X:=X) (Y:=Y)
+
+/-- Exercise 3.6.6. You may find `SetTheory.Set.curry_equiv` useful. -/
 theorem SetTheory.Set.pow_pow_EqualCard_pow_prod (A B C:Set) :
     EqualCard ((A ^ B) ^ C) (A ^ (B ×ˢ C)) := by sorry
 


### PR DESCRIPTION
This makes 3.6.14 (f) slightly less painful and helps significantly with `pow_pow_EqualCard_pow_prod`.

Also adding a hint to remember we have `curry_equiv`.

## Playthrough

```lean
noncomputable def SetTheory.Set.pow_fun_equiv {X Y : Set} : ↑(Y ^ X) ≃ (X → Y) where
  toFun F := ((powerset_axiom _).mp F.property).choose
  invFun f := ⟨f, (powerset_axiom _).mpr ⟨f, by simp⟩⟩
  left_inv F := by ext; exact ((powerset_axiom _).mp F.property).choose_spec
  right_inv f := by simp

-- ...

/-- Proposition 3.6.14 (f) / Exercise 3.6.4 -/
theorem SetTheory.Set.card_pow {X Y:Set} (hX: X.finite) (hY: Y.finite) :
    (Y ^ X).finite ∧ (Y ^ X).card = Y.card ^ X.card := by
  induction' hXc: X.card with n ih generalizing X
  · rw [pow_zero, empty_of_card_eq_zero hX hXc]
    have heq : Y ^ (∅: Set) ≈ Fin 1 := by
      use fun _ ↦ ⟨0, by rw [mem_Fin]; aesop⟩
      constructor
      · intro z1 z2
        simp only [forall_const]
        rw [←pow_fun_equiv.apply_eq_iff_eq]
        have := not_mem_empty
        grind
      intro y
      let f : (∅: Set) → Y := fun e ↦ by have := e.property; simp_all
      use pow_fun_equiv.symm f
      have := y.property
      rw [mem_Fin] at this
      simp_all
    constructor
    · use 1
    rw [EquivCard_to_card_eq heq, Fin_card]
  have hXn := card_to_has_card (by omega) hXc
  have hxne := pos_card_nonempty (by omega) hXn
  let x := nonempty_choose hxne
  have hX'n := card_erase (by omega) hXn x
  simp only [add_tsub_cancel_right] at hX'n
  set X' := X \ {↑x}
  have hX : X = X' ∪ {↑x} := by
    symm; rw [union_comm]
    apply union_compl
    simp [subset_def, x.property]
  have hX'f: X'.finite := ⟨n, hX'n⟩
  have hX'c := has_card_to_card hX'n
  obtain ⟨hpowf, hpowc⟩ := ih hX'f hX'c
  rw [pow_succ, ←hpowc]
  have ⟨hprodf, hprodc⟩ := card_prod hpowf hY
  have heq : Y ^ X ≈ (Y ^ X') ×ˢ Y := by
    use fun z ↦
      let f := pow_fun_equiv z
      let f' : X' → Y := fun x' ↦ f ⟨x', by have := x'.property; simp [X'] at this; grind⟩
      mk_cartesian (pow_fun_equiv.symm f') (f x)
    constructor
    · intro z1 z2 heq
      rw [←pow_fun_equiv.apply_eq_iff_eq]
      ext x2; congr
      simp only [mk_cartesian, Subtype.mk.injEq, EmbeddingLike.apply_eq_iff_eq,
        OrderedPair.mk.injEq, SetCoe.ext_iff] at heq
      by_cases hx : x = x2
      · grind
      let x2' : X' := ⟨x2, by simp only [mem_sdiff, mem_singleton, X', x2.property]; grind⟩
      have := congrArg (pow_fun_equiv · x2') heq.1
      grind
    intro z'
    let f' := ((powerset_axiom _).mp (fst z').property).choose
    simp only [Subtype.exists, powerset_axiom]
    let f : X → Y := open Classical in fun x2 ↦
      if hx2 : x2 = x then
        (snd z')
      else
        f' ⟨x2, by have := x2.property; simp [X']; grind⟩
    use f, by use f
    rw [←mk_cartesian_fst_snd_eq z']
    simp only [mk_cartesian, Subtype.mk.injEq,
      EmbeddingLike.apply_eq_iff_eq, OrderedPair.mk.injEq]
    constructor
    · simp only [pow_fun_equiv, Equiv.coe_fn_mk, Equiv.coe_fn_symm_mk]
      generalize_proofs hf
      have := hf.choose_spec
      rw [coe_of_fun_inj] at this
      rw [this]
      have hx' : ∀ (x' : X') hx'', ⟨x', hx''⟩ ≠ x := by
        intro x'
        have := x'.property
        simp only [mem_sdiff, mem_singleton, X'] at this
        grind
      simp only [hx', ↓reduceDIte, Subtype.coe_eta, f]
      generalize_proofs hf' at f'
      rw [hf'.choose_spec]
    congr
    simp only [pow_fun_equiv, Equiv.coe_fn_mk]
    generalize_proofs hf
    have := hf.choose_spec
    rw [coe_of_fun_inj] at this
    simp [this, f]
  have heqc := EquivCard_to_card_eq heq
  constructor
  · use ((Y ^ X') ×ˢ Y).card
    rw [EquivCard_to_has_card_eq heq]
    exact has_card_card hprodf
  rw [heqc]
  exact hprodc

-- ...

/-- Exercise 3.6.6. You may find `SetTheory.Set.curry_equiv` useful. -/
theorem SetTheory.Set.pow_pow_EqualCard_pow_prod (A B C:Set) :
    EqualCard ((A ^ B) ^ C) (A ^ (B ×ˢ C)) := by
  have abc_to_cab := pow_fun_equiv' C ↑(A ^ B)
  have cab_to_cba := Equiv.arrowCongr (Equiv.refl C) (pow_fun_equiv' B A)
  have cxba_to_bxca := Equiv.arrowCongr (prod_commutator C B) (Equiv.refl A)
  have cba_to_bxca := curry_equiv.trans cxba_to_bxca
  have bxca_to_abxc := (pow_fun_equiv' (B ×ˢ C) A).symm
  have abc_to_cba := abc_to_cab.trans cab_to_cba
  have abc_to_bxca := abc_to_cba.trans cba_to_bxca
  have abc_to_abxc := abc_to_bxca.trans bxca_to_abxc
  use abc_to_abxc
  exact abc_to_abxc.bijective
```