### PR TITLE
Section 11.6: sum over ℕ in integral test from issue #517

### DIFF
--- a/Analysis/Section_11_6.lean
+++ b/Analysis/Section_11_6.lean
@@ -147,7 +147,7 @@ theorem integ_of_bdd_antitone {I:BoundedInterval} {f:ℝ → ℝ} (hbound: BddOn
 /-- Proposition 11.6.4 (Integral test) -/
 theorem summable_iff_integ_of_antitone {f:ℝ → ℝ} (hnon: ∀ x ≥ 0, f x ≥ 0)
   (hf: AntitoneOn f (.Ici 0)) :
-  Summable f ↔ ∃ M, ∀ N ≥ 0, integ f (Icc 0 N) ≤ M := by
+  Summable (fun n:ℕ ↦ f n) ↔ ∃ M, ∀ N ≥ 0, integ f (Icc 0 N) ≤ M := by
   sorry
 
 -- Exercise 11.6.2: Formulate a reasonable notion of a piecewise monotone function, and then


### PR DESCRIPTION
## Summary
- `summable_iff_integ_of_antitone` used `Summable f` for `f : ℝ → ℝ`, i.e. summability over the reals.
- Tao's integral test (Prop. 11.6.4) is about the series `∑_{n=0}^∞ f(n)`, so the LHS should be `Summable (fun n:ℕ ↦ f n)`.

## Root cause
With `Summable f` on `ℝ`, any nonnegative antitone function with uncountable positive support makes the LHS false while the integral bound can still hold (e.g. `f = exp(-·)`).

## Test plan
- [ ] `lake build Analysis/Section_11_6.lean` (statement-only change; proof remains `sorry`)

Fixes part of #517.


Made with [Cursor](https://cursor.com)