### PR TITLE
Chore: added an import of Section_3_3 in Section_3_5

### DIFF
--- a/Analysis/Section_3_6.lean
+++ b/Analysis/Section_3_6.lean
@@ -1,4 +1,5 @@
 import Mathlib.Tactic
+import Analysis.Section_3_3
 import Analysis.Section_3_5
 
 /-!


### PR DESCRIPTION
To show that EqualCard is a symmetric relation, it is useful to have access to Function.inverse.  This is introduced in Section_3_3.  It wasn't imported before (or transitively imported).