### PR TITLE
Measure theory 1.4.1: fix quantifier scoping in eq_generated_by_iff (Example 1.4.11)

### DIFF
--- a/Analysis/MeasureTheory/Section_1_4_1.lean
+++ b/Analysis/MeasureTheory/Section_1_4_1.lean
@@ -259,7 +259,7 @@ instance ConcreteBooleanAlgebra.instCompleteLattice {X:Type*} : CompleteLattice 
   }
 
 /-- Example 1.4.11 -/
-instance ConcreteBooleanAlgebra.eq_generated_by_iff {X:Type*} (F: Set (Set X)) : ∃ (B : ConcreteBooleanAlgebra X), B.measurableSets = F ↔ (ConcreteBooleanAlgebra.generated_by F).measurableSets = F := by sorry
+instance ConcreteBooleanAlgebra.eq_generated_by_iff {X:Type*} (F: Set (Set X)) : (∃ (B : ConcreteBooleanAlgebra X), B.measurableSets = F) ↔ (ConcreteBooleanAlgebra.generated_by F).measurableSets = F := by sorry
 
 /-- Exercise 1.4.7 (Generation by boxes) -/
 instance EuclideanSpace'.elementary_boolean_algebra_generated_by_boxes (d:ℕ) : EuclideanSpace'.elementary_boolean_algebra d =


### PR DESCRIPTION
In `eq_generated_by_iff` the existential is scoped **inside** the iff:

```lean
∃ (B : ConcreteBooleanAlgebra X),
  B.measurableSets = F ↔ (generated_by F).measurableSets = F
```

So the statement is `∃ B, (B.measurableSets = F ↔ Q)` for the fixed proposition `Q := (generated_by F).measurableSets = F`. This is degenerate: whenever `Q` is false one can pick any `B` with `B.measurableSets ≠ F` (e.g. `⊤`) and the iff holds vacuously, so the statement carries no content about whether `F` is realisable.

Example 1.4.11 is the characterisation "`F` is the family of measurable sets of some Boolean algebra **iff** `F` equals the algebra it generates". Pulling the `∃` to the left of the iff:

```lean
(∃ B, B.measurableSets = F) ↔ (generated_by F).measurableSets = F
```

(`←` take `B = generated_by F`; `→` since `generated_by F` is the least algebra containing `F`, any realiser `B` sandwiches it to equality.)