### PR TITLE
fix: require g ≠ 0 in PiecewiseConstantOn.div

### DIFF
--- a/Analysis/Section_11_2.lean
+++ b/Analysis/Section_11_2.lean
@@ -155,9 +155,10 @@ theorem PiecewiseConstantOn.smul {f: ℝ → ℝ} {I: BoundedInterval}
   (c:ℝ) (hf: PiecewiseConstantOn f I) : PiecewiseConstantOn (c • f) I := by
   sorry
 
-/-- Lemma 11.2.8 / Exercise 11.2.2.  I believe the hypothesis that {name}`g` does not vanish is not needed. -/
+/-- Lemma 11.2.8 / Exercise 11.2.2. -/
 theorem PiecewiseConstantOn.div {f g: ℝ → ℝ} {I: BoundedInterval}
-  (hf: PiecewiseConstantOn f I) (hg: PiecewiseConstantOn g I) : PiecewiseConstantOn (f / g) I := by
+  (hf: PiecewiseConstantOn f I) (hg: PiecewiseConstantOn g I) (hg_ne : ∀ x ∈ I.toSet, g x ≠ 0) :
+  PiecewiseConstantOn (f / g) I := by
   sorry
 
 /-- Definition 11.2.9 (Piecewise constant integral I)-/


### PR DESCRIPTION
## Summary
- `PiecewiseConstantOn.div` was missing a nonvanishing hypothesis on `g`.
- If `g` hits zero on part of `I` while `f` doesn't, `f/g` blows up there — not piecewise constant.

## Test plan
- [ ] `lake build Analysis.Section_11_2`


Made with [Cursor](https://cursor.com)