### PR TITLE
Section 11.2: fix PiecewiseConstantOn.div hypothesis

### DIFF
--- a/Analysis/Section_11_2.lean
+++ b/Analysis/Section_11_2.lean
@@ -157,7 +157,7 @@ theorem PiecewiseConstantOn.smul {f: ℝ → ℝ} {I: BoundedInterval}
 
 /-- Lemma 11.2.8 / Exercise 11.2.2.  I believe the hypothesis that {name}`g` does not vanish is not needed. -/
 theorem PiecewiseConstantOn.div {f g: ℝ → ℝ} {I: BoundedInterval}
-  (hf: PiecewiseConstantOn f I) (hg: PiecewiseConstantOn f I) : PiecewiseConstantOn (f / g) I := by
+  (hf: PiecewiseConstantOn f I) (hg: PiecewiseConstantOn g I) : PiecewiseConstantOn (f / g) I := by
   sorry
 
 /-- Definition 11.2.9 (Piecewise constant integral I)-/


### PR DESCRIPTION
## Summary

Lemma 11.2.8 (`PiecewiseConstantOn.div`) duplicated the hypothesis on `f` instead of requiring `g` to be piecewise constant on `I`.

## Root cause

Copy-paste error: `(hg: PiecewiseConstantOn f I)` should name `g`.

## Why this fix is correct

The quotient `f / g` is piecewise constant on `I` only when both factors are; the second hypothesis must be `PiecewiseConstantOn g I`, matching the parallel lemmas for `add`, `mul`, etc.

## Test plan
- [ ] `lake build`

Made with [Cursor](https://cursor.com)