### PR TITLE
Measure theory 1.2.1, 1.3.3: fix false statements from issue #517

### DIFF
--- a/Analysis/MeasureTheory/Section_1_2_1.lean
+++ b/Analysis/MeasureTheory/Section_1_2_1.lean
@@ -2164,7 +2164,8 @@ example : set_dist (Ico 0 1).toSet (Icc 1 2).toSet = 0 := by
       exact dist_nonneg
 
 /-- Exercise 1.2.4 -/
-theorem dist_of_disj_compact_pos {d:ℕ} (E F: Set (EuclideanSpace' d)) (hE: IsCompact E) (hF: IsCompact F) (hdisj: E ∩ F = ∅) :
+theorem dist_of_disj_compact_pos {d:ℕ} (E F: Set (EuclideanSpace' d)) (hEn: E.Nonempty) (hFn: F.Nonempty)
+    (hE: IsCompact E) (hF: IsCompact F) (hdisj: E ∩ F = ∅) :
     set_dist E F > 0 := by
   sorry
 

--- a/Analysis/MeasureTheory/Section_1_3_2.lean
+++ b/Analysis/MeasureTheory/Section_1_3_2.lean
@@ -1732,13 +1732,16 @@ theorem UnsignedMeasurable.limsup {d:ℕ} {f: ℕ → EuclideanSpace' d → ERea
 theorem UnsignedMeasurable.liminf {d:ℕ} {f: ℕ → EuclideanSpace' d → EReal} (hf: ∀ n, UnsignedMeasurable (f n)) : UnsignedMeasurable (fun x ↦ Filter.atTop.liminf (fun n ↦ f n x) ) := by sorry
 
 /-- Exercise 1.3.3(iv) -/
-theorem UnsignedMeasurable.aeEqual {d:ℕ} {f g: EuclideanSpace' d → EReal} (hf: UnsignedMeasurable f) (heq: AlmostEverywhereEqual f g) : UnsignedMeasurable g := by sorry
+theorem UnsignedMeasurable.aeEqual {d:ℕ} {f g: EuclideanSpace' d → EReal} (hf: UnsignedMeasurable f) (hg: Unsigned g)
+    (heq: AlmostEverywhereEqual f g) : UnsignedMeasurable g := by sorry
 
 /-- Exercise 1.3.3(v) -/
-theorem UnsignedMeasurable.aeLimit {d:ℕ} {f: EuclideanSpace' d → EReal} (g: ℕ → EuclideanSpace' d → EReal) (hf: ∀ n, UnsignedMeasurable (g n)) (heq: PointwiseAeConvergesTo g f) : UnsignedMeasurable f := by sorry
+theorem UnsignedMeasurable.aeLimit {d:ℕ} {f: EuclideanSpace' d → EReal} (g: ℕ → EuclideanSpace' d → EReal) (hf: ∀ n, UnsignedMeasurable (g n))
+    (hfu: Unsigned f) (heq: PointwiseAeConvergesTo g f) : UnsignedMeasurable f := by sorry
 
 /-- Exercise 1.3.3(vi) -/
-theorem UnsignedMeasurable.comp_cts {d:ℕ} {f: EuclideanSpace' d → EReal} (hf: UnsignedMeasurable f) {φ: EReal → EReal} (hφ: Continuous φ)  : UnsignedMeasurable (φ ∘ f) := by sorry
+theorem UnsignedMeasurable.comp_cts {d:ℕ} {f: EuclideanSpace' d → EReal} (hf: UnsignedMeasurable f) {φ: EReal → EReal}
+    (hφ: Continuous φ) (hφu: Unsigned φ) : UnsignedMeasurable (φ ∘ f) := by sorry
 
 /-- Exercise 1.3.3(vii) -/
 theorem UnsignedMeasurable.add {d:ℕ} {f g: EuclideanSpace' d → EReal} (hf: UnsignedMeasurable f) (hg: UnsignedMeasurable g) : UnsignedMeasurable (f + g) := by sorry


### PR DESCRIPTION
## Summary
- **`dist_of_disj_compact_pos`**: require `E.Nonempty` and `F.Nonempty`. With `E = ∅`, `set_dist E F = sInf ∅ = 0`, contradicting `> 0`.
- **`UnsignedMeasurable.aeEqual` / `aeLimit` / `comp_cts`**: add everywhere-nonnegativity hypotheses (`Unsigned g`, `Unsigned f`, `Unsigned φ`). `UnsignedMeasurable` requires global nonnegativity, but the old statements only gave it a.e. or not at all (e.g. `φ = · - 1`).

## Root cause
Issue #517: statements were false as formalized because hypotheses were too weak for the conclusion types.

## Test plan
- [ ] `lake build` (sorry-only change; no new proof obligations beyond corrected signatures)


Made with [Cursor](https://cursor.com)