### PR TITLE
Fix IVT statement typo in Theorem 9.7.1

### DIFF
--- a/Analysis/Section_9_7.lean
+++ b/Analysis/Section_9_7.lean
@@ -19,7 +19,7 @@ Main constructions and results of this section:
 namespace Chapter9
 
 /-- Theorem 9.7.1 (Intermediate value theorem) -/
-theorem intermediate_value {a b:ℝ} (hab: a < b) {f:ℝ → ℝ} (hf: ContinuousOn f (.Icc a b)) {y:ℝ} (hy: y ∈ Set.Icc (f a) (f b) ∨ y ∈ Set.Icc (f a) (f b)) :
+theorem intermediate_value {a b:ℝ} (hab: a < b) {f:ℝ → ℝ} (hf: ContinuousOn f (.Icc a b)) {y:ℝ} (hy: y ∈ Set.Icc (f a) (f b) ∨ y ∈ Set.Icc (f b) (f a)) :
   ∃ c ∈ Set.Icc a b, f c = y := by
   -- This proof is written to follow the structure of the original text.
   obtain hy_left | hy_right := hy


### PR DESCRIPTION
Both disjuncts of `hy` in `intermediate_value` were identical (`y ∈ Set.Icc (f a) (f b)`). Correct the second disjunct to `y ∈ Set.Icc (f b) (f a)` to cover the case `f b ≤ f a`, matching Tao's Theorem 9.7.1.