### PR TITLE
Update MeasureTheory sections to match mathlib changes

### DIFF
--- a/Analysis/MeasureTheory/Section_1_4_1.lean
+++ b/Analysis/MeasureTheory/Section_1_4_1.lean
@@ -254,10 +254,8 @@ instance ConcreteBooleanAlgebra.instCompleteLattice {X:Type*} : CompleteLattice 
     le_inf := sorry
     le_top := sorry
     bot_le := sorry
-    le_sSup := sorry
-    sSup_le := sorry
-    sInf_le := sorry
-    le_sInf := sorry
+    isLUB_sSup := sorry
+    isGLB_sInf := sorry
   }
 
 /-- Example 1.4.11 -/

--- a/Analysis/MeasureTheory/Section_1_4_2.lean
+++ b/Analysis/MeasureTheory/Section_1_4_2.lean
@@ -117,10 +117,8 @@ instance ConcreteSigmaAlgebra.instCompleteLattice {X:Type*} : CompleteLattice (C
     le_inf := sorry
     le_top := sorry
     bot_le := sorry
-    le_sSup := sorry
-    sSup_le := sorry
-    sInf_le := sorry
-    le_sInf := sorry
+    isLUB_sSup := sorry
+    isGLB_sInf := sorry
   }
 
 theorem ConcreteSigmaAlgebra.generated_by_le {X:Type*} (F: Set (Set X)) : ConcreteBooleanAlgebra.generated_by F ≤ (ConcreteSigmaAlgebra.generated_by F).toConcreteBooleanAlgebra := by sorry

--- a/Analysis/MeasureTheory/Section_1_4_3.lean
+++ b/Analysis/MeasureTheory/Section_1_4_3.lean
@@ -58,7 +58,7 @@ noncomputable def FinitelyAdditiveMeasure.dirac {X:Type*} (x₀:X) (B: ConcreteB
   }
 
 /-- Example 1.4.23 (Zero measure) -/
-instance FinitelyAdditiveMeasure.instZero {X:Type*} (B: ConcreteBooleanAlgebra X) : Zero (FinitelyAdditiveMeasure B) :=
+noncomputable instance FinitelyAdditiveMeasure.instZero {X:Type*} (B: ConcreteBooleanAlgebra X) : Zero (FinitelyAdditiveMeasure B) :=
   {
     zero := {
       measure := fun A => 0
@@ -69,7 +69,7 @@ instance FinitelyAdditiveMeasure.instZero {X:Type*} (B: ConcreteBooleanAlgebra X
   }
 
 /-- Example 1.4.24 (linear combinations of measures) -/
-instance FinitelyAdditiveMeasure.instAdd {X:Type*} {B: ConcreteBooleanAlgebra X} : Add (FinitelyAdditiveMeasure B) :=
+noncomputable instance FinitelyAdditiveMeasure.instAdd {X:Type*} {B: ConcreteBooleanAlgebra X} : Add (FinitelyAdditiveMeasure B) :=
   {
     add := fun μ ν =>
       {
@@ -91,7 +91,7 @@ noncomputable instance FinitelyAdditiveMeasure.instSmul {X:Type*} {B: ConcreteBo
         }
 }
 
-instance FinitelyAdditiveMeasure.instAddCommMonoid {X:Type*} {B: ConcreteBooleanAlgebra X} : AddCommMonoid (FinitelyAdditiveMeasure B) :=
+noncomputable instance FinitelyAdditiveMeasure.instAddCommMonoid {X:Type*} {B: ConcreteBooleanAlgebra X} : AddCommMonoid (FinitelyAdditiveMeasure B) :=
 {
   add_assoc := by sorry,
   zero_add := by sorry,
@@ -193,7 +193,7 @@ def CountablyAdditiveMeasure.restrict {X:Type*} {B: ConcreteSigmaAlgebra X} (μ:
     measure_countable_additive := by sorry
   }
 
-instance CountablyAdditiveMeasure.instZero {X:Type*} (B: ConcreteSigmaAlgebra X) : Zero (CountablyAdditiveMeasure B) :=
+noncomputable instance CountablyAdditiveMeasure.instZero {X:Type*} (B: ConcreteSigmaAlgebra X) : Zero (CountablyAdditiveMeasure B) :=
   {
     zero := {
       toFinitelyAdditiveMeasure := 0
@@ -201,7 +201,7 @@ instance CountablyAdditiveMeasure.instZero {X:Type*} (B: ConcreteSigmaAlgebra X)
     }
   }
 
-instance CountablyAdditiveMeasure.instAdd {X:Type*} {B: ConcreteSigmaAlgebra X} : Add (CountablyAdditiveMeasure B) :=
+noncomputable instance CountablyAdditiveMeasure.instAdd {X:Type*} {B: ConcreteSigmaAlgebra X} : Add (CountablyAdditiveMeasure B) :=
   {
     add := fun μ ν =>
       {
@@ -210,7 +210,7 @@ instance CountablyAdditiveMeasure.instAdd {X:Type*} {B: ConcreteSigmaAlgebra X} 
       }
   }
 
-instance CountablyAdditiveMeasure.instAddCommMonoid {X:Type*} {B: ConcreteSigmaAlgebra X} : AddCommMonoid (CountablyAdditiveMeasure B) :=
+noncomputable instance CountablyAdditiveMeasure.instAddCommMonoid {X:Type*} {B: ConcreteSigmaAlgebra X} : AddCommMonoid (CountablyAdditiveMeasure B) :=
 {
   add_assoc := by sorry,
   zero_add := by sorry,


### PR DESCRIPTION
Mathlib has changed in ways that broke compilation of a few files, required simple updates:

- Update CompleteLattice to match changes in mathlib introduced with PR leanprover-community/mathlib4#35328

- Add noncomputable to instances due to dependence on noncomputable definitions like `instZeroEReal`.