### PR TITLE
Section 11.1: fix two unprovable statements

### DIFF
--- a/Analysis/Section_11_1.lean
+++ b/Analysis/Section_11_1.lean
@@ -93,7 +93,7 @@ theorem BoundedInterval.inter_eq (I J: BoundedInterval) : (I ∩ J : BoundedInte
   (BoundedInterval.inter I J).choose_spec.symm
 
 example :
-  (Ioo 2 4 ∩ Icc 4 6) = (Icc 4 4 : Set ℝ) := by
+  (Icc 2 4 ∩ Icc 4 6) = (Icc 4 4 : Set ℝ) := by
   sorry
 
 instance BoundedInterval.instMembership : Membership ℝ BoundedInterval where
@@ -429,9 +429,12 @@ noncomputable instance Partition.instMax (I: BoundedInterval) : Max (Partition I
     }
 
 
-/-- Example 11.1.17 -/
-example : ∃ P P' : Partition (Icc 1 4), P.intervals = {Ico 1 3, Icc 3 4} ∧ P'.intervals = {Icc 1 2, Ioc 2 4} ∧
-  (P' ⊔ P).intervals = {Icc 1 2, Ioo 2 3, Icc 3 4, ∅} := by
+/-- Example 11.1.17. -/
+example : ∃ P P' : Partition (Icc 1 4),
+    P.intervals = {Ico 1 3, Icc 3 4} ∧
+    P'.intervals = {Icc 1 2, Ioc 2 4} ∧
+    (P' ⊔ P).intervals.image toSet =
+      {Set.Icc 1 2, Set.Ioo 2 3, Set.Icc 3 4, ∅} := by
   sorry
 
 /-- Lemma 11.1.8 / Exercise 11.1.4 -/


### PR DESCRIPTION
- The intersection example near `BoundedInterval.inter_eq` claimed `Ioo 2 4 ∩ Icc 4 6 = Icc 4 4`, which is false as sets (`Ioo 2 4 ∩ Icc 4 6 = ∅`).  Change to `Icc 2 4 ∩ Icc 4 6`, matching the intended `Icc 4 4` RHS.

- Example 11.1.17 stated `(P' ⊔ P).intervals = {Icc 1 2, Ioo 2 3, Icc 3 4, ∅}` as a `Finset BoundedInterval` equality, which is unprovable because `BoundedInterval.inter` is `Classical.choose`-based and does not commit to a canonical constructor (e.g. nothing forces `(Icc 1 2 ∩ Ico 1 3 : BoundedInterval) = Icc 1 2`).  Restate the third conjunct at the set level, via the coercion image, with a comment explaining why.