### PR TITLE
Section 11.6: fix Summable indexing and Exercise 11.6.4 statements

### DIFF
--- a/Analysis/Section_11_6.lean
+++ b/Analysis/Section_11_6.lean
@@ -147,17 +147,17 @@ theorem integ_of_bdd_antitone {I:BoundedInterval} {f:ℝ → ℝ} (hbound: BddOn
 /-- Proposition 11.6.4 (Integral test) -/
 theorem summable_iff_integ_of_antitone {f:ℝ → ℝ} (hnon: ∀ x ≥ 0, f x ≥ 0)
   (hf: AntitoneOn f (.Ici 0)) :
-  Summable f ↔ ∃ M, ∀ N ≥ 0, integ f (Icc 0 N) ≤ M := by
+  Summable (fun n:ℕ ↦ f n) ↔ ∃ M, ∀ N ≥ 0, integ f (Icc 0 N) ≤ M := by
   sorry
 
 -- Exercise 11.6.2: Formulate a reasonable notion of a piecewise monotone function, and then
 -- show that all bounded piecewise monotone functions are Riemann integrable.
 
 /-- Exercise 11.6.4 -/
-example : ∃ (f:ℝ → ℝ) (hnon: ∀ x ≥ 0, f x ≥ 0), Summable f ∧ ¬ ∃ M, ∀ N ≥ 0, integ f (Icc 0 N) ≤ M := by
+example : ∃ (f:ℝ → ℝ), (∀ x ≥ 0, f x ≥ 0) ∧ Summable (fun n:ℕ ↦ f n) ∧ ¬ ∃ M, ∀ N ≥ 0, integ f (Icc 0 N) ≤ M := by
   sorry
 
-example : ∃ (f:ℝ → ℝ) (hnon: ∀ x ≥ 0, f x ≥ 0), ¬ Summable f ∧ ∃ M, ∀ N ≥ 0, integ f (Icc 0 N) ≤ M := by
+example : ∃ (f:ℝ → ℝ), (∀ x ≥ 0, f x ≥ 0) ∧ ¬ Summable (fun n:ℕ ↦ f n) ∧ ∃ M, ∀ N ≥ 0, integ f (Icc 0 N) ≤ M := by
   sorry
 
 end Chapter11


### PR DESCRIPTION
`Summable f` with `f : ℝ → ℝ` sums over the index type ℝ, which makes these statements unprovable, so the intended statement is `Summable (fun n:ℕ ↦ f n)`.

Also restate the Exercise 11.6.4 examples with nonnegativity as a conjunct `(∀ x ≥ 0, f x ≥ 0) ∧ ...` rather than a named existential binder: the book asks for counterexamples satisfying all hypotheses of the integral test except monotonicity, and the binder form triggers unused-variable warnings once the proofs are filled in.