### PR TITLE
Measure theory 1.2.23: add translation invariance to Lebesgue_measure.unique

### DIFF
--- a/Analysis/MeasureTheory/Section_1_2_2.lean
+++ b/Analysis/MeasureTheory/Section_1_2_2.lean
@@ -1767,6 +1767,7 @@ theorem Lebesgue_measure.prod {d₁ d₂:ℕ} {E₁: Set (EuclideanSpace' d₁)}
 theorem Lebesgue_measure.unique {d:ℕ} (m: Set (EuclideanSpace' d) → EReal)
   (h_empty: m ∅ = 0) (h_pos: ∀ E, 0 ≤ m E)
   (h_add: ∀ E: ℕ → Set (EuclideanSpace' d), (Set.univ.PairwiseDisjoint E) → (∀ n, LebesgueMeasurable (E n)) → m (⋃ n, E n) = ∑' n, m (E n))
+  (h_transl: ∀ (x : EuclideanSpace' d) (E : Set (EuclideanSpace' d)), m (E + {x}) = m E)
   (hnorm: m (Box.unit_cube d) = 1)
   : ∀ E, LebesgueMeasurable E → m E = Lebesgue_measure E := by sorry
 


### PR DESCRIPTION
Fixes narinluangrath's report on #517.

## Bug
`Lebesgue_measure.unique` only assumed empty-set zero, nonnegativity, countable additivity on Lebesgue measurable sets, and unit-cube normalization. That does not characterize Lebesgue measure.

## Root cause
The standard uniqueness proof subdivides the unit cube into congruent boxes; that step needs translation invariance, which was missing from the hypotheses.

## Why this fix is correct
Any density-weighted measure `m(E) = ∫_E f` with `f ≥ 0`, `∫_{[0,1]^d} f = 1`, and non-constant `f` satisfies the old hypotheses but is not Lebesgue measure. Adding `m (E + {x}) = m E` matches Tao's Exercise 1.2.23 and the Jordan-measure uniqueness statements earlier in the project.

## Test plan
- [ ] `lake build Analysis.MeasureTheory.Section_1_2_2`

Made with [Cursor](https://cursor.com)