### PR TITLE
Add build instructions and style conventions to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,26 @@
 
 I would be interested in having volunteers "playtest" the companion (using downstream forks of the repository) to see if this can actually be done (and if the helper lemmas or "API" provided in the Lean files are sufficient to fill in the sorries in a conceptually straightforward manner without having to rely on more esoteric Lean programming techniques). Any other feedback will of course also be welcome.  However, I do not intend to place solutions in this repository directly.
 
-# Adding a section
+## Building
+
+```bash
+lake exe cache get   # Fetch Mathlib prebuilt cache (run once)
+lake build           # Build and verify all proofs
+```
+
+The Lean toolchain version is pinned in `lean-toolchain`. Mathlib is pinned in `lakefile.lean`.
+
+## Style conventions
+
+- **Faithfulness over golfing.** Proofs should closely parallel the textbook argument, even if a shorter proof exists. Do not golf or "clean up" existing proofs — this has led to reverts (e.g., [#476]).
+- **Textbook definitions first.** Early chapters (especially Ch. 2) use custom definitions, not Mathlib. Later chapters transition to Mathlib. Respect whichever convention the section uses.
+- **Verso docstrings.** The project uses `doc.verso = true` for literate documentation. Docstrings use Verso format, not standard Lean doc comments.
+- **Line length.** Follow Mathlib convention: 100 characters max.
+- **Sorry warnings.** The project suppresses sorry warnings (`-Dwarn.sorry=false` in `lakefile.lean`) by design.
+
+[#476]: https://github.com/teorth/analysis/pull/476
+
+## Adding a section
 
 1. Add the relevant file to `Analysis/`
 2. Adapt the line in the README


### PR DESCRIPTION
Adds build instructions and style conventions to CONTRIBUTING.md:

- **Build instructions** — `lake exe cache get && lake build`
- **Style conventions** — faithfulness over golfing (with [#476] as precedent for reverts), textbook definitions, Verso docstrings, line length, sorry warning suppression

**Context:** Your recent update clarifies that solutions belong in downstream forks. I considered whether a style guide still makes sense given that framing, but looking at the PR history, there are active upstream contributions — statement/scaffold fixes (rkirov), infrastructure (david-christiansen), measure theory formalization (aodecipher) — where these conventions apply. Build instructions are useful for anyone working in a fork as well.

Separately — from my experience with PR #477, it may be worth adding a line encouraging contributors to engage with the textbook before filing proofs. I was approaching this as an AI-assisted experiment rather than learning the math, and that's probably worth discouraging.