### PR TITLE
Add +1 to LIM_mono_fail sequences

### DIFF
--- a/analysis/Analysis/Section_5_4.lean
+++ b/analysis/Analysis/Section_5_4.lean
@@ -277,8 +277,8 @@ theorem Real.LIM_mono_fail :
     ∧ (b:Sequence).IsCauchy
     ∧ (∀ n, a n > b n)
     ∧ ¬LIM a > LIM b := by
-  use (fun n ↦ 1 + 1/(n:ℚ))
-  use (fun n ↦ 1 - 1/(n:ℚ))
+  use (fun n ↦ 1 + 1/((n:ℚ) + 1))
+  use (fun n ↦ 1 - 1/((n:ℚ) + 1))
   sorry
 
 /-- Proposition 5.4.12 (Bounding reals by rationals) -/


### PR DESCRIPTION
Otherwise, we get division by 0 at `n =0`, which actually makes `a n = b n`.