### PR TITLE
Section 11.10: fix sign in Exercise 11.10.3 statement

### DIFF
--- a/Analysis/Section_11_10.lean
+++ b/Analysis/Section_11_10.lean
@@ -221,7 +221,7 @@ theorem integ_of_comp {a b:ℝ} (hab: a < b) {φ f: ℝ → ℝ}
 /-- Exercise 11.10.3-/
 example {a b:ℝ} (hab: a < b) {f: ℝ → ℝ} (hf: IntegrableOn f (Icc a b)) :
   IntegrableOn (fun x ↦ f (-x)) (Icc (-b) (-a)) ∧
-  integ (fun x ↦ f (-x)) (Icc (-b) (-a)) = -integ f (Icc a b) := by
+  integ (fun x ↦ f (-x)) (Icc (-b) (-a)) = integ f (Icc a b) := by
   sorry
 
 /- Exercise 11.10.4: state and prove a version of `integ_of_comp` in which `φ` is `Antitone` rather than `Monotone`. -/


### PR DESCRIPTION
## Summary
- Exercise 11.10.3 claimed `∫_{[-b,-a]} f(-x) = -∫_{[a,b]} f`, but reflection `x ↦ -x` preserves interval length, so the integrals are equal with no sign change.

## Root cause
A stray minus sign on the RHS; the change-of-variables/substitution `u = -x` maps `Icc (-b) (-a)` bijectively to `Icc a b` with Jacobian magnitude 1.

## Why this fix is correct
For `f = 1`, `a = 1`, `b = 2`: LHS `= integ 1 (Icc (-2) (-1)) = 1`, but the old RHS `= -integ 1 (Icc 1 2) = -1`. The corrected RHS gives `1`.

Related: #533

## Test plan
- [ ] `lake build Analysis.Section_11_10` (statement-only change; proof remains `sorry`)