### PR TITLE
Fix Exercise 9.8.2 IVT counterexample statements

### DIFF
--- a/Analysis/Section_9_8.lean
+++ b/Analysis/Section_9_8.lean
@@ -107,13 +107,25 @@ theorem BddOn.of_antitone {a b:ℝ} {f:ℝ → ℝ} (hf: AntitoneOn f (.Icc a b)
 
 
 /-- Exercise 9.8.2 -/
-theorem no_strictmono_intermediate_value : ∃ (a b:ℝ) (hab: a < b) (f:ℝ → ℝ) (hf: StrictMonoOn f (.Icc a b)), ¬ ∃ y, y ∈ Set.Icc (f a) (f b) ∨ y ∈ Set.Icc (f a) (f b) := by sorry
+theorem no_strictmono_intermediate_value :
+    ∃ (a b:ℝ) (hab: a < b) (f:ℝ → ℝ) (hf: StrictMonoOn f (.Icc a b)),
+      ∃ y, (y ∈ Set.Icc (f a) (f b) ∨ y ∈ Set.Icc (f b) (f a)) ∧
+      ¬ ∃ c ∈ Set.Icc a b, f c = y := by sorry
 
-theorem no_monotone_intermediate_value : ∃ (a b:ℝ) (hab: a < b) (f:ℝ → ℝ) (hf: MonotoneOn f (.Icc a b)), ¬ ∃ y, y ∈ Set.Icc (f a) (f b) ∨ y ∈ Set.Icc (f a) (f b) := by sorry
+theorem no_monotone_intermediate_value :
+    ∃ (a b:ℝ) (hab: a < b) (f:ℝ → ℝ) (hf: MonotoneOn f (.Icc a b)),
+      ∃ y, (y ∈ Set.Icc (f a) (f b) ∨ y ∈ Set.Icc (f b) (f a)) ∧
+      ¬ ∃ c ∈ Set.Icc a b, f c = y := by sorry
 
-theorem no_strictanti_intermediate_value : ∃ (a b:ℝ) (hab: a < b) (f:ℝ → ℝ) (hf: StrictAntiOn f (.Icc a b)), ¬ ∃ y, y ∈ Set.Icc (f a) (f b) ∨ y ∈ Set.Icc (f a) (f b) := by sorry
+theorem no_strictanti_intermediate_value :
+    ∃ (a b:ℝ) (hab: a < b) (f:ℝ → ℝ) (hf: StrictAntiOn f (.Icc a b)),
+      ∃ y, (y ∈ Set.Icc (f a) (f b) ∨ y ∈ Set.Icc (f b) (f a)) ∧
+      ¬ ∃ c ∈ Set.Icc a b, f c = y := by sorry
 
-theorem no_antitone_intermediate_value : ∃ (a b:ℝ) (hab: a < b) (f:ℝ → ℝ) (hf: AntitoneOn f (.Icc a b)), ¬ ∃ y, y ∈ Set.Icc (f a) (f b) ∨ y ∈ Set.Icc (f a) (f b) := by sorry
+theorem no_antitone_intermediate_value :
+    ∃ (a b:ℝ) (hab: a < b) (f:ℝ → ℝ) (hf: AntitoneOn f (.Icc a b)),
+      ∃ y, (y ∈ Set.Icc (f a) (f b) ∨ y ∈ Set.Icc (f b) (f a)) ∧
+      ¬ ∃ c ∈ Set.Icc a b, f c = y := by sorry
 
 /-- Exercise 9.8.3 -/
 theorem mono_of_continuous_inj {a b:ℝ} (h: a < b) {f:ℝ → ℝ}


### PR DESCRIPTION
This corrects the statements of the four Exercise 9.8.2 counterexamples.

The previous statements negated the existence of an intermediate value `y`, and also duplicated the interval condition. This expressed that no intermediate value exists, rather than that an intermediate value has no preimage in `[a,b]`.

The updated statements follow the shape of Theorem 9.7.1: choose `y` between `f a` and `f b`, then assert that no `c ∈ Set.Icc a b` maps to `y`.

No exercise solutions are added; the proofs remain `sorry`.

Verified with:
`lake build Analysis.Section_9_8`