### PR TITLE
Measure theory 1.3.2: fix TFAE Lebesgue strength from issue #517

### DIFF
--- a/Analysis/MeasureTheory/Section_1_3_2.lean
+++ b/Analysis/MeasureTheory/Section_1_3_2.lean
@@ -3257,8 +3257,8 @@ theorem RealMeasurable.TFAE {d:ℕ} {f: EuclideanSpace' d → ℝ}:
       RealMeasurable f,
       ∃ (g: ℕ → EuclideanSpace' d → ℝ), (∀ n, RealSimpleFunction (g n)) ∧ (PointwiseAeConvergesTo g f),
       UnsignedMeasurable (EReal.pos_fun f) ∧ UnsignedMeasurable (EReal.neg_fun f),
-      ∀ U: Set ℝ, IsOpen U → MeasurableSet (f⁻¹' U),
-      ∀ K: Set ℝ, IsClosed K → MeasurableSet (f⁻¹' K)
+      ∀ U: Set ℝ, IsOpen U → LebesgueMeasurable (f⁻¹' U),
+      ∀ K: Set ℝ, IsClosed K → LebesgueMeasurable (f⁻¹' K)
     ].TFAE
   := by sorry
 
@@ -3268,8 +3268,8 @@ theorem ComplexMeasurable.TFAE {d:ℕ} {f: EuclideanSpace' d → ℂ}:
       ∃ (g: ℕ → EuclideanSpace' d → ℂ), (∀ n, ComplexSimpleFunction (g n)) ∧ (PointwiseAeConvergesTo g f),
       RealMeasurable (Complex.re_fun f) ∧ RealMeasurable (Complex.im_fun f),
       UnsignedMeasurable (EReal.pos_fun (Complex.re_fun f)) ∧ UnsignedMeasurable (EReal.neg_fun (Complex.im_fun f)) ∧ UnsignedMeasurable (EReal.pos_fun (Complex.im_fun f)) ∧ UnsignedMeasurable (EReal.neg_fun (Complex.re_fun f)),
-      ∀ U: Set ℂ, IsOpen U → MeasurableSet (f⁻¹' U),
-      ∀ K: Set ℂ, IsClosed K → MeasurableSet (f⁻¹' K)
+      ∀ U: Set ℂ, IsOpen U → LebesgueMeasurable (f⁻¹' U),
+      ∀ K: Set ℂ, IsClosed K → LebesgueMeasurable (f⁻¹' K)
     ].TFAE
   := by sorry
 


### PR DESCRIPTION
Fixes part of #517

## Bug
`RealMeasurable.TFAE` and `ComplexMeasurable.TFAE` used `MeasurableSet` for open/closed preimages, which is Borel strength on `EuclideanSpace' d`, while conditions (1)–(3) are Lebesgue-strength.

## Root cause
Conditions (4)/(5) copied Mathlib's Borel `MeasurableSet` instead of the project's `LebesgueMeasurable`, unlike `UnsignedMeasurable.TFAE`.

## Why this fix is correct
A Lebesgue-measurable function can have a non-Borel preimage of an open set, so (1) does not imply the old (4). Matching the unsigned TFAE list restores a consistent equivalence chain.

## Test plan
- [ ] `lake build`

Made with [Cursor](https://cursor.com)