### PR TITLE
Scaffolding for Exercise 3.6.12 (i)

### DIFF
--- a/analysis/Analysis/Section_3_5.lean
+++ b/analysis/Analysis/Section_3_5.lean
@@ -291,7 +291,7 @@ theorem SetTheory.Set.Fin.toNat_lt {n:ℕ} (i: Fin n) : i < n := (toNat_spec i).
 theorem SetTheory.Set.Fin.coe_toNat {n:ℕ} (i: Fin n) : ((i:ℕ):Object) = (i:Object) := by
   set j := (i:ℕ); obtain ⟨ h, h':i = Fin_mk n j h ⟩ := toNat_spec i; rw [h']
 
-@[simp]
+@[simp low]
 lemma SetTheory.Set.Fin.coe_inj {n:ℕ} {i j: Fin n} : i = j ↔ (i:ℕ) = (j:ℕ) := by
   constructor
   · simp_all
@@ -307,6 +307,17 @@ theorem SetTheory.Set.Fin.coe_eq_iff {n:ℕ} (i: Fin n) {j:ℕ} : (i:Object) = (
     obtain ⟨_, rfl⟩ := h
     simp [←Object.natCast_inj]
   aesop
+
+@[simp]
+theorem SetTheory.Set.Fin.coe_eq_iff' {n m:ℕ} (i: Fin n) (hi : ↑i ∈ Fin m) : ((⟨i, hi⟩ : Fin m):ℕ) = (i:ℕ) := by
+  obtain ⟨val, property⟩ := i
+  simp only [toNat, Subtype.mk.injEq, exists_prop]
+  generalize_proofs h1 h2
+  suffices : (h1.choose: Object) = h2.choose
+  · aesop
+  have := h1.choose_spec
+  have := h2.choose_spec
+  grind
 
 @[simp]
 theorem SetTheory.Set.Fin.toNat_mk {n:ℕ} (m:ℕ) (h: m < n) : (Fin_mk n m h : ℕ) = m := by

--- a/analysis/Analysis/Section_3_6.lean
+++ b/analysis/Analysis/Section_3_6.lean
@@ -297,7 +297,10 @@ theorem SetTheory.Set.Permutations_finite (n: ℕ): (Permutations n).finite := b
 
 /- To continue Exercise 3.6.12 (i), we'll first develop some theory about `Permutations` and `Fin`. -/
 
-noncomputable def SetTheory.Set.Permutations_toFun {n: ℕ} (p: Permutations n) : (Fin n) → (Fin n) := by sorry
+noncomputable def SetTheory.Set.Permutations_toFun {n: ℕ} (p: Permutations n) : (Fin n) → (Fin n) := by
+  have := p.property
+  simp only [Permutations, specification_axiom'', powerset_axiom] at this
+  exact this.choose.choose
 
 theorem SetTheory.Set.Permutations_bijective {n: ℕ} (p: Permutations n) :
     Function.Bijective (Permutations_toFun p) := by sorry
@@ -307,7 +310,7 @@ theorem SetTheory.Set.Permutations_inj {n: ℕ} (p1 p2: Permutations n) :
 
 /-- This connects our concept of a permutation with Mathlib's `Equiv` between `Fin n` and `Fin n`. -/
 noncomputable def SetTheory.Set.perm_equiv_equiv {n : ℕ} : Permutations n ≃ (Fin n ≃ Fin n) := {
-  toFun := sorry
+  toFun := fun p => Equiv.ofBijective (Permutations_toFun p) (Permutations_bijective p)
   invFun := sorry
   left_inv := sorry
   right_inv := sorry
@@ -386,8 +389,10 @@ theorem SetTheory.Set.Permutations_ih (n: ℕ):
   let S i := (Permutations (n + 1)).specify (fun p ↦ perm_equiv_equiv p (Fin.last n) = i)
 
   have hSe : ∀ i, S i ≈ Permutations n := by
+    intro i
     -- Hint: you might find `perm_equiv_equiv`, `Fin.succAbove`, and `Fin.predAbove` useful.
-    sorry
+    have equiv : S i ≃ Permutations n := sorry
+    use equiv, equiv.injective, equiv.surjective
 
   -- Hint: you might find `card_iUnion_card_disjoint` and `Permutations_finite` useful.
   sorry

--- a/analysis/Analysis/Section_3_6.lean
+++ b/analysis/Analysis/Section_3_6.lean
@@ -305,7 +305,7 @@ theorem SetTheory.Set.Permutations_bijective {n: ℕ} (p: Permutations n) :
 theorem SetTheory.Set.Permutations_inj {n: ℕ} (p1 p2: Permutations n) :
     Permutations_toFun p1 = Permutations_toFun p2 ↔ p1 = p2 := by sorry
 
-/-- It's handy to think of a permutation as an equivalence between `Fin n` and `Fin n`. -/
+/-- This connects our concept of a permutation with Mathlib's `Equiv` between `Fin n` and `Fin n`. -/
 noncomputable def SetTheory.Set.perm_equiv_equiv {n : ℕ} : Permutations n ≃ (Fin n ≃ Fin n) := {
   toFun := sorry
   invFun := sorry
@@ -315,29 +315,29 @@ noncomputable def SetTheory.Set.perm_equiv_equiv {n : ℕ} : Permutations n ≃ 
 
 /- Exercise 3.6.12 involves a lot of moving between `Fin n` and `Fin (n + 1)` so let's add some conveniences. -/
 
-/-- Any `Fin n` can be cast to `Fin (n + 1)`. Compare to Mathlib `_root_.Fin.castSucc`. -/
-def SetTheory.Set.Fin.castSucc (x : Fin n) : Fin (n + 1) :=
+/-- Any `Fin n` can be cast to `Fin (n + 1)`. Compare to Mathlib `Fin.castSucc`. -/
+def SetTheory.Set.Fin.castSucc {n} (x : Fin n) : Fin (n + 1) :=
   Fin_embed _ _ (by omega) x
 
 @[simp]
-lemma SetTheory.Set.Fin.castSucc_inj : castSucc x = castSucc y ↔ x = y := by sorry
+lemma SetTheory.Set.Fin.castSucc_inj {n} {x y : Fin n} : castSucc x = castSucc y ↔ x = y := by sorry
 
 @[simp]
-theorem SetTheory.Set.Fin.castSucc_ne (x : Fin n) : castSucc x ≠ n := by sorry
+theorem SetTheory.Set.Fin.castSucc_ne {n} (x : Fin n) : castSucc x ≠ n := by sorry
 
-/-- Any `Fin (n + 1)` except `n` can be cast to `Fin n`. Compare to Mathlib `_root_.Fin.castPred`. -/
-noncomputable def SetTheory.Set.Fin.castPred (x : Fin (n + 1)) (h : (x : ℕ) ≠ n) : Fin n :=
+/-- Any `Fin (n + 1)` except `n` can be cast to `Fin n`. Compare to Mathlib `Fin.castPred`. -/
+noncomputable def SetTheory.Set.Fin.castPred {n} (x : Fin (n + 1)) (h : (x : ℕ) ≠ n) : Fin n :=
   Fin_mk _ (x : ℕ) (by have := Fin.toNat_lt x; omega)
 
 @[simp]
-theorem SetTheory.Set.Fin.castSucc_castPred (x : Fin (n + 1)) (h : (x : ℕ) ≠ n) :
+theorem SetTheory.Set.Fin.castSucc_castPred {n} (x : Fin (n + 1)) (h : (x : ℕ) ≠ n) :
     castSucc (castPred x h) = x := by sorry
 
 @[simp]
-theorem SetTheory.Set.Fin.castPred_castSucc (x : Fin n) (h : ((castSucc x : Fin (n + 1)) : ℕ) ≠ n) :
+theorem SetTheory.Set.Fin.castPred_castSucc {n} (x : Fin n) (h : ((castSucc x : Fin (n + 1)) : ℕ) ≠ n) :
     castPred (castSucc x) h = x := by sorry
 
-/-- Any natural `n` can be cast to `Fin (n + 1)`. Compare to Mathlib `_root.Fin.last`. -/
+/-- Any natural `n` can be cast to `Fin (n + 1)`. Compare to Mathlib `Fin.last`. -/
 def SetTheory.Set.Fin.last (n : ℕ) : Fin (n + 1) := Fin_mk _ n (by omega)
 
 /-- Now is a good time to prove this result, which will be useful for completing Exercise 3.6.12 (i). -/
@@ -350,7 +350,7 @@ theorem SetTheory.Set.card_iUnion_card_disjoint {n m: ℕ} {S : Fin n → Set}
 
 /--
   If some `x : Fin (n+1)` is never equal to `i`, we can shrink it into `Fin n` by shifting all `x > i` down by one.
-  Compare to Mathlib `_root_.Fin.predAbove`.
+  Compare to Mathlib `Fin.predAbove`.
 -/
 noncomputable def SetTheory.Set.Fin.predAbove {n} (i : Fin (n + 1)) (x : Fin (n + 1)) (h : x ≠ i) : Fin n :=
   if hx : (x:ℕ) < i then
@@ -361,7 +361,7 @@ noncomputable def SetTheory.Set.Fin.predAbove {n} (i : Fin (n + 1)) (x : Fin (n 
 /--
   We can expand `x : Fin n` into `Fin (n + 1)` by shifting all `x ≥ i` up by one.
   The output is never `i`, so it forms an inverse to the shrinking done by `predAbove`.
-  Compare to Mathlib `_root_.Fin.succAbove`.
+  Compare to Mathlib `Fin.succAbove`.
 -/
 noncomputable def SetTheory.Set.Fin.succAbove {n} (i : Fin (n + 1)) (x : Fin n) : Fin (n + 1) :=
   if (x:ℕ) < i then

--- a/analysis/Analysis/Section_3_6.lean
+++ b/analysis/Analysis/Section_3_6.lean
@@ -290,14 +290,107 @@ theorem SetTheory.Set.two_to_two_iff {X Y:Set} (f: X → Y): Function.Injective 
 
 /-- Exercise 3.6.12 -/
 def SetTheory.Set.Permutations (n: ℕ): Set := (Fin n ^ Fin n).specify (fun F ↦
-    Function.Bijective ((powerset_axiom F).mp F.prop).choose)
+    Function.Bijective (pow_fun_equiv F))
 
-/-- Exercise 3.6.12 (i) -/
+/-- Exercise 3.6.12 (i), first part -/
 theorem SetTheory.Set.Permutations_finite (n: ℕ): (Permutations n).finite := by sorry
 
-/-- Exercise 3.6.12 (i) -/
+/- To continue Exercise 3.6.12 (i), we'll first develop some theory about `Permutations` and `Fin`. -/
+
+noncomputable def SetTheory.Set.Permutations_toFun {n: ℕ} (p: Permutations n) : (Fin n) → (Fin n) := by sorry
+
+theorem SetTheory.Set.Permutations_bijective {n: ℕ} (p: Permutations n) :
+    Function.Bijective (Permutations_toFun p) := by sorry
+
+theorem SetTheory.Set.Permutations_inj {n: ℕ} (p1 p2: Permutations n) :
+    Permutations_toFun p1 = Permutations_toFun p2 ↔ p1 = p2 := by sorry
+
+/-- It's handy to think of a permutation as an equivalence between `Fin n` and `Fin n`. -/
+noncomputable def SetTheory.Set.perm_equiv_equiv {n : ℕ} : Permutations n ≃ (Fin n ≃ Fin n) := {
+  toFun := sorry
+  invFun := sorry
+  left_inv := sorry
+  right_inv := sorry
+}
+
+/- Exercise 3.6.12 involves a lot of moving between `Fin n` and `Fin (n + 1)` so let's add some conveniences. -/
+
+/-- Any `Fin n` can be cast to `Fin (n + 1)`. Compare to Mathlib `_root_.Fin.castSucc`. -/
+def SetTheory.Set.Fin.castSucc (x : Fin n) : Fin (n + 1) :=
+  Fin_embed _ _ (by omega) x
+
+@[simp]
+lemma SetTheory.Set.Fin.castSucc_inj : castSucc x = castSucc y ↔ x = y := by sorry
+
+@[simp]
+theorem SetTheory.Set.Fin.castSucc_ne (x : Fin n) : castSucc x ≠ n := by sorry
+
+/-- Any `Fin (n + 1)` except `n` can be cast to `Fin n`. Compare to Mathlib `_root_.Fin.castPred`. -/
+noncomputable def SetTheory.Set.Fin.castPred (x : Fin (n + 1)) (h : (x : ℕ) ≠ n) : Fin n :=
+  Fin_mk _ (x : ℕ) (by have := Fin.toNat_lt x; omega)
+
+@[simp]
+theorem SetTheory.Set.Fin.castSucc_castPred (x : Fin (n + 1)) (h : (x : ℕ) ≠ n) :
+    castSucc (castPred x h) = x := by sorry
+
+@[simp]
+theorem SetTheory.Set.Fin.castPred_castSucc (x : Fin n) (h : ((castSucc x : Fin (n + 1)) : ℕ) ≠ n) :
+    castPred (castSucc x) h = x := by sorry
+
+/-- Any natural `n` can be cast to `Fin (n + 1)`. Compare to Mathlib `_root.Fin.last`. -/
+def SetTheory.Set.Fin.last (n : ℕ) : Fin (n + 1) := Fin_mk _ n (by omega)
+
+/-- Now is a good time to prove this result, which will be useful for completing Exercise 3.6.12 (i). -/
+theorem SetTheory.Set.card_iUnion_card_disjoint {n m: ℕ} {S : Fin n → Set}
+    (hSc : ∀ i, (S i).has_card m)
+    (hSd : Pairwise fun i j => Disjoint (S i) (S j)) :
+    ((Fin n).iUnion S).finite ∧ ((Fin n).iUnion S).card = n * m := by sorry
+
+/- Finally, we'll set up a way to shrink `Fin (n + 1)` into `Fin n` (or expand the latter) by making a hole. -/
+
+/--
+  If some `x : Fin (n+1)` is never equal to `i`, we can shrink it into `Fin n` by shifting all `x > i` down by one.
+  Compare to Mathlib `_root_.Fin.predAbove`.
+-/
+noncomputable def SetTheory.Set.Fin.predAbove {n} (i : Fin (n + 1)) (x : Fin (n + 1)) (h : x ≠ i) : Fin n :=
+  if hx : (x:ℕ) < i then
+    Fin_mk _ (x:ℕ) (by sorry)
+  else
+    Fin_mk _ ((x:ℕ) - 1) (by sorry)
+
+/--
+  We can expand `x : Fin n` into `Fin (n + 1)` by shifting all `x ≥ i` up by one.
+  The output is never `i`, so it forms an inverse to the shrinking done by `predAbove`.
+  Compare to Mathlib `_root_.Fin.succAbove`.
+-/
+noncomputable def SetTheory.Set.Fin.succAbove {n} (i : Fin (n + 1)) (x : Fin n) : Fin (n + 1) :=
+  if (x:ℕ) < i then
+    Fin_embed _ _ (by sorry) x
+  else
+    Fin_mk _ ((x:ℕ) + 1) (by sorry)
+
+@[simp]
+theorem SetTheory.Set.Fin.succAbove_ne {n} (i : Fin (n + 1)) (x : Fin n) : succAbove i x ≠ i := by sorry
+
+@[simp]
+theorem SetTheory.Set.Fin.succAbove_predAbove {n} (i : Fin (n + 1)) (x : Fin (n + 1)) (h : x ≠ i) :
+    (succAbove i) (predAbove i x h) = x := by sorry
+
+@[simp]
+theorem SetTheory.Set.Fin.predAbove_succAbove {n} (i : Fin (n + 1)) (x : Fin n) :
+    (predAbove i) (succAbove i x) (succAbove_ne i x) = x := by sorry
+
+/-- Exercise 3.6.12 (i), second part -/
 theorem SetTheory.Set.Permutations_ih (n: ℕ):
-    (Permutations (n + 1)).card = (n + 1) * (Permutations n).card := by sorry
+    (Permutations (n + 1)).card = (n + 1) * (Permutations n).card := by
+  let S i := (Permutations (n + 1)).specify (fun p ↦ perm_equiv_equiv p (Fin.last n) = i)
+
+  have hSe : ∀ i, S i ≈ Permutations n := by
+    -- Hint: you might find `perm_equiv_equiv`, `Fin.succAbove`, and `Fin.predAbove` useful.
+    sorry
+
+  -- Hint: you might find `card_iUnion_card_disjoint` and `Permutations_finite` useful.
+  sorry
 
 /-- Exercise 3.6.12 (ii) -/
 theorem SetTheory.Set.Permutations_card (n: ℕ):


### PR DESCRIPTION
As [discussed](https://leanprover.zulipchat.com/#narrow/channel/514017-Analysis-I/topic/Confused.20by.20the.20hint.20in.203.2E6.2E12/with/539978177), Exercise 3.6.12 is too hard in this formalization.
Both @rkirov and me ended up spending at least a week on it.

There's a few difficulties:

- Moving between `Fin n` and `Fin (n + 1)`, which we do a *lot* here, is painful without dedicated lemmas.
- Dealing with set-theoretic `Permutations` definition is annoying with all the existentials and functions-as-objects.
- The hint in the book is handy but applying it is hard because we have no machinery for "accumulating" a sum yet.
- Writing a mapping between `Fin n` functions and `Fin (n + 1)` functions turns into a subtype hell.
- With this many definitions inside the theorem itself, the type checker eventually slows to a crawl.

My approach was to first solve it with some inline helpers. Then I checked Mathlib and it turns out that my helpers corresponded to existing concepts like `Fin.last`, `Fin.castSucc` / `Fin.castPred`, and `Fin.succAbove` / `Fin.predAbove`. So I did the same as elsewhere in the book, and ported over those concepts at the top level. This also solved perf issues. Both the definitions and the lemmas I've added are almost exactly as in Mathlib so you end up learning those.

I've also set up some minimal `Permutations` API that makes it harder to shoot yourself in the foot. In particular, I found it nice to treat it as an `Equiv` because then we get bijectivity of the transformation itself for free. I've defined `perm_equiv_equiv` to nudge the reader towards thinking about permutations as equivalences but this isn't enforced.

I've ordered the additions by "when you need them" so that you have some constraints on when to use what.

## Playthrough

```lean
/-- Exercise 3.6.12 -/
def SetTheory.Set.Permutations (n: ℕ): Set := (Fin n ^ Fin n).specify (fun F ↦
    Function.Bijective (pow_fun_equiv F))

/-- Exercise 3.6.12 (i), first part -/
theorem SetTheory.Set.Permutations_finite (n: ℕ): (Permutations n).finite := by
  have hs : Permutations n ⊆ (Fin n ^ Fin n) := by
    simp only [Permutations]
    apply specify_subset
  have ⟨hpf, hpc⟩ := card_pow (Fin_finite n) (Fin_finite n)
  exact (card_subset hpf hs).1

/- To continue Exercise 3.6.12 (i), we'll first develop some theory about `Permutations` and `Fin`. -/

noncomputable def SetTheory.Set.Permutations_toFun {n: ℕ} (p: Permutations n) : (Fin n) → (Fin n) := by
  have := p.property
  simp only [Permutations, specification_axiom'', powerset_axiom] at this
  exact this.choose.choose

theorem SetTheory.Set.Permutations_bijective {n: ℕ} (p: Permutations n) : Function.Bijective (Permutations_toFun p) := by
  have := p.property
  simp only [Permutations, specification_axiom'', powerset_axiom] at this
  aesop

theorem SetTheory.Set.Permutations_inj {n: ℕ} (p1 p2: Permutations n) : Permutations_toFun p1 = Permutations_toFun p2 ↔ p1 = p2 := by
  constructor
  · intro h
    simp [Permutations_toFun] at h
    generalize_proofs h1 h2 at h
    have := h1.choose_spec
    have := h2.choose_spec
    grind
  intro h
  grind

/-- It's handy to think of a permutation as an equivalence between `Fin n` and `Fin n`. -/
noncomputable def SetTheory.Set.perm_equiv_equiv {n : ℕ} : Permutations n ≃ (Fin n ≃ Fin n) := {
  toFun := fun p => Equiv.ofBijective (Permutations_toFun p) (Permutations_bijective p)
  invFun := fun e => ⟨e, by simp [Permutations, pow_fun_equiv, e.bijective]⟩
  left_inv := fun p => by rw [←Permutations_inj]; simp [Equiv.ofBijective, Permutations_toFun]
  right_inv := fun e => by ext; simp [Permutations_toFun, Equiv.ofBijective]
}

/- Exercise 3.6.12 involves a lot of moving between `Fin n` and `Fin (n + 1)` so let's add some conveniences. -/

/-- Any `Fin n` can be cast to `Fin (n + 1)`. Compare to Mathlib `_root_.Fin.castSucc`. -/
def SetTheory.Set.Fin.castSucc (x : Fin n) : Fin (n + 1) :=
  Fin_embed _ _ (by omega) x

@[simp]
lemma SetTheory.Set.Fin.castSucc_inj : castSucc x = castSucc y ↔ x = y := by
  constructor
  · intro h
    simp [castSucc] at h
    aesop
  aesop

noncomputable def SetTheory.Set.Fin.castPred (x : Fin (n + 1)) (h : (x : ℕ) ≠ n) : Fin n :=
  Fin_mk _ (x : ℕ) (by have := Fin.toNat_lt x; omega)

@[simp]
theorem SetTheory.Set.Fin.castSucc_castPred (x : Fin (n + 1)) (h : (x : ℕ) ≠ n) :
    castSucc (castPred x h) = x := by ext; simp [castSucc, castPred, Fin_embed]

@[simp]
theorem SetTheory.Set.Fin.castPred_castSucc (x : Fin n) (h : ((castSucc x : Fin (n + 1)) : ℕ) ≠ n) :
    castPred (castSucc x) h = x := by ext; simp [castSucc, castPred, Fin_embed]

@[simp]
theorem SetTheory.Set.Fin.castSucc_ne (x : Fin n) : castSucc x ≠ n := by
  intro h
  have : (x : ℕ) = n := by
    simp [castSucc] at h
    exact h
  have : (x : ℕ) < n := Fin.toNat_lt x
  omega

def SetTheory.Set.Fin.last (n : ℕ) : Fin (n + 1) := Fin_mk _ n (by omega)

/-- Now is a good time to prove this result, which will be useful for completing Exercise 3.6.12 (i). -/
theorem SetTheory.Set.card_iUnion_card_disjoint {n m: ℕ} {S : Fin n → Set}
    (hSc : ∀ i, (S i).has_card m)
    (hSd : Pairwise fun i j => Disjoint (S i) (S j)) :
    ((Fin n).iUnion S).finite ∧ ((Fin n).iUnion S).card = n * m := by
  induction' n with n ih
  · rw [zero_mul]
    suffices : (Fin 0).iUnion S = ∅
    · constructor
      · apply finite_of_empty this
      · apply card_eq_zero_of_empty this
    ext x
    simp only [not_mem_empty, iff_false]
    intro h
    rw [mem_iUnion] at h
    obtain ⟨a, ha⟩ := h
    have := Fin.toNat_lt a
    omega
  let S' : (Fin n).toSubtype → Set := fun i ↦ S (Fin.castSucc i)
  have hS' : ∀ i, S (Fin.castSucc i) = S' i := by simp [S']
  have hSc' : ∀ (i : (Fin n).toSubtype), (S' i).has_card m := by intro i; apply hSc
  have hSd' : Pairwise fun i j ↦ Disjoint (S' i) (S' j) := by intro i j hij; apply hSd; aesop
  specialize ih hSc' hSd'
  have hSnf : (S (Fin.last n)).finite := by use m; apply hSc
  have hSnc := has_card_to_card (hSc (Fin.last n))
  rw [add_mul, one_mul, ←ih.2, ←hSnc]
  have hU : (Fin (n + 1)).iUnion S = (Fin n).iUnion S' ∪ S (Fin.last n) := by
    ext x
    constructor
    · intro hx
      rw [mem_iUnion] at hx
      rw [mem_union, mem_iUnion]
      obtain ⟨a, ha⟩ := hx
      by_cases ha' : a < n
      · left
        use Fin.castPred a (by omega)
        aesop
      right
      have : a = n := by have := Fin.toNat_lt a; omega
      have : a = Fin.last n := by aesop
      aesop
    intro hx
    rw [mem_iUnion]
    rw [mem_union, mem_iUnion] at hx
    rcases hx with (hx | hx)
    · simp only [S'] at hx
      obtain ⟨a, ha⟩ := hx
      use Fin.castSucc a
    use Fin.last n
  have hUf : ((Fin n).iUnion S').finite := ih.1
  rw [hU]
  set X := (Fin n).iUnion S'
  set Y := S (Fin.last n)
  have hd : Disjoint X Y := by
    rw [disjoint_iff, eq_empty_iff_forall_notMem]
    intro x
    rw [mem_inter]
    simp only [X, Y, mem_iUnion]
    intro ⟨⟨i, hi⟩, hx⟩
    let i' : Fin (n+1) := Fin_embed _ _ (by omega) i
    have : i' ≠ Fin.last n := by
      intro h
      have := Fin.toNat_lt i
      have : i = n := by aesop
      omega
    specialize hSd this
    rw [disjoint_iff, eq_empty_iff_forall_notMem] at hSd
    aesop
  have := card_union hUf hSnf
  use this.1
  exact card_union_disjoint hUf hSnf hd

/- Finally, we'll set up a way to shrink `Fin (n + 1)` into `Fin n` (or expand the latter) by making a hole. -/

/--
  If some `x : Fin (n+1)` is never equal to `i`, we can shrink it into `Fin n` by shifting all `x > i` down by one.
  Compare to Mathlib `_root_.Fin.predAbove`.
-/
noncomputable def SetTheory.Set.Fin.predAbove {n} (i : Fin (n + 1)) (x : Fin (n + 1)) (h : x ≠ i) : Fin n :=
  if hlt : (x : ℕ) < i then
    Fin_mk _ (x : ℕ) (by have := Fin.toNat_lt x; have := Fin.toNat_lt i; omega)
  else
    Fin_mk _ ((x : ℕ) - 1) (by
      have := Fin.toNat_lt x
      have : (x : ℕ) ≠ i := by aesop
      omega)

/--
  We can expand `x : Fin n` into `Fin (n + 1)` by shifting all `x ≥ i` up by one.
  The output is never `i`, so it forms an inverse to the shrinking done by `predAbove`.
  Compare to Mathlib `_root_.Fin.succAbove`.
-/
noncomputable def SetTheory.Set.Fin.succAbove {n} (i : Fin (n + 1)) (x : Fin n) : Fin (n + 1) :=
  if (x : ℕ) < i then
    Fin_embed _ _ (by omega) x
  else
    Fin_mk _ ((x : ℕ) + 1) (by have := Fin.toNat_lt x; omega)

@[simp]
theorem SetTheory.Set.Fin.succAbove_ne {n} (i : Fin (n + 1)) (x : Fin n) : succAbove i x ≠ i := by
  intro h
  simp only [succAbove, Fin_embed] at h
  by_cases hx : (x : ℕ) < i
  · aesop
  simp only [hx, ↓reduceIte, coe_inj, toNat_mk] at h
  omega

@[simp]
theorem SetTheory.Set.Fin.succAbove_predAbove {n} (i : Fin (n + 1)) (x : Fin (n + 1)) (h : x ≠ i) :
    (succAbove i) (predAbove i x h) = x := by
  simp only [succAbove, predAbove, coe_inj]
  have : x ≠ (i:ℕ) := by aesop
  by_cases hx : (x:ℕ) < i <;> simp only [hx, ↓reduceDIte, toNat_mk, ↓reduceIte, coe_eq_iff']
  by_cases hx' : (x:ℕ) - 1 < i <;> simp only [hx', coe_eq_iff', toNat_mk, ↓reduceIte] <;> omega

@[simp]
theorem SetTheory.Set.Fin.predAbove_succAbove {n} (i : Fin (n + 1)) (x : Fin n) :
    (predAbove i) (succAbove i x) (succAbove_ne i x) = x := by
  simp only [succAbove, predAbove]
  by_cases hx : (x:ℕ) < i <;> simp only [hx, ↓reduceIte]
  · aesop
  have hx' : ¬((x : ℕ) + 1 < i) := by omega
  simp [hx']

/-- Exercise 3.6.12 (i), second part -/
theorem SetTheory.Set.Permutations_ih (n: ℕ):
    (Permutations (n + 1)).card = (n + 1) * (Permutations n).card := by
  let S i := (Permutations (n + 1)).specify (fun p ↦ perm_equiv_equiv p (Fin.last n) = i)

  have hSd : Pairwise fun i j => Disjoint (S i) (S j) := by
    intro i h hij
    rw [disjoint_iff, eq_empty_iff_forall_notMem]
    aesop

  have hSe : ∀ i, S i ≈ Permutations n := by
    intro i
    have si_to_equiv : S i ≃ {f : Fin (n + 1) ≃ Fin (n + 1) // f (Fin.last n) = i} := {
      toFun s := by
        let hs := s.property
        simp only [specification_axiom'', S] at hs
        let p : Permutations (n + 1) := ⟨s, by grind⟩
        let f := perm_equiv_equiv p
        exact ⟨f, by grind⟩
      invFun := fun ⟨f, hf⟩ ↦
        let p := perm_equiv_equiv.symm f
        ⟨p, by simp only [specification_axiom'', S]; grind⟩
      left_inv s := by ext; simp
      right_inv e := by ext; simp
    }
    have equiv_to_equiv : {f : Fin (n + 1) ≃ Fin (n + 1) // f (Fin.last n) = i} ≃ (Fin n ≃ Fin n) := open Classical in {
      toFun := fun ⟨f, hf⟩ => {
        toFun x := Fin.predAbove i (f (Fin.castSucc x)) (by
          intro h
          rw [←hf] at h
          have := f.injective h
          have : x = n := by simpa
          have : x < n := Fin.toNat_lt x
          omega)
        invFun x := Fin.castPred (f.invFun (Fin.succAbove i x)) (by
          suffices : f.invFun (Fin.succAbove i x) ≠ (Fin.last n)
          · simpa
          intro h
          rw [←h, Equiv.invFun_as_coe] at hf
          aesop)
        left_inv := by intro; simp
        right_inv := by intro; simp
      },
      invFun := fun g => ⟨{
        toFun x := if hx : x = n then i else Fin.succAbove i (g (Fin.castPred x hx))
        invFun x := if hx : x = i then Fin.last n else Fin.castSucc (g.invFun (Fin.predAbove i x hx))
        left_inv := by intro; aesop
        right_inv := by intro; aesop
      }, by simp⟩
      left_inv := by intro f; ext x; simp_all [Subtype.coe_inj, ←f.property]
      right_inv := by intro; aesop
    }
    have equiv := si_to_equiv.trans (equiv_to_equiv.trans perm_equiv_equiv.symm)
    exact ⟨equiv.toFun, equiv.injective, equiv.surjective⟩

  have hSc : ∀ i, (S i).has_card (Permutations n).card := by
    intro i
    rw [EquivCard_to_has_card_eq (hSe i)]
    apply has_card_card
    apply Permutations_finite

  have hPu : Permutations (n + 1) = iUnion (Fin (n + 1)) S := by
    ext x
    simp only [mem_iUnion, S, specification_axiom'']
    grind

  have ⟨_, huc⟩ := card_iUnion_card_disjoint hSc hSd
  rw [hPu, huc]
```