### PR TITLE
Tweak definitions for 3.6.6

### DIFF
--- a/analysis/Analysis/Section_3_6.lean
+++ b/analysis/Analysis/Section_3_6.lean
@@ -258,12 +258,12 @@ noncomputable def SetTheory.Set.pow_fun_equiv' (X Y : Set) : ↑(Y ^ X) ≃ (X �
 theorem SetTheory.Set.pow_pow_EqualCard_pow_prod (A B C:Set) :
     EqualCard ((A ^ B) ^ C) (A ^ (B ×ˢ C)) := by sorry
 
-example (a b c:ℕ): (a^b)^c = a^(b*c) := by sorry
+theorem SetTheory.Set.Exercise_3_6_6_a (a b c:ℕ): (a^b)^c = a^(b*c) := by sorry
 
 theorem SetTheory.Set.pow_prod_pow_EqualCard_pow_union (A B C:Set) (hd: Disjoint B C) :
     EqualCard ((A ^ B) ×ˢ (A ^ C)) (A ^ (B ∪ C)) := by sorry
 
-example (a b c:ℕ): (a^b) * a^c = a^(b+c) := by sorry
+theorem SetTheory.Set.Exercise_3_6_6_b (a b c:ℕ): (a^b) * a^c = a^(b+c) := by sorry
 
 /-- Exercise 3.6.7 -/
 theorem SetTheory.Set.injection_iff_card_le {A B:Set} (hA: A.finite) (hB: B.finite) :

--- a/analysis/Analysis/Section_3_6.lean
+++ b/analysis/Analysis/Section_3_6.lean
@@ -243,7 +243,6 @@ noncomputable def SetTheory.Set.pow_fun_equiv {A B : Set} : ↑(A ^ B) ≃ (B �
   left_inv := sorry
   right_inv := sorry
 
-@[simp]
 lemma SetTheory.Set.pow_fun_eq_iff {A B : Set} (x y : ↑(A ^ B)) : x = y ↔ pow_fun_equiv x = pow_fun_equiv y := by
   rw [←pow_fun_equiv.apply_eq_iff_eq]
 

--- a/analysis/Analysis/Section_3_6.lean
+++ b/analysis/Analysis/Section_3_6.lean
@@ -258,12 +258,12 @@ noncomputable def SetTheory.Set.pow_fun_equiv' (X Y : Set) : ↑(Y ^ X) ≃ (X �
 theorem SetTheory.Set.pow_pow_EqualCard_pow_prod (A B C:Set) :
     EqualCard ((A ^ B) ^ C) (A ^ (B ×ˢ C)) := by sorry
 
-theorem SetTheory.Set.Exercise_3_6_6_a (a b c:ℕ): (a^b)^c = a^(b*c) := by sorry
+theorem SetTheory.Set.pow_pow_eq_pow_mul (a b c:ℕ): (a^b)^c = a^(b*c) := by sorry
 
 theorem SetTheory.Set.pow_prod_pow_EqualCard_pow_union (A B C:Set) (hd: Disjoint B C) :
     EqualCard ((A ^ B) ×ˢ (A ^ C)) (A ^ (B ∪ C)) := by sorry
 
-theorem SetTheory.Set.Exercise_3_6_6_b (a b c:ℕ): (a^b) * a^c = a^(b+c) := by sorry
+theorem SetTheory.Set.pow_mul_pow_eq_pow_add (a b c:ℕ): (a^b) * a^c = a^(b+c) := by sorry
 
 /-- Exercise 3.6.7 -/
 theorem SetTheory.Set.injection_iff_card_le {A B:Set} (hA: A.finite) (hB: B.finite) :

--- a/analysis/Analysis/Section_3_6.lean
+++ b/analysis/Analysis/Section_3_6.lean
@@ -161,9 +161,9 @@ theorem SetTheory.Set.card_to_has_card {X:Set} {n: ℕ} (hn: n ≠ 0): X.card = 
 
 theorem SetTheory.Set.card_fin_eq (n:ℕ): (Fin n).has_card n := (has_card_iff _ _).mp ⟨ id, Function.bijective_id ⟩
 
-theorem SetTheory.Set.Fin_card {n:ℕ}: (Fin n).card = n := has_card_to_card (card_fin_eq n)
+theorem SetTheory.Set.Fin_card (n:ℕ): (Fin n).card = n := has_card_to_card (card_fin_eq n)
 
-theorem SetTheory.Set.Fin_finite {n:ℕ}: (Fin n).finite := ⟨n, card_fin_eq n⟩
+theorem SetTheory.Set.Fin_finite (n:ℕ): (Fin n).finite := ⟨n, card_fin_eq n⟩
 
 theorem SetTheory.Set.EquivCard_to_has_card_eq {X Y:Set} {n: ℕ} (h: X ≈ Y): X.has_card n ↔ Y.has_card n := by
   choose f hf using h; let e := Equiv.ofBijective f hf
@@ -244,7 +244,7 @@ noncomputable def SetTheory.Set.pow_fun_equiv {X Y : Set} : ↑(Y ^ X) ≃ (X �
   right_inv := sorry
 
 /-- Proposition 3.6.14 (f) / Exercise 3.6.4 -/
-theorem SetTheory.Set.card_pow {X Y:Set} (hX: X.finite) (hY: Y.finite) :
+theorem SetTheory.Set.card_pow {X Y:Set} (hY: Y.finite) (hX: X.finite) :
     (Y ^ X).finite ∧ (Y ^ X).card = Y.card ^ X.card := by sorry
 
 /-- Exercise 3.6.5. You might find `SetTheory.Set.prod_commutator` useful. -/

--- a/analysis/Analysis/Section_3_6.lean
+++ b/analysis/Analysis/Section_3_6.lean
@@ -251,7 +251,7 @@ theorem SetTheory.Set.card_pow {X Y:Set} (hY: Y.finite) (hX: X.finite) :
 theorem SetTheory.Set.prod_EqualCard_prod (A B:Set) :
     EqualCard (A ×ˢ B) (B ×ˢ A) := by sorry
 
-noncomputable def SetTheory.Set.pow_fun_equiv' (A B : Set) : ↑(A ^ B) ≃ (B → A) :=
+noncomputable abbrev SetTheory.Set.pow_fun_equiv' (A B : Set) : ↑(A ^ B) ≃ (B → A) :=
   pow_fun_equiv (A:=A) (B:=B)
 
 /-- Exercise 3.6.6. You may find `SetTheory.Set.curry_equiv` useful. -/

--- a/analysis/Analysis/Section_3_6.lean
+++ b/analysis/Analysis/Section_3_6.lean
@@ -237,7 +237,7 @@ theorem SetTheory.Set.card_image_inj {X Y:Set} (hX: X.finite) {f: X → Y}
 theorem SetTheory.Set.card_prod {X Y:Set} (hX: X.finite) (hY: Y.finite) :
     (X ×ˢ Y).finite ∧ (X ×ˢ Y).card = X.card * Y.card := by sorry
 
-noncomputable abbrev SetTheory.Set.pow_fun_equiv {X Y : Set} : ↑(Y ^ X) ≃ (X → Y) where
+noncomputable abbrev SetTheory.Set.pow_fun_equiv {A B : Set} : ↑(A ^ B) ≃ (B → A) where
   toFun := sorry
   invFun := sorry
   left_inv := sorry
@@ -251,8 +251,8 @@ theorem SetTheory.Set.card_pow {X Y:Set} (hY: Y.finite) (hX: X.finite) :
 theorem SetTheory.Set.prod_EqualCard_prod (A B:Set) :
     EqualCard (A ×ˢ B) (B ×ˢ A) := by sorry
 
-noncomputable def SetTheory.Set.pow_fun_equiv' (Y X : Set) : ↑(Y ^ X) ≃ (X → Y) :=
-  pow_fun_equiv (X:=X) (Y:=Y)
+noncomputable def SetTheory.Set.pow_fun_equiv' (A B : Set) : ↑(A ^ B) ≃ (B → A) :=
+  pow_fun_equiv (A:=A) (B:=B)
 
 /-- Exercise 3.6.6. You may find `SetTheory.Set.curry_equiv` useful. -/
 theorem SetTheory.Set.pow_pow_EqualCard_pow_prod (A B C:Set) :

--- a/analysis/Analysis/Section_3_6.lean
+++ b/analysis/Analysis/Section_3_6.lean
@@ -251,7 +251,7 @@ theorem SetTheory.Set.card_pow {X Y:Set} (hY: Y.finite) (hX: X.finite) :
 theorem SetTheory.Set.prod_EqualCard_prod (A B:Set) :
     EqualCard (A ×ˢ B) (B ×ˢ A) := by sorry
 
-noncomputable def SetTheory.Set.pow_fun_equiv' (X Y : Set) : ↑(Y ^ X) ≃ (X → Y) :=
+noncomputable def SetTheory.Set.pow_fun_equiv' (Y X : Set) : ↑(Y ^ X) ≃ (X → Y) :=
   pow_fun_equiv (X:=X) (Y:=Y)
 
 /-- Exercise 3.6.6. You may find `SetTheory.Set.curry_equiv` useful. -/

--- a/analysis/Analysis/Section_3_6.lean
+++ b/analysis/Analysis/Section_3_6.lean
@@ -237,11 +237,15 @@ theorem SetTheory.Set.card_image_inj {X Y:Set} (hX: X.finite) {f: X → Y}
 theorem SetTheory.Set.card_prod {X Y:Set} (hX: X.finite) (hY: Y.finite) :
     (X ×ˢ Y).finite ∧ (X ×ˢ Y).card = X.card * Y.card := by sorry
 
-noncomputable abbrev SetTheory.Set.pow_fun_equiv {A B : Set} : ↑(A ^ B) ≃ (B → A) where
+noncomputable def SetTheory.Set.pow_fun_equiv {A B : Set} : ↑(A ^ B) ≃ (B → A) where
   toFun := sorry
   invFun := sorry
   left_inv := sorry
   right_inv := sorry
+
+@[simp]
+lemma SetTheory.Set.pow_fun_eq_iff {A B : Set} (x y : ↑(A ^ B)) : x = y ↔ pow_fun_equiv x = pow_fun_equiv y := by
+  rw [←pow_fun_equiv.apply_eq_iff_eq]
 
 /-- Proposition 3.6.14 (f) / Exercise 3.6.4 -/
 theorem SetTheory.Set.card_pow {X Y:Set} (hY: Y.finite) (hX: X.finite) :

--- a/analysis/Analysis/Section_3_6.lean
+++ b/analysis/Analysis/Section_3_6.lean
@@ -237,7 +237,7 @@ theorem SetTheory.Set.card_image_inj {X Y:Set} (hX: X.finite) {f: X → Y}
 theorem SetTheory.Set.card_prod {X Y:Set} (hX: X.finite) (hY: Y.finite) :
     (X ×ˢ Y).finite ∧ (X ×ˢ Y).card = X.card * Y.card := by sorry
 
-noncomputable def SetTheory.Set.pow_fun_equiv {X Y : Set} : ↑(Y ^ X) ≃ (X → Y) where
+noncomputable abbrev SetTheory.Set.pow_fun_equiv {X Y : Set} : ↑(Y ^ X) ≃ (X → Y) where
   toFun := sorry
   invFun := sorry
   left_inv := sorry


### PR DESCRIPTION
Follow-up to https://github.com/teorth/analysis/pull/345:

- Make `n` an explicit argument for `Fin_card` and `Fin_finite`. There's nothing to infer it from.
- Reorder `card_pow` to accept `hY` first so that `card_pow A B` would give you a statement about `A^B`.
- Similarly, reorder `pow_fun_equiv'` so we can write `pow_fun_equiv' A B` to get a statement about `A^B`.
- Rename `X Y` to `A B` in places where you'd usually call them with `Y X` to reduce confusion.
- Give `SetTheory.Set` namespace to examples to make the goals in them less wordy.
- Add a helper lemma for `pow_fun_equiv` (simplifies the proofs significantly).

## Playthrough

```lean
noncomputable def SetTheory.Set.pow_fun_equiv {A B : Set} : ↑(A ^ B) ≃ (B → A) where
  toFun F := ((powerset_axiom _).mp F.property).choose
  invFun f := ⟨f, (powerset_axiom _).mpr ⟨f, by simp⟩⟩
  left_inv F := by ext; apply ((powerset_axiom _).mp F.property).choose_spec
  right_inv f := by simp

-- ...

theorem SetTheory.Set.card_pow {X Y:Set} (hY: Y.finite) (hX: X.finite) :
    (Y ^ X).finite ∧ (Y ^ X).card = Y.card ^ X.card := by
  induction' hXc: X.card with n ih generalizing X
  · rw [pow_zero, empty_of_card_eq_zero hX hXc]
    have heq : Y ^ (∅: Set) ≈ Fin 1 := by
      use fun _ ↦ ⟨0, by rw [mem_Fin]; aesop⟩
      constructor
      · intro z1 z2
        simp only [pow_fun_eq_iff, forall_const]
        grind [not_mem_empty]
      intro y
      let f : (∅: Set) → Y := fun e ↦ by have := e.property; simp_all
      use pow_fun_equiv.symm f
      have := y.property
      rw [mem_Fin] at this
      simp_all
    constructor
    · use 1
    rw [EquivCard_to_card_eq heq, Fin_card]
  have hXn := card_to_has_card (by omega) hXc
  have hxne := pos_card_nonempty (by omega) hXn
  let x := nonempty_choose hxne
  have hX'n := card_erase (by omega) hXn x
  simp only [add_tsub_cancel_right] at hX'n
  set X' := X \ {↑x}
  have hX : X = X' ∪ {↑x} := by
    symm; rw [union_comm]
    apply union_compl
    simp [subset_def, x.property]
  have hX'f: X'.finite := ⟨n, hX'n⟩
  have hX'c := has_card_to_card hX'n
  obtain ⟨hpowf, hpowc⟩ := ih hX'f hX'c
  rw [pow_succ, ←hpowc]
  have ⟨hprodf, hprodc⟩ := card_prod hpowf hY
  have heq : Y ^ X ≈ (Y ^ X') ×ˢ Y := by
    use fun z ↦
      let f := pow_fun_equiv z
      let f' : X' → Y := fun x' ↦ f ⟨x', by have := x'.property; simp [X'] at this; grind⟩
      mk_cartesian (pow_fun_equiv.symm f') (f x)
    constructor
    · intro z1 z2 heq
      rw [pow_fun_eq_iff]
      ext x2; congr
      simp only [mk_cartesian, Subtype.mk.injEq, EmbeddingLike.apply_eq_iff_eq,
        OrderedPair.mk.injEq, SetCoe.ext_iff] at heq
      by_cases hx : x = x2
      · grind
      let x2' : X' := ⟨x2, by simp only [mem_sdiff, mem_singleton, X', x2.property]; grind⟩
      have := congrArg (pow_fun_equiv · x2') heq.1
      grind
    intro z'
    let f' := pow_fun_equiv (fst z')
    let f : X → Y := open Classical in fun x2 ↦
      if hx2 : x2 = x then
        (snd z')
      else
        f' ⟨x2, by have := x2.property; simp [X']; grind⟩
    use pow_fun_equiv.symm f
    rw [←mk_cartesian_fst_snd_eq z']
    simp only [mk_cartesian, Subtype.mk.injEq,
      EmbeddingLike.apply_eq_iff_eq, OrderedPair.mk.injEq]
    constructor
    · simp only [Equiv.apply_symm_apply, f, f']
      congr
      simp only [pow_fun_eq_iff]
      ext x'
      have : x'.val ≠ x := by have := x'.property; simp [X'] at this; grind
      grind
    simp [f]
  have heqc := EquivCard_to_card_eq heq
  constructor
  · use ((Y ^ X') ×ˢ Y).card
    rw [EquivCard_to_has_card_eq heq]
    exact has_card_card hprodf
  rw [heqc]
  exact hprodc

-- ...

theorem SetTheory.Set.pow_pow_EqualCard_pow_prod (A B C:Set) :
    EqualCard ((A ^ B) ^ C) (A ^ (B ×ˢ C)) := by
  have e1 := pow_fun_equiv' (A ^ B) C
  have e2 := Equiv.arrowCongr (Equiv.refl C) (pow_fun_equiv' A B)
  have e3 : (C → (B → A)) ≃ (C ×ˢ B → A) := curry_equiv
  have e4 := Equiv.arrowCongr (prod_commutator C B) (Equiv.refl A)
  have e5 := (pow_fun_equiv' A (B ×ˢ C)).symm
  use e1.trans <| e2.trans <| e3.trans <| e4.trans <| e5
  apply Equiv.bijective

theorem SetTheory.Set.pow_pow_eq_pow_mul (a b c:ℕ): (a^b)^c = a^(b*c) := by
  have h1 := card_pow (Fin_finite a) (Fin_finite b)
  have h2 := card_pow h1.1 (Fin_finite c)
  have h3 := card_prod (Fin_finite b) (Fin_finite c)
  have h4 := card_pow (Fin_finite a) h3.1
  rw [←Fin_card a, ←Fin_card b, ←Fin_card c]
  rw [←h1.2, ←h2.2, ←h3.2, ←h4.2]
  have := pow_pow_EqualCard_pow_prod (Fin a) (Fin b) (Fin c)
  rw [EquivCard_to_card_eq this]

theorem SetTheory.Set.pow_prod_pow_EqualCard_pow_union (A B C:Set) (hd: Disjoint B C) :
    EqualCard ((A ^ B) ×ˢ (A ^ C)) (A ^ (B ∪ C)) := by
  use fun z ↦
    let f' (bc : ↑(B ∪ C)) : A := open Classical in
      if h: ↑bc ∈ B then
        let b : B := ⟨bc, by simp_all⟩
        pow_fun_equiv (fst z) b
      else
        let c : C := ⟨bc, by have := bc.property; simp_all⟩
        pow_fun_equiv (snd z) c
    pow_fun_equiv.symm f'
  constructor
  · intro z1 z2 heq
    ext
    simp only [pair_eq_fst_snd, pair_eq_fst_snd, EmbeddingLike.apply_eq_iff_eq, OrderedPair.mk.injEq]
    simp only [EmbeddingLike.apply_eq_iff_eq] at heq
    constructor
    · rw [Subtype.val_inj, pow_fun_eq_iff]
      ext b
      let bc : ↑(B ∪ C) := ⟨b, by have := b.property; simp_all⟩
      have := congrFun heq bc
      grind
    rw [Subtype.val_inj, pow_fun_eq_iff]
    ext c
    let bc : ↑(B ∪ C) := ⟨c, by have := c.property; simp_all⟩
    simp_rw [disjoint_iff, eq_empty_iff_forall_notMem, mem_inter] at hd
    have := congrFun heq bc
    grind
  intro z'
  let f := pow_fun_equiv z'
  let ba (b : B) := f ⟨b, by have := b.property; simp_all⟩
  let ca (c : C) := f ⟨c, by have := c.property; simp_all⟩
  use mk_cartesian (pow_fun_equiv.symm ba) (pow_fun_equiv.symm ca)
  simp [ba, ca, f]

theorem SetTheory.Set.pow_mul_pow_eq_pow_add (a b c:ℕ): (a^b) * a^c = a^(b+c) := by
  let fc (c: Fin c): Nat := ↑(c + b)
  have hfc : Function.Injective fc := by intro x1 x2; aesop
  have ⟨hCf, _⟩ := card_image (Fin_finite c) fc
  set C := image fc (Fin c)
  have hCd : Disjoint (Fin b) C := by rw [disjoint_iff]; aesop
  have h1 := card_image_inj (Fin_finite c) hfc
  have h2 := card_pow (Fin_finite a) (Fin_finite b)
  have h3 := card_pow (Fin_finite a) hCf
  have h4 := card_prod h2.1 h3.1
  have h5 := card_union_disjoint (Fin_finite b) hCf hCd
  have h6 := card_union (Fin_finite b) hCf
  have h7 := card_pow (Fin_finite a) h6.1
  rw [←Fin_card a, ←Fin_card b, ←Fin_card c]
  rw [←h1, ←h2.2, ←h3.2, ←h4.2, ←h5, ←h7.2]
  have := pow_prod_pow_EqualCard_pow_union (Fin a) (Fin b) C hCd
  rw [EquivCard_to_card_eq this]
```