### PR TITLE
Section 11.3: fix statement typos in three exercises

### DIFF
--- a/Analysis/Section_11_3.lean
+++ b/Analysis/Section_11_3.lean
@@ -151,12 +151,12 @@ noncomputable abbrev lower_riemann_sum (f:ℝ → ℝ) {I: BoundedInterval} (P: 
 
 /-- Lemma 11.3.11 / Exercise 11.3.4 -/
 theorem upper_riemann_sum_le {f g: ℝ → ℝ} {I:BoundedInterval} (P: Partition I)
-  (hf: BddOn f I) (hgf: MajorizesOn g f I) (hg: PiecewiseConstantOn g I) :
+  (hgf: MajorizesOn g f I) (hg: PiecewiseConstantWith g P) :
   upper_riemann_sum f P ≤ integ g I := by
    sorry
 
 theorem lower_riemann_sum_ge {f h: ℝ → ℝ} {I:BoundedInterval} (P: Partition I)
-  (hf: BddOn f I) (hfh: MinorizesOn h f I) (hg: PiecewiseConstantOn h I) :
+  (hfh: MinorizesOn h f I) (hg: PiecewiseConstantWith h P) :
   integ h I ≤ lower_riemann_sum f P := by
    sorry
 
@@ -184,7 +184,7 @@ theorem MajorizesOn.trans {f g h: ℝ → ℝ} {I: BoundedInterval}
 
 /-- Exercise 11.3.1 -/
 theorem MajorizesOn.anti_symm {f g: ℝ → ℝ} {I: BoundedInterval}:
-  ∀ x ∈ (I:Set ℝ), f x = g x ↔ MajorizesOn f g I ∧ MajorizesOn g f I := by
+  (∀ x ∈ (I:Set ℝ), f x = g x) ↔ MajorizesOn f g I ∧ MajorizesOn g f I := by
   sorry
 
 /-- Exercise 11.3.2 -/


### PR DESCRIPTION
* `MajorizesOn.anti_symm` (Exercise 11.3.1): wrap the universal in parentheses so the iff scopes over `(∀ x ∈ I, f x = g x)` instead of `f x = g x` alone.

* `upper_riemann_sum_le` (Lemma 11.3.11 / Exercise 11.3.4): the original hypothesis `PiecewiseConstantOn g I` lets g be piecewise constant on an arbitrary partition, making the statement false. Counterexample: I = [0,1], f = g = 1_{(0.49,0.51)}, P = ⊥; then upper_riemann_sum f P = 1 but integ g = 0.02. Tighten to `PiecewiseConstantWith g P` so g is constant on the pieces of the partition used to form the upper Riemann sum. Drop the unused `hf: BddOn f I` hypothesis.

* `lower_riemann_sum_ge`: dual fix.