### PR TITLE
Measure theory 1.1.24: pin interval in riemann_integral_smul

### DIFF
--- a/Analysis/MeasureTheory/Section_1_1_3.lean
+++ b/Analysis/MeasureTheory/Section_1_1_3.lean
@@ -1054,7 +1054,7 @@ theorem RiemannIntegrableOn.smul {I: BoundedInterval} (c:ℝ) {f: ℝ → ℝ} (
 
 /-- Exercise 1.1.24 (a) (Linearity of the piecewise constant integral) -/
 -- The integral of a scalar multiple: integral(c * f) = c * integral(f).
-theorem riemann_integral_smul {I:BoundedInterval} (c:ℝ) {f: ℝ → ℝ} (h: RiemannIntegrableOn f I) : riemannIntegral (c • f) = c • (riemannIntegral f) := by sorry
+theorem riemann_integral_smul {I:BoundedInterval} (c:ℝ) {f: ℝ → ℝ} (h: RiemannIntegrableOn f I) : riemannIntegral (c • f) I = c • (riemannIntegral f I) := by sorry
 
 /-- Exercise 1.1.24 (a) (Linearity of the piecewise constant integral) -/
 -- The sum of two Riemann integrable functions is Riemann integrable.


### PR DESCRIPTION
## Summary
- `riemann_integral_smul` concluded `riemannIntegral (c • f) = c • riemannIntegral f` with no interval pinned.
- Hypothesis `RiemannIntegrableOn f I` only controls behavior on `I`, so the bare function is false off `I`.

## Root cause
Same missing interval argument as the already-fixed `riemann_integral_add` / `riemann_integral_mono` statements from #517.

## Why this fix is correct
Exercise 1.1.24 is linearity on a fixed interval: `riemannIntegral (c • f) I = c • riemannIntegral f I`.

## Test plan
- [ ] `lake build Analysis.MeasureTheory.Section_1_1_3`

Fixes part of #517.

Made with [Cursor](https://cursor.com)