### PR TITLE
Sections 8.5, 9.3, 1.1.3: fix false statements from issue #517

### DIFF
--- a/Analysis/MeasureTheory/Section_1_1_3.lean
+++ b/Analysis/MeasureTheory/Section_1_1_3.lean
@@ -769,7 +769,7 @@ theorem PiecewiseConstantOn.smul {I: BoundedInterval} (c:ℝ) {f: ℝ → ℝ} (
 
 /-- Exercise 1.1.21 (a) (Linearity of the piecewise constant integral) -/
 -- The integral is linear: integral(c * f) = c * integral(f).
-theorem PiecewiseConstantFunction.integral_smul {I:BoundedInterval} (c:ℝ) {f: ℝ → ℝ} (h: PiecewiseConstantOn f I) : (h.smul c).integral = h.integral := by sorry
+theorem PiecewiseConstantFunction.integral_smul {I:BoundedInterval} (c:ℝ) {f: ℝ → ℝ} (h: PiecewiseConstantOn f I) : (h.smul c).integral = c • h.integral := by sorry
 
 /-- Exercise 1.1.21 (a) (Linearity of the piecewise constant integral) -/
 -- The sum of two piecewise constant functions is piecewise constant.

--- a/Analysis/Section_8_5.lean
+++ b/Analysis/Section_8_5.lean
@@ -368,10 +368,10 @@ def OrderIdeals.iso {X: Type} [PartialOrder X] : X ≃o OrderIdeals X := {
   }
 
 /-- Exercise 8.5.7 -/
-example {Y:Type} [PartialOrder Y] {x y:Y} (hx: IsMin x) (hy: IsMin y) : x = y := by
+example {Y:Type} [LinearOrder Y] {x y:Y} (hx: IsMin x) (hy: IsMin y) : x = y := by
   sorry
 
-example {Y:Type} [PartialOrder Y] {x y:Y} (hx: IsMax x) (hy: IsMax y) : x = y := by
+example {Y:Type} [LinearOrder Y] {x y:Y} (hx: IsMax x) (hy: IsMax y) : x = y := by
  sorry
 
 /-- Exercise 8.5.9 -/

--- a/Analysis/Section_9_3.lean
+++ b/Analysis/Section_9_3.lean
@@ -215,9 +215,9 @@ open Classical in
 /-- Example 9.3.21 -/
 noncomputable abbrev f_9_3_21 : ℝ → ℝ := fun x ↦ if x ∈ (fun q:ℚ ↦ (q:ℝ)) '' .univ then 1 else 0
 
-example : Filter.atTop.Tendsto (fun n ↦ f_9_3_21 (1/n:ℝ)) (nhds 1) := by sorry
+example : Filter.atTop.Tendsto (fun (n:ℕ) ↦ f_9_3_21 (1/n:ℝ)) (nhds 1) := by sorry
 
-example : Filter.atTop.Tendsto (fun n ↦ f_9_3_21 ((Real.sqrt 2)/n:ℝ)) (nhds 0) := by sorry
+example : Filter.atTop.Tendsto (fun (n:ℕ) ↦ f_9_3_21 ((Real.sqrt 2)/n:ℝ)) (nhds 0) := by sorry
 
 example : ¬ ∃ L, Convergesto .univ f_9_3_21 L 0 := by sorry
 


### PR DESCRIPTION
Fixes part of #517

## Bug
Example 9.3.21 indexed `atTop` over `ℝ` instead of `ℕ`; Exercise 8.5.7 claimed min/max uniqueness in a general partial order; and `PiecewiseConstantFunction.integral_smul` dropped the scalar factor.

## Root cause
Bound variables elaborated to `ℝ` via `:ℝ` ascribing; `PartialOrder` allows incomparable minima; the integral identity omitted `c •` on the RHS.

## Why this fix is correct
Example 9.3.21 is about sequences `n ↦ f(1/n)` and `n ↦ f(√2/n)` with `n : ℕ`. Exercise 8.5.7 needs a linear order for uniqueness. The `smul` integral law is `∫ (c·f) = c · ∫ f` per the adjacent docstring.

## Test plan
- [ ] `lake build`

Made with [Cursor](https://cursor.com)