### PR TITLE
Section 11.2: fix Example 11.2.15 integral statement

### DIFF
--- a/Analysis/Section_11_2.lean
+++ b/Analysis/Section_11_2.lean
@@ -226,7 +226,7 @@ theorem PiecewiseConstantOn.integ_congr {f g:ℝ → ℝ} {I: BoundedInterval}
   rw [←PiecewiseConstantWith.congr h]; exact hf.choose_spec
 
 /-- Example 11.2.15 -/
-example : PiecewiseConstantOn.integ f_11_2_4 (Icc 1 6) = 10 := by
+example : PiecewiseConstantOn.integ f_11_2_12 (Icc 1 4) = 10 := by
   sorry
 
 /-- Theorem 11.2.16 (a) (Laws of integration) / Exercise 11.2.4 -/


### PR DESCRIPTION
## Summary

Example 11.2.15 claimed `PiecewiseConstantOn.integ f_11_2_4 (Icc 1 6) = 10`, but the integral value 10 is computed for `f_11_2_12` on `Icc 1 4` in Example 11.2.12 just above.

## Root cause

Copy-paste error: the example line reused the function and interval from Example 11.2.4/11.2.6 instead of Example 11.2.12.

## Why this fix is correct

Examples 11.2.12–11.2.14 define `f_11_2_12`, partition `P_11_2_12` on `[1,4]`, and show `PiecewiseConstantWith.integ f_11_2_12 P_11_2_12 = 10`. Example 11.2.15 applies the `PiecewiseConstantOn.integ` API to that same setup.

## Test plan
- [ ] `lake build`


Made with [Cursor](https://cursor.com)