### PR TITLE
Measure theory 1.3.4: add measurability to glue from issue #517

### DIFF
--- a/Analysis/MeasureTheory/Section_1_3_4.lean
+++ b/Analysis/MeasureTheory/Section_1_3_4.lean
@@ -1035,7 +1035,10 @@ noncomputable def ComplexAbsolutelyIntegrableOn.integ {d:ℕ} {f: EuclideanSpace
   ComplexAbsolutelyIntegrable.integ hf
 
 /-- Exercise 1.3.22 -/
-theorem ComplexAbsolutelyIntegrableOn.glue {d:ℕ} {f: EuclideanSpace' d → ℂ} {E F: Set (EuclideanSpace' d)} (hdisj: Disjoint E F) (hf: ComplexAbsolutelyIntegrableOn f (E ∪ F)) : ∃ hE : ComplexAbsolutelyIntegrableOn f E, ∃ hF: ComplexAbsolutelyIntegrableOn f F, hf.integ = hE.integ + hF.integ := by sorry
+theorem ComplexAbsolutelyIntegrableOn.glue {d:ℕ} {f: EuclideanSpace' d → ℂ} {E F: Set (EuclideanSpace' d)}
+    (hE: LebesgueMeasurable E) (hF: LebesgueMeasurable F) (hdisj: Disjoint E F)
+    (hf: ComplexAbsolutelyIntegrableOn f (E ∪ F)) :
+    ∃ hE : ComplexAbsolutelyIntegrableOn f E, ∃ hF: ComplexAbsolutelyIntegrableOn f F, hf.integ = hE.integ + hF.integ := by sorry
 
 def ComplexAbsolutelyIntegrableOn.restrict {d:ℕ} {f: EuclideanSpace' d → ℂ} {E F: Set (EuclideanSpace' d)} (hf: ComplexAbsolutelyIntegrableOn f E) (hF: LebesgueMeasurable F): ComplexAbsolutelyIntegrableOn (f * Complex.indicator F) E := by sorry
 


### PR DESCRIPTION
Fixes part of #517

## Bug
`ComplexAbsolutelyIntegrableOn.glue` concluded integrability on `E` from integrability on `E ∪ F` without assuming `E` or `F` is measurable.

## Root cause
`ComplexAbsolutelyIntegrableOn f E` requires `ComplexMeasurable (f · indicator E)`, which fails for non-measurable `E` even when `E ∪ F` is well-behaved.

## Why this fix is correct
Exercise 1.3.22 explicitly assumes `E` and `F` are measurable; the indicator `f · 𝟙_E` is only a limit of complex simple functions when `E` is Lebesgue measurable.

## Test plan
- [ ] `lake build`

Made with [Cursor](https://cursor.com)