### PR TITLE
Section 11.2: fix div hypothesis and Example 11.2.15 integral

### DIFF
--- a/Analysis/Section_11_2.lean
+++ b/Analysis/Section_11_2.lean
@@ -157,7 +157,7 @@ theorem PiecewiseConstantOn.smul {f: ℝ → ℝ} {I: BoundedInterval}
 
 /-- Lemma 11.2.8 / Exercise 11.2.2.  I believe the hypothesis that {name}`g` does not vanish is not needed. -/
 theorem PiecewiseConstantOn.div {f g: ℝ → ℝ} {I: BoundedInterval}
-  (hf: PiecewiseConstantOn f I) (hg: PiecewiseConstantOn f I) : PiecewiseConstantOn (f / g) I := by
+  (hf: PiecewiseConstantOn f I) (hg: PiecewiseConstantOn g I) : PiecewiseConstantOn (f / g) I := by
   sorry
 
 /-- Definition 11.2.9 (Piecewise constant integral I)-/
@@ -226,7 +226,7 @@ theorem PiecewiseConstantOn.integ_congr {f g:ℝ → ℝ} {I: BoundedInterval}
   rw [←PiecewiseConstantWith.congr h]; exact hf.choose_spec
 
 /-- Example 11.2.15 -/
-example : PiecewiseConstantOn.integ f_11_2_4 (Icc 1 6) = 10 := by
+example : PiecewiseConstantOn.integ f_11_2_12 (Icc 1 4) = 10 := by
   sorry
 
 /-- Theorem 11.2.16 (a) (Laws of integration) / Exercise 11.2.4 -/


### PR DESCRIPTION
## Summary

Fixes two incorrect statement scaffolds in Section 11.2 called out in rkirov's review on #506.

## Root cause

- `PiecewiseConstantOn.div` copied the `PiecewiseConstantOn f I` hypothesis for both `f` and `g`, so the division lemma does not even typecheck the intended statement about `g`.
- Example 11.2.15 referenced `f_11_2_4` on `Icc 1 6`; the integral value 10 comes from `f_11_2_12` on `Icc 1 4` (Examples 11.2.12–13).

## Why this fix is correct

The div lemma should require piecewise constancy of the divisor `g`. Example 11.2.15 matches the function and interval used in the preceding examples whose partition integral is 10.

## Test plan
- [ ] `lake build Analysis.Section_11_2`


Made with [Cursor](https://cursor.com)