### PR TITLE
Measure theory 1.1.24: pin interval in riemann_integral_smul

### DIFF
--- a/Analysis/MeasureTheory/Section_1_1_3.lean
+++ b/Analysis/MeasureTheory/Section_1_1_3.lean
@@ -1054,7 +1054,7 @@ theorem RiemannIntegrableOn.smul {I: BoundedInterval} (c:ℝ) {f: ℝ → ℝ} (
 
 /-- Exercise 1.1.24 (a) (Linearity of the piecewise constant integral) -/
 -- The integral of a scalar multiple: integral(c * f) = c * integral(f).
-theorem riemann_integral_smul {I:BoundedInterval} (c:ℝ) {f: ℝ → ℝ} (h: RiemannIntegrableOn f I) : riemannIntegral (c • f) = c • (riemannIntegral f) := by sorry
+theorem riemann_integral_smul {I:BoundedInterval} (c:ℝ) {f: ℝ → ℝ} (h: RiemannIntegrableOn f I) : riemannIntegral (c • f) I = c • (riemannIntegral f I) := by sorry
 
 /-- Exercise 1.1.24 (a) (Linearity of the piecewise constant integral) -/
 -- The sum of two Riemann integrable functions is Riemann integrable.


### PR DESCRIPTION
Follow-up to #517 / #521.

## Bug
`riemann_integral_smul` concluded `riemannIntegral (c • f) = c • riemannIntegral f` with no interval argument, while the hypotheses only constrain behavior on `I`.

## Root cause
Same omission as the old `riemann_integral_add` / `riemann_integral_mono` statements fixed in #521.

## Why this fix is correct
Exercise 1.1.24(a) is linearity on a fixed interval: `riemannIntegral (c • f) I = c • riemannIntegral f I`.

## Test plan
- [ ] `lake build Analysis.MeasureTheory.Section_1_1_3`

Made with [Cursor](https://cursor.com)