### PR TITLE
Section 11.9: restrict Exercise 11.9.3 to the open interval

### DIFF
--- a/Analysis/Section_11_9.lean
+++ b/Analysis/Section_11_9.lean
@@ -229,7 +229,7 @@ theorem antideriv_eq_antideriv_add_const {I:BoundedInterval} {f F G : ℝ → �
     sorry
 
 /-- Exercise 11.9.3 -/
-example {a b x₀:ℝ} (hab: a < b) (hx₀: x₀ ∈ Icc a b) {f: ℝ → ℝ} (hf: MonotoneOn f (Icc a b)) :
+example {a b x₀:ℝ} (hab: a < b) (hx₀: x₀ ∈ Ioo a b) {f: ℝ → ℝ} (hf: MonotoneOn f (Icc a b)) :
   DifferentiableWithinAt ℝ (fun x => integ f (Icc a x)) (Icc a b) x₀ ↔
   ContinuousWithinAt f (Icc a b) x₀ := by
   sorry


### PR DESCRIPTION
The equivalence
  DifferentiableWithinAt ℝ (fun x => integ f (Icc a x)) (Icc a b) x₀
    ↔ ContinuousWithinAt f (Icc a b) x₀
fails at the endpoints, so x₀ must lie in `Ioo a b`, not `Icc a b`.

At an endpoint the within-derivative is one-sided, and for monotone f it always exists (it equals the one-sided limit), whereas f need not be one-sided-continuous there. E.g. on [a,b] take f a = 0 and f = 1 on (a,b]: then F(x) = integ f (Icc a x) = x - a has F'(a+) = 1, so F is differentiable within at a, yet f is not (right-)continuous at a.