### PR TITLE
Measure theory 1.3.5: Lebesgue measurability for local integrability

### DIFF
--- a/Analysis/MeasureTheory/Section_1_3_5.lean
+++ b/Analysis/MeasureTheory/Section_1_3_5.lean
@@ -1544,6 +1544,7 @@ theorem PointwiseAeConvergesTo.uniformlyConverges_outside_small {d:ℕ} {f : ℕ
   (hf: ∀ n, ComplexMeasurable (f n))
   (hfg: PointwiseAeConvergesTo f g)
   (S: Set (EuclideanSpace' d))
+  (hSm: LebesgueMeasurable S)
   (hS: Lebesgue_measure S < ⊤)
   (ε : ℝ) (hε : 0 < ε) :
   ∃ (E: Set (EuclideanSpace' d)), MeasurableSet E ∧
@@ -1564,7 +1565,7 @@ example : ∃ (d:ℕ) (f : EuclideanSpace' d → ℝ),
     ∀ (E: Set (EuclideanSpace' d)), MeasurableSet E → Lebesgue_measure E ≤ 1 → ¬ ContinuousOn f Eᶜ := by sorry
 
 def LocallyComplexAbsolutelyIntegrable {d:ℕ} (f: EuclideanSpace' d → ℂ) : Prop :=
-  ∀ (S: Set (EuclideanSpace' d)), MeasurableSet S ∧ Bornology.IsBounded S → ComplexAbsolutelyIntegrableOn f S
+  ∀ (S: Set (EuclideanSpace' d)), LebesgueMeasurable S ∧ Bornology.IsBounded S → ComplexAbsolutelyIntegrableOn f S
 
 /-- Exercise 1.3.23 (Lusin's theorem only requires local absolute integrability )-/
 theorem LocallyComplexAbsolutelyIntegrable.approx_by_continuous_outside_small {d:ℕ} {f : EuclideanSpace' d → ℂ}


### PR DESCRIPTION
## Summary
- `LocallyComplexAbsolutelyIntegrable` now quantifies over `LebesgueMeasurable` bounded sets, not Borel `MeasurableSet`.
- `uniformlyConverges_outside_small` requires `LebesgueMeasurable S` when using `Lebesgue_measure S`.

## Test plan
- [ ] `lake build Analysis/MeasureTheory/Section_1_3_5.lean`

Follow-up to #547 / #546.


Made with [Cursor](https://cursor.com)