### PR TITLE
Section 11.5: fix integ_zero hypothesis from issue #517

### DIFF
--- a/Analysis/Section_11_5.lean
+++ b/Analysis/Section_11_5.lean
@@ -219,7 +219,7 @@ theorem integ_of_bdd_piecewise_cts {I: BoundedInterval} {f:ℝ → ℝ}
   sorry
 
 /-- Exercise 11.5.2 -/
-theorem integ_zero {a b:ℝ} (hab: a ≤ b) (f: ℝ → ℝ) (hf: ContinuousOn f (Icc a b))
+theorem integ_zero {a b:ℝ} (hab: a < b) (f: ℝ → ℝ) (hf: ContinuousOn f (Icc a b))
   (hnonneg: MajorizesOn f (fun _ ↦ 0) (Icc a b)) (hinteg : integ f (Icc a b) = 0) :
   ∀ x ∈ Icc a b, f x = 0 := by
     sorry


### PR DESCRIPTION
## Summary
Exercise 11.5.2 (`integ_zero`) had hypothesis `a ≤ b`, but at `a = b` the interval has length zero so `integ f (Icc a a) = 0` for any `f`, while the conclusion still demands `f a = 0`. Strengthen to `a < b` as in #517.

## Test plan
- [ ] `lake build Analysis.Section_11_5`


Made with [Cursor](https://cursor.com)