### PR TITLE
Fix statement of Exercise 4.1.8

### DIFF
--- a/analysis/Analysis/Section_4_1.lean
+++ b/analysis/Analysis/Section_4_1.lean
@@ -301,7 +301,7 @@ instance Int.instLinearOrder : LinearOrder Int where
 theorem Int.neg_one_mul (a:Int) : -1 * a = -a := by sorry
 
 /-- Exercise 4.1.8 -/
-theorem Int.no_induction : ∃ P: Int → Prop, P 0 ∧ ∀ n, P n → P (n+1) ∧ ¬ ∀ n, P n := by sorry
+theorem Int.no_induction : ∃ P: Int → Prop, (P 0 ∧ ∀ n, P n → P (n+1)) ∧ ¬ ∀ n, P n := by sorry
 
 /-- A nonnegative number squared is nonnegative. This is a special case of 4.1.9 that's useful for proving the general case. --/
 lemma Int.sq_nonneg_of_pos (n:Int) (h: 0 ≤ n) : 0 ≤ n*n := by sorry


### PR DESCRIPTION
I might be misreading it but I think this is the intended meaning. We want to separately say "the prop is true for 0 and carries through each n -> n + 1 step" and "there's still some n for which the prop isn't true". But the latter used to be nested into former due to operator precedence.

## Playthrough

```lean
theorem Int.no_induction : ∃ P: Int → Prop, (P 0 ∧ ∀ n, P n → P (n+1)) ∧ ¬ ∀ n, P n := by
  use fun x ↦ x ≥ 0
  simp only [le_refl, true_and]
  constructor
  · intro n hn
    trans n
    · rw [ge_iff_le, le_iff]
      use 1
      simp
    exact hn
  push_neg
  use -1
  rw [lt_iff]
  constructor
  · use 1; norm_num
  · norm_num
```