### PR TITLE
Section 9.8: fix undecidable Exercise 9.8.4 statements from issue #517

### DIFF
--- a/Analysis/Section_9_8.lean
+++ b/Analysis/Section_9_8.lean
@@ -135,23 +135,26 @@ theorem mono_of_continuous_inj {a b:ℝ} (h: a < b) {f:ℝ → ℝ}
   sorry
 
 /-- Exercise 9.8.4 -/
-theorem MonotoneOn.exist_inverse_without_continuity {a b:ℝ} (h: a < b) {f: ℝ → ℝ} (hcont: ContinuousOn f (.Icc a b))
-    (hmono: StrictMonoOn f (.Icc a b)) :
-  f '' (.Icc a b) = .Icc (f a) (f b) ∧
-  ∃ finv: ℝ → ℝ, ContinuousOn finv (.Icc (f a) (f b)) ∧ StrictMonoOn finv (.Icc (f a) (f b)) ∧
-  finv '' (.Icc (f a) (f b)) = .Icc a b ∧
-  (∀ x ∈ Set.Icc a b, finv (f x) = x) ∧
-  ∀ y ∈ Set.Icc (f a) (f b), f (finv y) = y := by
+def MonotoneOn.exist_inverse_without_continuity :
+    Decidable (∀ (a b : ℝ) (_ : a < b) (f : ℝ → ℝ) (_ : StrictMonoOn f (Icc a b)),
+      f '' (Icc a b) = Icc (f a) (f b) ∧
+      ∃ finv : ℝ → ℝ, ContinuousOn finv (Icc (f a) (f b)) ∧ StrictMonoOn finv (Icc (f a) (f b)) ∧
+        finv '' (Icc (f a) (f b)) = Icc a b ∧
+        (∀ x ∈ Set.Icc a b, finv (f x) = x) ∧
+        ∀ y ∈ Set.Icc (f a) (f b), f (finv y) = y) := by
+  -- apply isFalse: strict mono alone doesn't guarantee a continuous inverse
   sorry
 
 /-- Exercise 9.8.4 -/
-theorem MonotoneOn.exist_inverse_without_strictmono {a b:ℝ} (h: a < b) (f: ℝ → ℝ)
-    (hcont: ContinuousOn f (.Icc a b)) (hmono: StrictMonoOn f (.Icc a b)) :
-  f '' (.Icc a b) = .Icc (f a) (f b) ∧
-  ∃ finv: ℝ → ℝ, ContinuousOn finv (.Icc (f a) (f b)) ∧ StrictMonoOn finv (.Icc (f a) (f b)) ∧
-  finv '' (.Icc (f a) (f b)) = .Icc a b ∧
-  (∀ x ∈ Set.Icc a b, finv (f x) = x) ∧
-  ∀ y ∈ Set.Icc (f a) (f b), f (finv y) = y := by
+def MonotoneOn.exist_inverse_without_strictmono :
+    Decidable (∀ (a b : ℝ) (_ : a < b) (f : ℝ → ℝ) (_ : ContinuousOn f (Icc a b))
+        (_ : MonotoneOn f (Icc a b)),
+      f '' (Icc a b) = Icc (f a) (f b) ∧
+      ∃ finv : ℝ → ℝ, ContinuousOn finv (Icc (f a) (f b)) ∧ StrictMonoOn finv (Icc (f a) (f b)) ∧
+        finv '' (Icc (f a) (f b)) = Icc a b ∧
+        (∀ x ∈ Set.Icc a b, finv (f x) = x) ∧
+        ∀ y ∈ Set.Icc (f a) (f b), f (finv y) = y) := by
+  -- apply isFalse: e.g. a constant monotone f on [a,b] has no strict inverse
   sorry
 
 

--- a/Analysis/Section_9_8.lean
+++ b/Analysis/Section_9_8.lean
@@ -135,26 +135,23 @@ theorem mono_of_continuous_inj {a b:ℝ} (h: a < b) {f:ℝ → ℝ}
   sorry
 
 /-- Exercise 9.8.4 -/
-def MonotoneOn.exist_inverse_without_continuity {a b:ℝ} (h: a < b) {f: ℝ → ℝ} (hmono: StrictMonoOn f (.Icc a b)) :
-  Decidable ( f '' (.Icc a b) = .Icc (f a) (f b) ∧
+theorem MonotoneOn.exist_inverse_without_continuity {a b:ℝ} (h: a < b) {f: ℝ → ℝ} (hcont: ContinuousOn f (.Icc a b))
+    (hmono: StrictMonoOn f (.Icc a b)) :
+  f '' (.Icc a b) = .Icc (f a) (f b) ∧
   ∃ finv: ℝ → ℝ, ContinuousOn finv (.Icc (f a) (f b)) ∧ StrictMonoOn finv (.Icc (f a) (f b)) ∧
   finv '' (.Icc (f a) (f b)) = .Icc a b ∧
   (∀ x ∈ Set.Icc a b, finv (f x) = x) ∧
-  ∀ y ∈ Set.Icc (f a) (f b), f (finv y) = y )
-   := by
-  -- the first line of this construction should be either `apply isTrue` or `apply isFalse`.
+  ∀ y ∈ Set.Icc (f a) (f b), f (finv y) = y := by
   sorry
 
 /-- Exercise 9.8.4 -/
-def MonotoneOn.exist_inverse_without_strictmono {a b:ℝ} (h: a < b) (f: ℝ → ℝ)
-  (hcont: ContinuousOn f (.Icc a b)) (hmono: MonotoneOn f (.Icc a b)) :
-  Decidable ( f '' (.Icc a b) = .Icc (f a) (f b) ∧
+theorem MonotoneOn.exist_inverse_without_strictmono {a b:ℝ} (h: a < b) (f: ℝ → ℝ)
+    (hcont: ContinuousOn f (.Icc a b)) (hmono: StrictMonoOn f (.Icc a b)) :
+  f '' (.Icc a b) = .Icc (f a) (f b) ∧
   ∃ finv: ℝ → ℝ, ContinuousOn finv (.Icc (f a) (f b)) ∧ StrictMonoOn finv (.Icc (f a) (f b)) ∧
   finv '' (.Icc (f a) (f b)) = .Icc a b ∧
   (∀ x ∈ Set.Icc a b, finv (f x) = x) ∧
-  ∀ y ∈ Set.Icc (f a) (f b), f (finv y) = y )
-   := by
-  -- the first line of this construction should be either `apply isTrue` or `apply isFalse`.
+  ∀ y ∈ Set.Icc (f a) (f b), f (finv y) = y := by
   sorry
 
 

--- a/Analysis/Section_9_8.lean
+++ b/Analysis/Section_9_8.lean
@@ -136,10 +136,10 @@ theorem mono_of_continuous_inj {a b:ℝ} (h: a < b) {f:ℝ → ℝ}
 
 /-- Exercise 9.8.4 -/
 def MonotoneOn.exist_inverse_without_continuity :
-    Decidable (∀ (a b : ℝ) (_ : a < b) (f : ℝ → ℝ) (_ : StrictMonoOn f (Icc a b)),
-      f '' (Icc a b) = Icc (f a) (f b) ∧
-      ∃ finv : ℝ → ℝ, ContinuousOn finv (Icc (f a) (f b)) ∧ StrictMonoOn finv (Icc (f a) (f b)) ∧
-        finv '' (Icc (f a) (f b)) = Icc a b ∧
+    Decidable (∀ (a b : ℝ) (_ : a < b) (f : ℝ → ℝ) (_ : StrictMonoOn f (.Icc a b)),
+      f '' (.Icc a b) = .Icc (f a) (f b) ∧
+      ∃ finv : ℝ → ℝ, ContinuousOn finv (.Icc (f a) (f b)) ∧ StrictMonoOn finv (.Icc (f a) (f b)) ∧
+        finv '' (.Icc (f a) (f b)) = .Icc a b ∧
         (∀ x ∈ Set.Icc a b, finv (f x) = x) ∧
         ∀ y ∈ Set.Icc (f a) (f b), f (finv y) = y) := by
   -- apply isFalse: strict mono alone doesn't guarantee a continuous inverse
@@ -147,11 +147,11 @@ def MonotoneOn.exist_inverse_without_continuity :
 
 /-- Exercise 9.8.4 -/
 def MonotoneOn.exist_inverse_without_strictmono :
-    Decidable (∀ (a b : ℝ) (_ : a < b) (f : ℝ → ℝ) (_ : ContinuousOn f (Icc a b))
-        (_ : MonotoneOn f (Icc a b)),
-      f '' (Icc a b) = Icc (f a) (f b) ∧
-      ∃ finv : ℝ → ℝ, ContinuousOn finv (Icc (f a) (f b)) ∧ StrictMonoOn finv (Icc (f a) (f b)) ∧
-        finv '' (Icc (f a) (f b)) = Icc a b ∧
+    Decidable (∀ (a b : ℝ) (_ : a < b) (f : ℝ → ℝ) (_ : ContinuousOn f (.Icc a b))
+        (_ : MonotoneOn f (.Icc a b)),
+      f '' (.Icc a b) = .Icc (f a) (f b) ∧
+      ∃ finv : ℝ → ℝ, ContinuousOn finv (.Icc (f a) (f b)) ∧ StrictMonoOn finv (.Icc (f a) (f b)) ∧
+        finv '' (.Icc (f a) (f b)) = .Icc a b ∧
         (∀ x ∈ Set.Icc a b, finv (f x) = x) ∧
         ∀ y ∈ Set.Icc (f a) (f b), f (finv y) = y) := by
   -- apply isFalse: e.g. a constant monotone f on [a,b] has no strict inverse


### PR DESCRIPTION
## Summary
Fixes the two `Exercise 9.8.4` `Decidable` exercises flagged in #517.

Previously the parameters (`a`, `b`, `f`, and the continuity/monotonicity hypotheses) were bound *outside* the `Decidable`, so the decided proposition depended on the specific function — making it true for some admissible inputs and false for others, i.e. not uniformly decidable.

Per @teorth's suggestion, the quantification is now moved **inside** the `Decidable`, so each exercise decides a single closed universal statement (in the spirit of the textbook's "is this true or false?" exercise):
- `exist_inverse_without_continuity`: decide whether strict monotonicity alone yields a (continuous, strict-mono) inverse.
- `exist_inverse_without_strictmono`: decide whether continuity + monotonicity (without strictness) yields such an inverse.

## Test plan
- [ ] `lake build` (signature-only change)