### PR TITLE
Fix stale declaration references in comments

### DIFF
--- a/Analysis/MeasureTheory/Section_1_1_3.lean
+++ b/Analysis/MeasureTheory/Section_1_1_3.lean
@@ -843,7 +843,10 @@ lemma to_PiecewiseConstantOn {I: BoundedInterval} (g: PiecewiseConstantFunction 
   use ⟨g, hg_agrees⟩
   exact PiecewiseConstantOn.integral_eq g.f ⟨g, hg_agrees⟩ g hg_agrees
 
-/-- Helper: Apply `PiecewiseConstantOn.integral_mono` between two {name}`PiecewiseConstantFunction`s via {name}`PiecewiseConstantOn` -/
+/--
+Helper: Apply {name}`PiecewiseConstantFunction.integral_mono` between two
+{name}`PiecewiseConstantFunction`s via {name}`PiecewiseConstantOn`.
+-/
 lemma integral_mono' {I: BoundedInterval}
     (g h: PiecewiseConstantFunction I) (h_pointwise: ∀ x ∈ I.toSet, g.f x ≤ h.f x) :
     g.integral ≤ h.integral := by

--- a/Analysis/Section_9_1.lean
+++ b/Analysis/Section_9_1.lean
@@ -56,7 +56,10 @@ example {a b: EReal} (h: a ≥ b) : Set.Ioo a b = ∅ := by
 example {a b: EReal} (h: a = b) : Set.Icc a b = {a} := by
   sorry
 
-/-- Definition 9.1.5.  Note that a slightly different `Real.adherent` was defined in Chapter 6.4 -/
+/--
+Definition 9.1.5.  Note that a slightly different {name}`Real.Adherent` was defined in
+Chapter 6.4
+-/
 abbrev Real.adherent' (ε:ℝ) (x:ℝ) (X: Set ℝ) := ∃ y ∈ X, |x - y| ≤ ε
 
 /-- Example 9.1.7 -/

--- a/Analysis/Section_9_8.lean
+++ b/Analysis/Section_9_8.lean
@@ -146,7 +146,10 @@ def MonotoneOn.exist_inverse_without_strictmono {a b:ℝ} (h: a < b) (f: ℝ →
   sorry
 
 
-/- Exercise 9.8.4: state and prove an analogue of `MonotoneOne.exist_inverse` for `Antitone` functions. -/
+/-
+Exercise 9.8.4: state and prove an analogue of `MonotoneOn.exist_inverse` for `Antitone`
+functions.
+-/
 -- theorem AntitoneOn.exist_inverse {a b:ℝ} (h: a < b) (f: ℝ → ℝ) (hcont: ContinuousOn f (.Icc a b)) (hmono: StrictAntiOn f (.Icc a b)) : sorry := by sorry
 
 /-- An equivalence between the natural numbers and the rationals. -/

--- a/Analysis/Section_9_9.lean
+++ b/Analysis/Section_9_9.lean
@@ -78,7 +78,10 @@ example : ¬ UniformContinuousOn (fun x:ℝ ↦ 1/x) (Set.Icc 0 2) := by
 
 end Chapter9
 
-/-- Definition 9.9.5.  This is similar but not identical to `Real.close_seq` from Section 6.1. -/
+/--
+Definition 9.9.5.  This is similar but not identical to {name}`Real.CloseSeq` from
+Section 6.1.
+-/
 abbrev Real.CloseSeqs (ε:ℝ) (a b: Chapter6.Sequence) : Prop :=
   (a.m = b.m) ∧ ∀ n ≥ a.m, ε.Close (a n) (b n)
 


### PR DESCRIPTION
While reading and playtesting the files, I noticed a few stale or misspelled declaration references in comments/docstrings.

This PR updates those references only:

- `MonotoneOne.exist_inverse` -> `MonotoneOn.exist_inverse`
- `Real.adherent` -> `Real.Adherent` where the comment refers to the Chapter 6.4 definition
- `Real.close_seq` -> `Real.CloseSeq`
- `PiecewiseConstantOn.integral_mono` -> `PiecewiseConstantFunction.integral_mono`

No statements or proofs are changed.

Verified with:

```bash
lake build Analysis.Section_9_1 Analysis.Section_9_8 Analysis.Section_9_9 Analysis.MeasureTheory.Section_1_1_3
```

I also checked that the updated names resolve with Lean `#check`.