### PR TITLE
fix: add global bounds in Ex. 1.3.8 aeEqual/aeLimit

### DIFF
--- a/Analysis/MeasureTheory/Section_1_3_2.lean
+++ b/Analysis/MeasureTheory/Section_1_3_2.lean
@@ -3282,14 +3282,20 @@ theorem Continuous.ComplexMeasurable {d:ℕ} {f: EuclideanSpace' d → ℂ} (hf:
 theorem UnsignedSimpleFunction.iff' {d:ℕ} {f: EuclideanSpace' d → EReal} (hf: Unsigned f) : UnsignedSimpleFunction f ↔ UnsignedMeasurable f ∧ Finite (f '' Set.univ) := by sorry
 
 /-- Exercise 1.3.8(iii) -/
-theorem RealMeasurable.aeEqual {d:ℕ} {f g: EuclideanSpace' d → ℝ} (hf: RealMeasurable f) (heq: AlmostEverywhereEqual f g) : RealMeasurable g := by sorry
+theorem RealMeasurable.aeEqual {d:ℕ} {f g: EuclideanSpace' d → ℝ} (hf: RealMeasurable f)
+    (hg : ∃ M : ℝ, ∀ x, |g x| ≤ M) (heq: AlmostEverywhereEqual f g) : RealMeasurable g := by sorry
 
-theorem ComplexMeasurable.aeEqual {d:ℕ} {f g: EuclideanSpace' d → ℂ} (hf: ComplexMeasurable f) (heq: AlmostEverywhereEqual f g) : ComplexMeasurable g := by sorry
+theorem ComplexMeasurable.aeEqual {d:ℕ} {f g: EuclideanSpace' d → ℂ} (hf: ComplexMeasurable f)
+    (hg : ∃ M : ℝ, ∀ x, ‖g x‖ ≤ M) (heq: AlmostEverywhereEqual f g) : ComplexMeasurable g := by sorry
 
 /-- Exercise 1.3.8(iv) -/
-theorem RealMeasurable.aeLimit {d:ℕ} {f: EuclideanSpace' d → ℝ} (g: ℕ → EuclideanSpace' d → ℝ) (hf: ∀ n, RealMeasurable (g n)) (heq: PointwiseAeConvergesTo g f) : RealMeasurable f := by sorry
+theorem RealMeasurable.aeLimit {d:ℕ} {f: EuclideanSpace' d → ℝ} (g: ℕ → EuclideanSpace' d → ℝ)
+    (hf : ∀ n, RealMeasurable (g n)) (hfn : ∃ M : ℝ, ∀ x, |f x| ≤ M)
+    (heq: PointwiseAeConvergesTo g f) : RealMeasurable f := by sorry
 
-theorem ComplexMeasurable.aeLimit {d:ℕ} {f: EuclideanSpace' d → ℂ} (g: ℕ → EuclideanSpace' d → ℂ) (hf: ∀ n, ComplexMeasurable (g n)) (heq: PointwiseAeConvergesTo g f) : ComplexMeasurable f := by sorry
+theorem ComplexMeasurable.aeLimit {d:ℕ} {f: EuclideanSpace' d → ℂ} (g: ℕ → EuclideanSpace' d → ℂ)
+    (hf : ∀ n, ComplexMeasurable (g n)) (hfn : ∃ M : ℝ, ∀ x, ‖f x‖ ≤ M)
+    (heq: PointwiseAeConvergesTo g f) : ComplexMeasurable f := by sorry
 
 /-- Exercise 1.3.8(v) -/
 theorem RealMeasurable.comp_cts {d:ℕ} {f: EuclideanSpace' d → ℝ} (hf: RealMeasurable f) {φ: ℝ → ℝ} (hφ: Continuous φ)  : RealMeasurable (φ ∘ f) := by sorry


### PR DESCRIPTION
## Summary
- Exercise 1.3.8(iii)-(iv) had the same gap as #532 for unsigned functions: ae closeness doesn't pin down behavior off a null set.
- aeEqual now assumes g is globally bounded; aeLimit assumes the limit f is globally bounded.

## Test plan
- [ ] `lake build Analysis.MeasureTheory.Section_1_3_2`


Made with [Cursor](https://cursor.com)