### PR TITLE
Section 11: fix false statements from issue #517

### DIFF
--- a/Analysis/Section_11_5.lean
+++ b/Analysis/Section_11_5.lean
@@ -219,7 +219,7 @@ theorem integ_of_bdd_piecewise_cts {I: BoundedInterval} {f:ℝ → ℝ}
   sorry
 
 /-- Exercise 11.5.2 -/
-theorem integ_zero {a b:ℝ} (hab: a ≤ b) (f: ℝ → ℝ) (hf: ContinuousOn f (Icc a b))
+theorem integ_zero {a b:ℝ} (hab: a < b) (f: ℝ → ℝ) (hf: ContinuousOn f (Icc a b))
   (hnonneg: MajorizesOn f (fun _ ↦ 0) (Icc a b)) (hinteg : integ f (Icc a b) = 0) :
   ∀ x ∈ Icc a b, f x = 0 := by
     sorry

--- a/Analysis/Section_11_6.lean
+++ b/Analysis/Section_11_6.lean
@@ -147,7 +147,7 @@ theorem integ_of_bdd_antitone {I:BoundedInterval} {f:ℝ → ℝ} (hbound: BddOn
 /-- Proposition 11.6.4 (Integral test) -/
 theorem summable_iff_integ_of_antitone {f:ℝ → ℝ} (hnon: ∀ x ≥ 0, f x ≥ 0)
   (hf: AntitoneOn f (.Ici 0)) :
-  Summable f ↔ ∃ M, ∀ N ≥ 0, integ f (Icc 0 N) ≤ M := by
+  Summable (fun n:ℕ ↦ f n) ↔ ∃ M, ∀ N ≥ 0, integ f (Icc 0 N) ≤ M := by
   sorry
 
 -- Exercise 11.6.2: Formulate a reasonable notion of a piecewise monotone function, and then

--- a/Analysis/Section_11_8.lean
+++ b/Analysis/Section_11_8.lean
@@ -250,7 +250,7 @@ noncomputable abbrev P_11_8_6 : Partition (Icc 1 3) :=
   (⊥: Partition (Ico 1 2)).join (⊥ : Partition (Icc 2 3))
   (join_Ico_Icc (by norm_num) (by norm_num) )
 
-theorem f_11_8_6_RS_integ : PiecewiseConstantWith.RS_integ f_11_8_6 P_11_8_6 (fun x ↦ x) = 22 := by
+theorem f_11_8_6_RS_integ : PiecewiseConstantWith.RS_integ f_11_8_6 P_11_8_6 (fun x ↦ x^2) = 22 := by
   sorry
 
 /-- Example 11.8.7 -/
@@ -468,7 +468,7 @@ theorem RS_integ_of_uniform_cts {I: BoundedInterval} {f:ℝ → ℝ} (hf: Unifor
   sorry
 
 /-- Exercise 11.8.5 -/
-theorem RS_integ_with_sign (f:ℝ → ℝ) (hf: ContinuousOn f (.Icc (-1) 1)) : RS_IntegrableOn f (Icc (-1) 1) Real.sign ∧ RS_integ f (Icc (-1) 1) (fun x ↦ -Real.sign x) = 2 * f 0 := by
+theorem RS_integ_with_sign (f:ℝ → ℝ) (hf: ContinuousOn f (.Icc (-1) 1)) : RS_IntegrableOn f (Icc (-1) 1) Real.sign ∧ RS_integ f (Icc (-1) 1) Real.sign = 2 * f 0 := by
   sorry
 
 /-- Analogue of Lemma 11.3.7 -/

--- a/Analysis/Section_11_9.lean
+++ b/Analysis/Section_11_9.lean
@@ -103,7 +103,7 @@ theorem DifferentiableOn.of_F_11_9_2 {x:ℝ} (hx: ¬ ∃ r:ℚ, x = r) (hx': x �
   exact ⟨_, this⟩
 
 /-- Exercise 11.9.1 -/
-theorem DifferentiableOn.of_F_11_9_2' {q:ℚ} (hq: (q:ℝ) ∈ Set.Icc 0 1) : ¬ DifferentiableWithinAt ℝ F_11_9_2 (.Icc 0 1) q := by sorry
+theorem DifferentiableOn.of_F_11_9_2' {q:ℚ} (hq: (q:ℝ) ∈ Set.Ioo 0 1) : ¬ DifferentiableWithinAt ℝ F_11_9_2 (.Icc 0 1) q := by sorry
 
 /-- Definition 11.9.3.  We drop the requirement that x be a limit point as this makes
     the Lean arguments slightly cleaner -/


### PR DESCRIPTION
Fixes part of #517

## Bug
Several Chapter 11 exercises were false as formalized: `integ_zero` allowed `a = b`, the integral test summed over `ℝ` instead of `ℕ`, Example 11.8.6 used the identity integrator, Exercise 11.8.5 used `-Real.sign`, and Exercise 11.9.1 claimed non-differentiability at the endpoints of `[0,1]`.

## Root cause
Missing or mismatched hypotheses (strict inequality, index type, integrator choice, interior-only rational points).

## Why this fix is correct
Each change restores Tao's intended statement from *Analysis I* (3rd ed.): positive-length intervals for Exercise 11.5.2, the `ℕ`-indexed integral test, `α(x)=x²` in Example 11.8.6, `sgn` in Exercise 11.8.5, and interior rationals in Exercise 11.9.1.

## Test plan
- [ ] `lake build`

Made with [Cursor](https://cursor.com)