### PR TITLE
Section 6.4: fix Example 6.4.9 upperseq and Example 6.4.10 labels

### DIFF
--- a/Analysis/Section_6_4.lean
+++ b/Analysis/Section_6_4.lean
@@ -119,7 +119,7 @@ example : Example_6_4_8.liminf = ⊥ := by sorry
 noncomputable abbrev Example_6_4_9 : Sequence :=
   (fun (n:ℕ) ↦ if Even n then (n+1:ℝ)⁻¹ else -(n+1:ℝ)⁻¹)
 
-example (n:ℕ) : Example_6_4_9.upperseq n = if Even n then (n+1:ℝ)⁻¹ else -(n+2:ℝ)⁻¹ := by sorry
+example (n:ℕ) : Example_6_4_9.upperseq n = if Even n then (n+1:ℝ)⁻¹ else (n+2:ℝ)⁻¹ := by sorry
 
 example : Example_6_4_9.limsup = 0 := by sorry
 
@@ -131,11 +131,11 @@ noncomputable abbrev Example_6_4_10 : Sequence := (fun (n:ℕ) ↦ (n+1:ℝ))
 
 example (n:ℕ) : Example_6_4_10.upperseq n = ⊤ := by sorry
 
-example : Example_6_4_9.limsup = ⊤ := by sorry
+example : Example_6_4_10.limsup = ⊤ := by sorry
 
-example (n:ℕ) : Example_6_4_9.lowerseq n = n+1 := by sorry
+example (n:ℕ) : Example_6_4_10.lowerseq n = n+1 := by sorry
 
-example : Example_6_4_9.liminf = ⊤ := by sorry
+example : Example_6_4_10.liminf = ⊤ := by sorry
 
 /-- Proposition 6.4.12(a) -/
 theorem Sequence.gt_limsup_bounds {a:Sequence} {x:EReal} (h: x > a.limsup) :


### PR DESCRIPTION
## Summary

Example 6.4.9's `upperseq` formula had a spurious minus on the odd-index branch, and the three statements after Example 6.4.10 were copy-pasted with `Example_6_4_9` instead of `Example_6_4_10`.

## Root cause

The odd branch of `upperseq` should take the next positive term `(n+2)⁻¹`, mirroring `lowerseq`. The Example 6.4.10 block reused the wrong sequence name from the preceding example.

## Why this fix is correct

For Example 6.4.9, `upperseq` is the sup of tail terms starting at index `N`; on odd indices the next positive value is `(n+2)⁻¹`, not its negative. The limsup/liminf/lowerseq claims with value `⊤` or `n+1` belong to the divergent Example 6.4.10 sequence `(n+1)`, not Example 6.4.9 which has limsup/liminf `0`.

Fixes #472

## Test plan
- [ ] `lake build`


Made with [Cursor](https://cursor.com)