### PR TITLE
Section 9.9: fix `.Icc 0 2` -> `.Ioo 0 2` in opening 1/x examples

### DIFF
--- a/Analysis/Section_9_9.lean
+++ b/Analysis/Section_9_9.lean
@@ -21,10 +21,10 @@ open Chapter6 Filter
 
 namespace Chapter9
 
-example : ContinuousOn (fun x:ℝ ↦ 1/x) (.Icc 0 2) := by
+example : ContinuousOn (fun x:ℝ ↦ 1/x) (.Ioo 0 2) := by
   sorry
 
-example : ¬ BddOn (fun x:ℝ ↦ 1/x) (.Icc 0 2) := by
+example : ¬ BddOn (fun x:ℝ ↦ 1/x) (.Ioo 0 2) := by
   sorry
 
 /-- Example 9.9.1 -/


### PR DESCRIPTION
The two opening examples about `1/x` use `.Icc 0 2` (closed interval including 0). With Mathlib's junk-valued `1/0 = 0`, the continuity claim at `0` is actually false (the limit from the right is `+∞` while the value is `0`), and the unboundedness claim reads oddly. The intended Tao statements are on the open interval `.Ioo 0 2`.