### PR TITLE
Section 11.1: fix intersection and partition refinement examples

### DIFF
--- a/Analysis/Section_11_1.lean
+++ b/Analysis/Section_11_1.lean
@@ -93,7 +93,7 @@ theorem BoundedInterval.inter_eq (I J: BoundedInterval) : (I ∩ J : BoundedInte
   (BoundedInterval.inter I J).choose_spec.symm
 
 example :
-  (Ioo 2 4 ∩ Icc 4 6) = (Icc 4 4 : Set ℝ) := by
+  (Icc 2 4 ∩ Icc 4 6) = (Icc 4 4 : Set ℝ) := by
   sorry
 
 instance BoundedInterval.instMembership : Membership ℝ BoundedInterval where
@@ -429,9 +429,12 @@ noncomputable instance Partition.instMax (I: BoundedInterval) : Max (Partition I
     }
 
 
-/-- Example 11.1.17 -/
-example : ∃ P P' : Partition (Icc 1 4), P.intervals = {Ico 1 3, Icc 3 4} ∧ P'.intervals = {Icc 1 2, Ioc 2 4} ∧
-  (P' ⊔ P).intervals = {Icc 1 2, Ioo 2 3, Icc 3 4, ∅} := by
+/-- Example 11.1.17. -/
+example : ∃ P P' : Partition (Icc 1 4),
+    P.intervals = {Ico 1 3, Icc 3 4} ∧
+    P'.intervals = {Icc 1 2, Ioc 2 4} ∧
+    (P' ⊔ P).intervals.image toSet =
+      {Set.Icc 1 2, Set.Ioo 2 3, Set.Icc 3 4, ∅} := by
   sorry
 
 /-- Lemma 11.1.8 / Exercise 11.1.4 -/


### PR DESCRIPTION
## Summary

Fixes two unprovable example statements in Section 11.1.

## Root cause

- The bounded-interval intersection example used `Ioo 2 4`, whose intersection with `Icc 4 6` is empty, not `{4}`.
- Example 11.1.17 compared `(P' ⊔ P).intervals` to a set of underlying real intervals, but `intervals` is a `Finset BoundedInterval`; the intended statement is about their images under `toSet`.

## Why this fix is correct

`Icc 2 4 ∩ Icc 4 6 = {4}` as required. For the refinement example, `(P' ⊔ P).intervals.image toSet` is the set of interval carriers appearing in the common refinement, matching the textbook picture.

Closes #499

## Test plan
- [ ] `lake build Analysis.Section_11_1`


Made with [Cursor](https://cursor.com)