### PR TITLE
Measure theory 1.4.3: fix inclusion-exclusion measurability from issue #517

### DIFF
--- a/Analysis/MeasureTheory/Section_1_4_3.lean
+++ b/Analysis/MeasureTheory/Section_1_4_3.lean
@@ -139,7 +139,8 @@ theorem FinitelyAdditiveMeasure.finite_subadditivity {X:Type*} {B: ConcreteBoole
   μ.measure (⋃ j ∈ I, E j) ≤ ∑ j ∈ I, μ.measure (E j) := by sorry
 
 /-- Exercise 1.4.20(iv) -/
-theorem FinitelyAdditiveMeasure.mes_union_add_mes_inter {X:Type*} {B: ConcreteBooleanAlgebra X} (μ: FinitelyAdditiveMeasure B) (E F : Set X) :
+theorem FinitelyAdditiveMeasure.mes_union_add_mes_inter {X:Type*} {B: ConcreteBooleanAlgebra X} (μ: FinitelyAdditiveMeasure B) {E F : Set X}
+    (hE: B.measurable E) (hF: B.measurable F) :
   μ.measure (E ∪ F) + μ.measure (E ∩ F) = μ.measure E + μ.measure F := by sorry
 
 open Classical in


### PR DESCRIPTION
Fixes part of #517

## Bug
`mes_union_add_mes_inter` applied to arbitrary sets `E, F : Set X`, but finite additivity of `μ.measure` is only defined for algebra members.

## Root cause
The exercise statement omitted `B.measurable` hypotheses on `E` and `F`.

## Why this fix is correct
Exercise 1.4.20(iv) is inclusion–exclusion for sets in the boolean algebra; `FinitelyAdditiveMeasure.measure` is constrained to measurable sets via `measure_finite_additive`.

## Test plan
- [ ] `lake build`

Made with [Cursor](https://cursor.com)