### PR TITLE
Measure theory 1.2.4: require nonempty sets in dist_of_disj_compact_pos

### DIFF
--- a/Analysis/MeasureTheory/Section_1_2_1.lean
+++ b/Analysis/MeasureTheory/Section_1_2_1.lean
@@ -2164,7 +2164,8 @@ example : set_dist (Ico 0 1).toSet (Icc 1 2).toSet = 0 := by
       exact dist_nonneg
 
 /-- Exercise 1.2.4 -/
-theorem dist_of_disj_compact_pos {d:ℕ} (E F: Set (EuclideanSpace' d)) (hE: IsCompact E) (hF: IsCompact F) (hdisj: E ∩ F = ∅) :
+theorem dist_of_disj_compact_pos {d:ℕ} (E F: Set (EuclideanSpace' d)) (hEn: E.Nonempty) (hFn: F.Nonempty)
+    (hE: IsCompact E) (hF: IsCompact F) (hdisj: E ∩ F = ∅) :
     set_dist E F > 0 := by
   sorry
 

--- a/Analysis/MeasureTheory/Section_1_2_1.lean
+++ b/Analysis/MeasureTheory/Section_1_2_1.lean
@@ -4790,6 +4790,10 @@ lemma dyadicCubeInteriorNonempty {d:ℕ} (n:ℤ) (a: Fin d → ℤ) :
     exact Set.nonempty_Ioo.mpr (div_lt_div_of_pos_right (by linarith) (zpow_pos (by norm_num) _))
   )).preimage (PiLp.homeomorph 2 (fun _ : Fin d => ℝ)).surjective
 
+lemma Box.toSet_nonempty_of_IsDyadic {d : ℕ} {B : Box d} (hB : B.IsDyadic) : B.toSet.Nonempty := by
+  obtain ⟨n, ⟨a, rfl⟩⟩ := hB
+  exact (dyadicCubeInteriorNonempty n a).mono (interior_subset (s := (DyadicCube n a).toSet))
+
 /-- At the same scale, dyadic cubes with different indices cannot have one contained in the other
     (since containment would imply empty interior for one). -/
 lemma dyadicCubeNoProperContainmentSameScale {d:ℕ} {n:ℤ} {a b : Fin d → ℤ}

--- a/Analysis/MeasureTheory/Section_1_2_2.lean
+++ b/Analysis/MeasureTheory/Section_1_2_2.lean
@@ -205,8 +205,12 @@ private lemma IsClosed.measurable_of_bounded {d:ℕ} {E: Set (EuclideanSpace' d)
             intro hxi
             exact (hQ_sub hxi).2 hxE
           -- By compactness: set_dist E F_t > 0 (t is nonempty, so F_t is nonempty)
+          have ht_ne : t.Nonempty := Finset.nonempty_iff_ne_empty.mpr ht_empty
+          obtain ⟨i, hi⟩ := ht_ne
+          have hF_nonempty : F_t.Nonempty :=
+            (Box.toSet_nonempty_of_IsDyadic (hQ_dyadic i)).mono (Set.subset_biUnion_of_mem hi)
           have h_sep : set_dist E F_t > 0 :=
-            dist_of_disj_compact_pos E F_t hE_compact hF_compact hE_F_disj
+            dist_of_disj_compact_pos E F_t hE_nonempty hF_nonempty hE_compact hF_compact hE_F_disj
           -- By separation: m*(E ∪ F_t) = m*(E) + m*(F_t)
           have h_add : Lebesgue_outer_measure (E ∪ F_t) =
                        Lebesgue_outer_measure E + Lebesgue_outer_measure F_t :=
@@ -1026,7 +1030,7 @@ private lemma Lebesgue_measure.countable_union_compact {d:ℕ} (hd : 0 < d)
             have h_nonempty_union : (⋃ n ∈ Finset.range N, E n).Nonempty :=
               Set.nonempty_iff_ne_empty.mpr h_empty_union
             have h_sep : set_dist (⋃ n ∈ Finset.range N, E n) (E N) > 0 :=
-              dist_of_disj_compact_pos _ _ hcompact_finite (hcompact N) h_disj_parts
+              dist_of_disj_compact_pos _ _ h_nonempty_union h_nonempty_N hcompact_finite (hcompact N) h_disj_parts
             have h_add := Lebesgue_outer_measure.union_of_separated hd h_sep
             -- h_add : Lebesgue_outer_measure (...) = Lebesgue_outer_measure (...) + Lebesgue_outer_measure (E N)
             -- Since Lebesgue_measure = Lebesgue_outer_measure, we can use this directly


### PR DESCRIPTION
## Summary
- `dist_of_disj_compact_pos` claimed `set_dist E F > 0` for any disjoint compact sets, but fails when either set is empty.

## Root cause
`set_dist E F = sInf (dist '' (E ×ˢ F))`. For `E = ∅`, the image is empty and `sInf ∅ = 0`, contradicting `> 0`. Empty sets are compact and disjoint from anything.

## Fix
Require `E.Nonempty` and `F.Nonempty`.

## Test plan
- [ ] `lake build` passes