### PR TITLE
Fix Section 10.2 typos and redundant hypotheses

### DIFF
--- a/Analysis/Section_10_2.lean
+++ b/Analysis/Section_10_2.lean
@@ -41,16 +41,16 @@ example : ¬ IsMinOn f_10_2_3 .univ 0 := by sorry
 
 example : IsMinOn f_10_2_3 (.Ioo (-1) 1) 0 := by sorry
 
-example : IsLocalMaxOn f_10_2_3 .univ 0 := by sorry
+example : IsLocalMinOn f_10_2_3 .univ 0 := by sorry
 
 /-- Example 10.2.4 -/
 example : ¬ ∃ x, IsMaxOn (· : ℝ → ℝ)  ((↑· : ℤ → ℝ) '' .univ) x := by sorry
 
 example : ¬ ∃ x, IsMinOn (· : ℝ → ℝ)  ((↑· : ℤ → ℝ) '' .univ) x := by sorry
 
-example (n:ℤ) : IsMaxOn (· : ℝ → ℝ)  ((↑· : ℤ → ℝ) '' .univ) n := by sorry
+example (n:ℤ) : IsLocalMaxOn (· : ℝ → ℝ)  ((↑· : ℤ → ℝ) '' .univ) n := by sorry
 
-example (n:ℤ) : IsMinOn (· : ℝ → ℝ)  ((↑· : ℤ → ℝ) '' .univ) n := by sorry
+example (n:ℤ) : IsLocalMinOn (· : ℝ → ℝ)  ((↑· : ℤ → ℝ) '' .univ) n := by sorry
 
 /-- Remark 10.2.5 -/
 theorem IsLocalMaxOn.of_restrict {X Y:Set ℝ} (hXY: Y ⊆ X) (f:ℝ → ℝ) (x₀:ℝ)
@@ -62,18 +62,18 @@ theorem IsLocalMinOn.of_restrict {X Y:Set ℝ} (hXY: Y ⊆ X) (f:ℝ → ℝ) (x
   sorry
 
 /-- Proposition 10.2.6 (Local extrema are stationary) / Exercise 10.2.1 -/
-theorem IsLocalMaxOn.deriv_eq_zero {a b:ℝ} (hab: a < b) {f:ℝ → ℝ} {x₀:ℝ}
+theorem IsLocalMaxOn.deriv_eq_zero {a b:ℝ} {f:ℝ → ℝ} {x₀:ℝ}
   (hx₀: x₀ ∈ Set.Ioo a b) (h: IsLocalMaxOn f (.Ioo a b) x₀) {L:ℝ}
   (hderiv: HasDerivWithinAt f L (.Ioo a b) x₀) : L = 0 := by
   sorry
 
 /-- Proposition 10.2.6 (Local extrema are stationary) / Exercise 10.2.1 -/
-theorem IsLocalMinOn.deriv_eq_zero {a b:ℝ} (hab: a < b) {f:ℝ → ℝ} {x₀:ℝ}
+theorem IsLocalMinOn.deriv_eq_zero {a b:ℝ} {f:ℝ → ℝ} {x₀:ℝ}
   (hx₀: x₀ ∈ Set.Ioo a b) (h: IsLocalMinOn f (.Ioo a b) x₀) {L:ℝ}
   (hderiv: HasDerivWithinAt f L (.Ioo a b) x₀) : L = 0 := by
   sorry
 
-theorem IsMaxOn.deriv_eq_zero_counter : ∃ (a b:ℝ) (hab: a < b) (f:ℝ → ℝ)
+theorem IsMaxOn.deriv_eq_zero_counter : ∃ (a b:ℝ) (f:ℝ → ℝ)
   (x₀:ℝ) (hx₀: x₀ ∈ Set.Icc a b) (h: IsMaxOn f (.Icc a b) x₀) (L:ℝ)
   (hderiv: HasDerivWithinAt f L (.Icc a b) x₀), L ≠ 0 := by
   sorry


### PR DESCRIPTION
Correct IsMaxOn/IsMinOn to IsLocalMaxOn/IsLocalMinOn in three examples where the local variants were intended. Remove redundant `hab: a < b` hypotheses from `deriv_eq_zero` lemmas and the `IsMaxOn` counterexample, since `x₀ ∈ Set.Ioo a b` already implies `a < b`.