### PR TITLE
Section 11.9: restrict Ex. 11.9.1 to interior rationals from issue #517

### DIFF
--- a/Analysis/Section_11_9.lean
+++ b/Analysis/Section_11_9.lean
@@ -103,7 +103,7 @@ theorem DifferentiableOn.of_F_11_9_2 {x:ℝ} (hx: ¬ ∃ r:ℚ, x = r) (hx': x �
   exact ⟨_, this⟩
 
 /-- Exercise 11.9.1 -/
-theorem DifferentiableOn.of_F_11_9_2' {q:ℚ} (hq: (q:ℝ) ∈ Set.Icc 0 1) : ¬ DifferentiableWithinAt ℝ F_11_9_2 (.Icc 0 1) q := by sorry
+theorem DifferentiableOn.of_F_11_9_2' {q:ℚ} (hq: (q:ℝ) ∈ Set.Ioo 0 1) : ¬ DifferentiableWithinAt ℝ F_11_9_2 (.Icc 0 1) q := by sorry
 
 /-- Definition 11.9.3.  We drop the requirement that x be a limit point as this makes
     the Lean arguments slightly cleaner -/


### PR DESCRIPTION
## Summary
- Exercise 11.9.1 claims `F` is not differentiable within `Icc 0 1` at every rational in `[0,1]`.
- `DifferentiableWithinAt` on a closed interval is a one-sided condition at endpoints, so `F` *is* differentiable at `q = 0` and `q = 1`.

## Root cause
The formalization used `q ∈ Icc 0 1`, which includes endpoints where the negated differentiability claim is false.

## Fix
Require `q ∈ Ioo 0 1`, matching Tao's intent for interior rationals.

## Test plan
- [ ] `lake build Analysis/Section_11_9.lean`

Fixes part of #517.


Made with [Cursor](https://cursor.com)