### PR TITLE
Section 11.5: fix integ_zero hypothesis a ≤ b → a < b

### DIFF
--- a/Analysis/Section_11_5.lean
+++ b/Analysis/Section_11_5.lean
@@ -219,7 +219,7 @@ theorem integ_of_bdd_piecewise_cts {I: BoundedInterval} {f:ℝ → ℝ}
   sorry
 
 /-- Exercise 11.5.2 -/
-theorem integ_zero {a b:ℝ} (hab: a ≤ b) (f: ℝ → ℝ) (hf: ContinuousOn f (Icc a b))
+theorem integ_zero {a b:ℝ} (hab: a < b) (f: ℝ → ℝ) (hf: ContinuousOn f (Icc a b))
   (hnonneg: MajorizesOn f (fun _ ↦ 0) (Icc a b)) (hinteg : integ f (Icc a b) = 0) :
   ∀ x ∈ Icc a b, f x = 0 := by
     sorry


### PR DESCRIPTION
Exercise 11.5.2 (integ_zero) is false on a degenerate interval: with a = b, take f ≡ 1. Then f is continuous and nonnegative on Icc a a = {a}, and integ f (Icc a a) = 0 (a point has length zero), yet the conclusion ∀ x ∈ Icc a a, f x = 0 fails. The intended (and provable) statement needs a nondegenerate interval, matching Tao's hypothesis a < b.