### PR TITLE
Measure theory 1.4.2: fix Exercise 1.4.18(ii) (slice non-measurability)

### DIFF
--- a/Analysis/MeasureTheory/Section_1_4_2.lean
+++ b/Analysis/MeasureTheory/Section_1_4_2.lean
@@ -198,9 +198,8 @@ theorem BorelSigmaAlgebra.slice_snd {d₁ d₂:ℕ} {E : Set (EuclideanSpace' (d
   by sorry
 
 /-- Exercise 1.4.18(ii) -/
-example (d₁ d₂ :ℕ) (E : Set (EuclideanSpace' (d₁+d₂)))
-  (hE: LebesgueMeasurable E)
-  (x₂ : EuclideanSpace' d₂ ) :
+example : ∃ (d₁ d₂ : ℕ) (E : Set (EuclideanSpace' (d₁+d₂))) (x₂ : EuclideanSpace' d₂),
+  LebesgueMeasurable E ∧
   ¬ LebesgueMeasurable { x₁ | (EuclideanSpace'.prod_equiv d₁ d₂).symm ⟨ x₁, x₂ ⟩ ∈ E } := by sorry
 
 /-- Exercise 1.4.19 -/


### PR DESCRIPTION
Exercise 1.4.18(ii) is stated universally:

```lean
example (d₁ d₂ : ℕ) (E : Set (EuclideanSpace' (d₁+d₂)))
  (hE : LebesgueMeasurable E) (x₂ : EuclideanSpace' d₂) :
  ¬ LebesgueMeasurable { x₁ | (EuclideanSpace'.prod_equiv d₁ d₂).symm ⟨x₁, x₂⟩ ∈ E }
```

This asserts that for **every** Lebesgue-measurable `E` and **every** `x₂` the slice is non-measurable, which is false (take `E = univ`: the slice is `univ`, which is measurable). The point of (ii) — contrasting with the Borel case in (i) — is that **some** Lebesgue-measurable set has a non-measurable slice (e.g. `V × {0}` with `V` non-measurable: it is null, hence Lebesgue-measurable, but its slice at `0` is `V`).

Restate it as an existence claim.