### PR TITLE
Measure theory 1.3.3: use Lebesgue measurability for set hypotheses

### DIFF
--- a/Analysis/MeasureTheory/Section_1_3_3.lean
+++ b/Analysis/MeasureTheory/Section_1_3_3.lean
@@ -149,7 +149,7 @@ theorem UpperUnsignedLebesgueIntegral.subadditive {d:ℕ} {f g: EuclideanSpace' 
     UpperUnsignedLebesgueIntegral (f + g) ≤ UpperUnsignedLebesgueIntegral f + UpperUnsignedLebesgueIntegral g := by sorry
 
 /-- Exercise 1.3.10(vii) (Divisibility) -/
-theorem LowerUnsignedLebesgueIntegral.eq_add {d:ℕ} {f: EuclideanSpace' d → EReal} (hf: UnsignedMeasurable f) {E: Set (EuclideanSpace' d)} (hE: MeasurableSet E) :
+theorem LowerUnsignedLebesgueIntegral.eq_add {d:ℕ} {f: EuclideanSpace' d → EReal} (hf: UnsignedMeasurable f) {E: Set (EuclideanSpace' d)} (hE: LebesgueMeasurable E) :
     LowerUnsignedLebesgueIntegral f = LowerUnsignedLebesgueIntegral (f * Real.toEReal ∘ E.indicator') +
       LowerUnsignedLebesgueIntegral (f * Real.toEReal ∘ Eᶜ.indicator') := by sorry
 
@@ -296,7 +296,7 @@ theorem LowerUnsignedLebesgueIntegral.add {d:ℕ} {f g: EuclideanSpace' d → ER
     exact LowerUnsignedLebesgueIntegral.superadditive hf hg
 
 /-- Exercise 1.3.12 (Upper Lebesgue integral and outer measure)-/
-theorem UpperUnsignedLebesgueIntegral.eq_outer_measure_integral {d:ℕ} {E: Set (EuclideanSpace' d)} (hE: MeasurableSet E) :
+theorem UpperUnsignedLebesgueIntegral.eq_outer_measure_integral {d:ℕ} {E: Set (EuclideanSpace' d)} (hE: LebesgueMeasurable E) :
     UpperUnsignedLebesgueIntegral (Real.toEReal ∘ E.indicator') = Lebesgue_outer_measure E := by sorry
 
 theorem LowerUnsignedLebesgueIntegral.not_additive : ∃ (d:ℕ) (f g: EuclideanSpace' d → EReal) (hf: Unsigned f) (hg: Unsigned g), (LowerUnsignedLebesgueIntegral (f + g) ≠ LowerUnsignedLebesgueIntegral f + LowerUnsignedLebesgueIntegral g) := by


### PR DESCRIPTION
## Summary
- `LowerUnsignedLebesgueIntegral.eq_add` and `UpperUnsignedLebesgueIntegral.eq_outer_measure_integral` now take `LebesgueMeasurable E` instead of `MeasurableSet E`.
- Matches the Lebesgue framework used elsewhere in the measure theory chapter (e.g. glue lemmas in 1.3.4).

## Test plan
- [ ] `lake build Analysis/MeasureTheory/Section_1_3_3.lean`

Related to #517.


Made with [Cursor](https://cursor.com)