### PR TITLE
Section 11.10: fix sign in Exercise 11.10.3 statement

### DIFF
--- a/Analysis/Section_11_10.lean
+++ b/Analysis/Section_11_10.lean
@@ -221,7 +221,7 @@ theorem integ_of_comp {a b:ℝ} (hab: a < b) {φ f: ℝ → ℝ}
 /-- Exercise 11.10.3-/
 example {a b:ℝ} (hab: a < b) {f: ℝ → ℝ} (hf: IntegrableOn f (Icc a b)) :
   IntegrableOn (fun x ↦ f (-x)) (Icc (-b) (-a)) ∧
-  integ (fun x ↦ f (-x)) (Icc (-b) (-a)) = -integ f (Icc a b) := by
+  integ (fun x ↦ f (-x)) (Icc (-b) (-a)) = integ f (Icc a b) := by
   sorry
 
 /- Exercise 11.10.4: state and prove a version of `integ_of_comp` in which `φ` is `Antitone` rather than `Monotone`. -/


### PR DESCRIPTION
The reflection x ↦ -x preserves interval length, so ∫_{[-b,-a]} f(-x) dx = ∫_{[a,b]} f, with no sign change.

Counterexample to the current statement (f = 1, a = 1, b = 2): LHS = integ 1 [-2,-1] = 1, but RHS = -integ 1 [1,2] = -1.