### PR TITLE
Add missing 6.4.1 exercise

### DIFF
--- a/Analysis/Section_6_4.lean
+++ b/Analysis/Section_6_4.lean
@@ -72,6 +72,10 @@ example : ¬ Example_6_4_4.LimitPoint 0 := by sorry
 theorem Sequence.limit_point_of_limit {a:Sequence} {x:ℝ} (h: a.TendsTo x) : a.LimitPoint x := by
   sorry
 
+/-- Proposition 6.4.5 / Exercise 6.4.1 -/
+theorem Sequence.limit_point_of_limit_unique {a:Sequence} {x y:ℝ} (h: a.TendsTo x) (hy: a.LimitPoint y) : x = y := by
+  sorry
+
 /--
   A technical issue uncovered by the formalization: the upper and lower sequences of a real
   sequence take values in the extended reals rather than the reals, so the definitions need to be


### PR DESCRIPTION
<img width="648" height="175" alt="image" src="https://github.com/user-attachments/assets/c99f0c65-9516-4a66-bbda-3793b072e8fa" />

The first part of the proposition is captured by `Sequence.limit_point_of_limit` but not the second.

[My solution](https://github.com/brandondong/analysis/blob/a8a1ba046394c3eddb252f99982822d73b5ba774/Analysis/Section_6_4.lean#L112)