### PR TITLE
Section 9.9: use Ioo for 1/x uniform continuity counterexample

### DIFF
--- a/Analysis/Section_9_9.lean
+++ b/Analysis/Section_9_9.lean
@@ -73,7 +73,7 @@ theorem ContinuousOn.ofUniformContinuousOn {X:Set ℝ} (f: ℝ → ℝ) (hf: Uni
   ContinuousOn f X := by
   sorry
 
-example : ¬ UniformContinuousOn (fun x:ℝ ↦ 1/x) (Set.Icc 0 2) := by
+example : ¬ UniformContinuousOn (fun x:ℝ ↦ 1/x) (Set.Ioo 0 2) := by
   sorry
 
 end Chapter9


### PR DESCRIPTION
## Summary

The counterexample showing `1/x` is not uniformly continuous still used `Set.Icc 0 2`, while the rest of Section 9.9 (including PR #500) treats `1/x` on `(0, 2)`.

## Root cause

Oversight when #500 changed the opening `ContinuousOn` / `BddOn` examples from `Icc` to `Ioo`; this line was not updated.

## Why this fix is correct

`1/x` is not defined at `0` in the intended analysis sense; the section already uses `Ioo 0 2` for `f_9_9_10` and the earlier examples. The counterexample should use the same domain.

## Test plan
- [ ] `lake build`


Made with [Cursor](https://cursor.com)