### PR TITLE
Chore: removes two unnecessary propositions in MeasureTheory/Section_1_1_1

### DIFF
--- a/Analysis/MeasureTheory/Section_1_1_1.lean
+++ b/Analysis/MeasureTheory/Section_1_1_1.lean
@@ -288,27 +288,35 @@ def witness_upperBound_lowerBounds {X : Set ℝ} (y : ℝ) (hy : y ∈ X)
   intro u hu; simp [lowerBounds] at hu; exact hu hy
 
 /-- If x < sSup X, then there exists z ∈ X with x < z -/
-theorem exists_gt_of_lt_csSup {X : Set ℝ} (hBddAbove : BddAbove X) (hNonempty : X.Nonempty)
-    (hLowerBound : ∃ y ∈ X, y ∈ lowerBounds (upperBounds X)) (x : ℝ) (hx : x < sSup X) :
+theorem exists_gt_of_lt_csSup_OLD {X : Set ℝ} (hBddAbove : BddAbove X) (hNonempty : X.Nonempty)
+(x : ℝ) (hx : x < sSup X) :
     ∃ z ∈ X, x < z := by
   by_contra! h
-  have : sSup X ≤ x := by
-    rw [← csInf_upperBounds_eq_csSup hBddAbove hNonempty]
-    exact csInf_le
-      (by obtain ⟨y, hy, _⟩ := hLowerBound; exact ⟨y, witness_lowerBound_upperBounds y hy⟩)
-      (fun z hz => h z hz)
+  --we are going to show that x < sSup X and its opposite
+  --sSup X ≤ x to get a contradiction that linarith can find
+  have not_hx: sSup X ≤ x := by
+    rw [←csInf_upperBounds_eq_csSup hBddAbove hNonempty]
+    obtain ⟨y,hy⟩ : ∃ y : ℝ, y ∈ X := (Set.nonempty_def).mp hNonempty
+    have yLowerBound : y ∈ lowerBounds (upperBounds X) :=
+      witness_lowerBound_upperBounds y hy
+    apply csInf_le ⟨y,yLowerBound⟩ (fun z hz => h z hz)
   linarith
 
+
+
 /-- If sInf X < x, then there exists w ∈ X with w ≤ x -/
-theorem exists_le_of_lt_csInf {X : Set ℝ} (hBddBelow : BddBelow X) (hNonempty : X.Nonempty)
-    (hUpperBound : ∃ y ∈ X, y ∈ upperBounds (lowerBounds X)) (x : ℝ) (hx : sInf X < x) :
+theorem exists_le_of_lt_csInf_OLD {X : Set ℝ} (hBddBelow : BddBelow X) (hNonempty : X.Nonempty)
+    (x : ℝ) (hx : sInf X < x) :
     ∃ w ∈ X, w ≤ x := by
   by_contra! h
-  have : x ≤ sInf X := by
+    --we are going to show that sInf X <  x and its opposite
+    --"x ≤ sInf X" to get a contradiction that linarith can find
+  have not_hx: x ≤ sInf X := by
     rw [← csSup_lowerBounds_eq_csInf hBddBelow hNonempty]
-    exact le_csSup
-      (by obtain ⟨y, hy, _⟩ := hUpperBound; exact ⟨y, witness_upperBound_lowerBounds y hy⟩)
-      (fun u hu => le_of_lt (h u hu))
+    obtain ⟨y,hy⟩ : ∃ y : ℝ, y ∈ X := (Set.nonempty_def).mp hNonempty
+    have yUpperBound : y ∈ upperBounds (lowerBounds X) :=
+       witness_upperBound_lowerBounds y hy
+    apply le_csSup ⟨y,yUpperBound⟩ (fun z hz => le_of_lt (h z hz))
   linarith
 
 /-- Show x < b when b = sSup X and b ∉ X -/
@@ -378,8 +386,8 @@ theorem BoundedInterval.ordConnected_iff (X:Set ℝ) :
             exact ⟨csInf_le hBddBelow hx, lt_sSup_of_ne_sSup hBddAbove rfl hb hx (le_csSup hBddAbove hx)⟩
           · intro hx; simp [Set.mem_Ico] at hx
             have hb_eq : b = sSup X := rfl
-            obtain ⟨z, hz, hxz⟩ := exists_gt_of_lt_csSup hBddAbove hNonempty
-              ⟨a, ha, witness_lowerBound_upperBounds a ha⟩ x (by rw [←hb_eq]; exact hx.2)
+            obtain ⟨z, hz, hxz⟩ := exists_gt_of_lt_csSup_OLD hBddAbove hNonempty x
+              (by rw [←hb_eq]; exact hx.2)
             exact mem_of_mem_Icc_ordConnected hOrdConn ha hz ⟨hx.1, le_of_lt hxz⟩
       · by_cases hb : b ∈ X
         · -- Case: a ∉ X ∧ b ∈ X → use Ioc a b
@@ -390,8 +398,8 @@ theorem BoundedInterval.ordConnected_iff (X:Set ℝ) :
             by_cases hx_eq_b : x = b
             · rw [hx_eq_b]; exact hb
             · have ha_eq : a = sInf X := rfl
-              obtain ⟨w, hw, hwx⟩ := exists_le_of_lt_csInf hBddBelow hNonempty
-                ⟨b, hb, witness_upperBound_lowerBounds b hb⟩ x (by rw [←ha_eq]; exact hx.1)
+              obtain ⟨w, hw, hwx⟩ := exists_le_of_lt_csInf_OLD hBddBelow hNonempty x
+                (by rw [←ha_eq]; exact hx.1)
               exact mem_of_mem_Icc_ordConnected hOrdConn hw hb ⟨hwx, hx.2⟩
         · -- Case: a ∉ X ∧ b ∉ X → use Ioo a b
           use Ioo a b; simp [set_Ioo]; ext x; constructor
@@ -400,13 +408,9 @@ theorem BoundedInterval.ordConnected_iff (X:Set ℝ) :
               lt_sSup_of_ne_sSup hBddAbove rfl hb hx (le_csSup hBddAbove hx)⟩
           · intro hx; simp [Set.mem_Ioo] at hx
             have ha_eq : a = sInf X := rfl; have hb_eq : b = sSup X := rfl
-            have h_lower : ∃ y ∈ X, y ∈ lowerBounds (upperBounds X) := by
-              obtain ⟨y, hy⟩ := hNonempty; exact ⟨y, hy, witness_lowerBound_upperBounds y hy⟩
-            have h_upper : ∃ y ∈ X, y ∈ upperBounds (lowerBounds X) := by
-              obtain ⟨y, hy⟩ := hNonempty; exact ⟨y, hy, witness_upperBound_lowerBounds y hy⟩
-            obtain ⟨z, hz, hxz⟩ := exists_gt_of_lt_csSup hBddAbove hNonempty h_lower x
+            obtain ⟨z, hz, hxz⟩ := exists_gt_of_lt_csSup_OLD hBddAbove hNonempty x
               (by rw [←hb_eq]; exact hx.2)
-            obtain ⟨w, hw, hwx⟩ := exists_le_of_lt_csInf hBddBelow hNonempty h_upper x
+            obtain ⟨w, hw, hwx⟩ := exists_le_of_lt_csInf_OLD hBddBelow hNonempty x
               (by rw [←ha_eq]; exact hx.1)
             exact mem_of_mem_Icc_ordConnected hOrdConn hw hz ⟨hwx, le_of_lt hxz⟩
   · -- Trivial direction: if X = I for some BoundedInterval I, then X is bounded and order-connected

--- a/Analysis/MeasureTheory/Section_1_1_1.lean
+++ b/Analysis/MeasureTheory/Section_1_1_1.lean
@@ -288,7 +288,7 @@ def witness_upperBound_lowerBounds {X : Set ℝ} (y : ℝ) (hy : y ∈ X)
   intro u hu; simp [lowerBounds] at hu; exact hu hy
 
 /-- If x < sSup X, then there exists z ∈ X with x < z -/
-theorem exists_gt_of_lt_csSup_OLD {X : Set ℝ} (hBddAbove : BddAbove X) (hNonempty : X.Nonempty)
+theorem exists_gt_of_lt_csSup{X : Set ℝ} (hBddAbove : BddAbove X) (hNonempty : X.Nonempty)
 (x : ℝ) (hx : x < sSup X) :
     ∃ z ∈ X, x < z := by
   by_contra! h
@@ -305,7 +305,7 @@ theorem exists_gt_of_lt_csSup_OLD {X : Set ℝ} (hBddAbove : BddAbove X) (hNonem
 
 
 /-- If sInf X < x, then there exists w ∈ X with w ≤ x -/
-theorem exists_le_of_lt_csInf_OLD {X : Set ℝ} (hBddBelow : BddBelow X) (hNonempty : X.Nonempty)
+theorem exists_le_of_lt_csInf {X : Set ℝ} (hBddBelow : BddBelow X) (hNonempty : X.Nonempty)
     (x : ℝ) (hx : sInf X < x) :
     ∃ w ∈ X, w ≤ x := by
   by_contra! h
@@ -386,7 +386,7 @@ theorem BoundedInterval.ordConnected_iff (X:Set ℝ) :
             exact ⟨csInf_le hBddBelow hx, lt_sSup_of_ne_sSup hBddAbove rfl hb hx (le_csSup hBddAbove hx)⟩
           · intro hx; simp [Set.mem_Ico] at hx
             have hb_eq : b = sSup X := rfl
-            obtain ⟨z, hz, hxz⟩ := exists_gt_of_lt_csSup_OLD hBddAbove hNonempty x
+            obtain ⟨z, hz, hxz⟩ := exists_gt_of_lt_csSup hBddAbove hNonempty x
               (by rw [←hb_eq]; exact hx.2)
             exact mem_of_mem_Icc_ordConnected hOrdConn ha hz ⟨hx.1, le_of_lt hxz⟩
       · by_cases hb : b ∈ X
@@ -398,7 +398,7 @@ theorem BoundedInterval.ordConnected_iff (X:Set ℝ) :
             by_cases hx_eq_b : x = b
             · rw [hx_eq_b]; exact hb
             · have ha_eq : a = sInf X := rfl
-              obtain ⟨w, hw, hwx⟩ := exists_le_of_lt_csInf_OLD hBddBelow hNonempty x
+              obtain ⟨w, hw, hwx⟩ := exists_le_of_lt_csInf hBddBelow hNonempty x
                 (by rw [←ha_eq]; exact hx.1)
               exact mem_of_mem_Icc_ordConnected hOrdConn hw hb ⟨hwx, hx.2⟩
         · -- Case: a ∉ X ∧ b ∉ X → use Ioo a b
@@ -408,9 +408,9 @@ theorem BoundedInterval.ordConnected_iff (X:Set ℝ) :
               lt_sSup_of_ne_sSup hBddAbove rfl hb hx (le_csSup hBddAbove hx)⟩
           · intro hx; simp [Set.mem_Ioo] at hx
             have ha_eq : a = sInf X := rfl; have hb_eq : b = sSup X := rfl
-            obtain ⟨z, hz, hxz⟩ := exists_gt_of_lt_csSup_OLD hBddAbove hNonempty x
+            obtain ⟨z, hz, hxz⟩ := exists_gt_of_lt_csSup hBddAbove hNonempty x
               (by rw [←hb_eq]; exact hx.2)
-            obtain ⟨w, hw, hwx⟩ := exists_le_of_lt_csInf_OLD hBddBelow hNonempty x
+            obtain ⟨w, hw, hwx⟩ := exists_le_of_lt_csInf hBddBelow hNonempty x
               (by rw [←ha_eq]; exact hx.1)
             exact mem_of_mem_Icc_ordConnected hOrdConn hw hz ⟨hwx, le_of_lt hxz⟩
   · -- Trivial direction: if X = I for some BoundedInterval I, then X is bounded and order-connected

--- a/Analysis/MeasureTheory/Section_1_1_1.lean
+++ b/Analysis/MeasureTheory/Section_1_1_1.lean
@@ -299,7 +299,7 @@ def witness_upperBound_lowerBounds {X : Set ℝ} (y : ℝ) (hy : y ∈ X)
 
 /-- Show x < b when b = sSup X and b ∉ X -/
 theorem lt_sSup_of_ne_sSup {X : Set ℝ} {x b : ℝ} (_hBddAbove : BddAbove X) (_hb : b = sSup X)
-    (hb_notin : b ∉ X) (hx : x ∈ X) (hx_le_b : x ≤ b) : x < b := by  
+    (hb_notin : b ∉ X) (hx : x ∈ X) (hx_le_b : x ≤ b) : x < b := by
   by_contra! h;  exact hb_notin (hx_le_b.antisymm h ▸ hx)
 
 /-- Show a < x when a = sInf X and a ∉ X -/

--- a/Analysis/MeasureTheory/Section_1_1_1.lean
+++ b/Analysis/MeasureTheory/Section_1_1_1.lean
@@ -287,42 +287,20 @@ def witness_upperBound_lowerBounds {X : Set ℝ} (y : ℝ) (hy : y ∈ X)
     : y ∈ upperBounds (lowerBounds X) := by
   intro u hu; simp [lowerBounds] at hu; exact hu hy
 
-/-- If x < sSup X, then there exists z ∈ X with x < z -/
-theorem exists_gt_of_lt_csSup{X : Set ℝ} (hBddAbove : BddAbove X) (hNonempty : X.Nonempty)
-(x : ℝ) (hx : x < sSup X) :
-    ∃ z ∈ X, x < z := by
-  by_contra! h
-  --we are going to show that x < sSup X and its opposite
-  --sSup X ≤ x to get a contradiction that linarith can find
-  have not_hx: sSup X ≤ x := by
-    rw [←csInf_upperBounds_eq_csSup hBddAbove hNonempty]
-    obtain ⟨y,hy⟩ : ∃ y : ℝ, y ∈ X := (Set.nonempty_def).mp hNonempty
-    have yLowerBound : y ∈ lowerBounds (upperBounds X) :=
-      witness_lowerBound_upperBounds y hy
-    apply csInf_le ⟨y,yLowerBound⟩ (fun z hz => h z hz)
-  linarith
+/- If x < sSup X and X is not empty, then there exists z ∈ X with x < z -/
+/- We don't need to assume that X is BddAbove
+-(if X is not Bddabove, we get that sSup X = 0 (the junk value) and the result still follows -/
+#check exists_lt_of_lt_csSup
 
-
-
-/-- If sInf X < x, then there exists w ∈ X with w ≤ x -/
-theorem exists_le_of_lt_csInf {X : Set ℝ} (hBddBelow : BddBelow X) (hNonempty : X.Nonempty)
-    (x : ℝ) (hx : sInf X < x) :
-    ∃ w ∈ X, w ≤ x := by
-  by_contra! h
-    --we are going to show that sInf X <  x and its opposite
-    --"x ≤ sInf X" to get a contradiction that linarith can find
-  have not_hx: x ≤ sInf X := by
-    rw [← csSup_lowerBounds_eq_csInf hBddBelow hNonempty]
-    obtain ⟨y,hy⟩ : ∃ y : ℝ, y ∈ X := (Set.nonempty_def).mp hNonempty
-    have yUpperBound : y ∈ upperBounds (lowerBounds X) :=
-       witness_upperBound_lowerBounds y hy
-    apply le_csSup ⟨y,yUpperBound⟩ (fun z hz => le_of_lt (h z hz))
-  linarith
+/- If sInf X < x and X is not empty, then there exists w ∈ X with w ≤ x -/
+/- We don't need to assume that X is BddBelow.
+-(if X if not BddBelow, we get that sInf X = 0 (the junk value) and the result still follows-/
+#check exists_lt_of_csInf_lt
 
 /-- Show x < b when b = sSup X and b ∉ X -/
 theorem lt_sSup_of_ne_sSup {X : Set ℝ} {x b : ℝ} (_hBddAbove : BddAbove X) (_hb : b = sSup X)
-    (hb_notin : b ∉ X) (hx : x ∈ X) (hx_le_b : x ≤ b) : x < b := by
-  by_contra! h; exact hb_notin (hx_le_b.antisymm h ▸ hx)
+    (hb_notin : b ∉ X) (hx : x ∈ X) (hx_le_b : x ≤ b) : x < b := by  
+  by_contra! h;  exact hb_notin (hx_le_b.antisymm h ▸ hx)
 
 /-- Show a < x when a = sInf X and a ∉ X -/
 theorem sInf_lt_of_ne_sInf {X : Set ℝ} {a x : ℝ} (_hBddBelow : BddBelow X) (_ha : a = sInf X)
@@ -386,7 +364,7 @@ theorem BoundedInterval.ordConnected_iff (X:Set ℝ) :
             exact ⟨csInf_le hBddBelow hx, lt_sSup_of_ne_sSup hBddAbove rfl hb hx (le_csSup hBddAbove hx)⟩
           · intro hx; simp [Set.mem_Ico] at hx
             have hb_eq : b = sSup X := rfl
-            obtain ⟨z, hz, hxz⟩ := exists_gt_of_lt_csSup hBddAbove hNonempty x
+            obtain ⟨z, hz, hxz⟩ := exists_lt_of_lt_csSup hNonempty
               (by rw [←hb_eq]; exact hx.2)
             exact mem_of_mem_Icc_ordConnected hOrdConn ha hz ⟨hx.1, le_of_lt hxz⟩
       · by_cases hb : b ∈ X
@@ -398,9 +376,9 @@ theorem BoundedInterval.ordConnected_iff (X:Set ℝ) :
             by_cases hx_eq_b : x = b
             · rw [hx_eq_b]; exact hb
             · have ha_eq : a = sInf X := rfl
-              obtain ⟨w, hw, hwx⟩ := exists_le_of_lt_csInf hBddBelow hNonempty x
+              obtain ⟨w, hw, hwx⟩ := exists_lt_of_csInf_lt  hNonempty
                 (by rw [←ha_eq]; exact hx.1)
-              exact mem_of_mem_Icc_ordConnected hOrdConn hw hb ⟨hwx, hx.2⟩
+              exact mem_of_mem_Icc_ordConnected hOrdConn hw hb ⟨le_of_lt hwx, hx.2⟩
         · -- Case: a ∉ X ∧ b ∉ X → use Ioo a b
           use Ioo a b; simp [set_Ioo]; ext x; constructor
           · intro hx; simp [Set.mem_Ioo]
@@ -408,11 +386,11 @@ theorem BoundedInterval.ordConnected_iff (X:Set ℝ) :
               lt_sSup_of_ne_sSup hBddAbove rfl hb hx (le_csSup hBddAbove hx)⟩
           · intro hx; simp [Set.mem_Ioo] at hx
             have ha_eq : a = sInf X := rfl; have hb_eq : b = sSup X := rfl
-            obtain ⟨z, hz, hxz⟩ := exists_gt_of_lt_csSup hBddAbove hNonempty x
+            obtain ⟨z, hz, hxz⟩ := exists_lt_of_lt_csSup hNonempty
               (by rw [←hb_eq]; exact hx.2)
-            obtain ⟨w, hw, hwx⟩ := exists_le_of_lt_csInf hBddBelow hNonempty x
+            obtain ⟨w, hw, hwx⟩ := exists_lt_of_csInf_lt hNonempty
               (by rw [←ha_eq]; exact hx.1)
-            exact mem_of_mem_Icc_ordConnected hOrdConn hw hz ⟨hwx, le_of_lt hxz⟩
+            exact mem_of_mem_Icc_ordConnected hOrdConn hw hz ⟨le_of_lt hwx, le_of_lt hxz⟩
   · -- Trivial direction: if X = I for some BoundedInterval I, then X is bounded and order-connected
     intro ⟨I, hX⟩
     have hX' : X = (I : Set ℝ) := hX


### PR DESCRIPTION
Removes two unnecessary propositions in Analysis/MeasureTheory/Section_1_1_1.  Instead of using the propositions we use almost identical propositions that are provided in Mathlib.