### PR TITLE
Measure theory 1.4.1: fix Restriction (Exercise 1.4.2) restrict + restrict_iff

### DIFF
--- a/Analysis/MeasureTheory/Section_1_4_1.lean
+++ b/Analysis/MeasureTheory/Section_1_4_1.lean
@@ -104,14 +104,14 @@ def IsNull.lt_lebesgue_boolean_algebra (d:ℕ) :
 /-- Exercise 1.4.2 (Restriction) -/
 def ConcreteBooleanAlgebra.restrict {X:Type*} (B: ConcreteBooleanAlgebra X) (A:Set X) : ConcreteBooleanAlgebra A :=
   {
-    measurable := fun E => ∃ E' : Set X, B.measurable E ∧ E = E' ∩ A
+    measurable := fun E => ∃ E' : Set X, B.measurable E' ∧ E = Subtype.val ⁻¹' E'
     empty_mem := by sorry
     compl_mem := by sorry
     union_mem := by sorry
   }
 
 def ConcreteBooleanAlgebra.restrict_iff {X:Type*} {B: ConcreteBooleanAlgebra X} {A:Set X} (h: B.measurable A) (E: Set A) :
-  (B.restrict A).measurable E ↔ B.measurable A :=
+  (B.restrict A).measurable E ↔ B.measurable (Subtype.val '' E) :=
   by sorry
 
 /-- Remark 1.4.2: {name}`ConcreteBooleanAlgebra`s are {name}`BooleanAlgebra`s -/


### PR DESCRIPTION
Two related issues in Exercise 1.4.2 (Restriction). The restriction algebra is `B↾A = {E' ∩ A : E' ∈ B}`, i.e. an `E : Set A` is measurable iff it is the trace of some `B`-measurable set.

**`restrict`** defined membership as
```lean
measurable := fun E => ∃ E' : Set X, B.measurable E ∧ E = E' ∩ A
```
The witness `E'` only appears in `E = E' ∩ A` (always satisfiable by `E' = ↑E`), and the real condition is `B.measurable E` on the **coerced** set — i.e. `Subtype.val '' E ∈ B`. That is the trace algebra only when `A ∈ B`; in general it tests the set `E` itself instead of the witness `E'`. Corrected to
```lean
measurable := fun E => ∃ E' : Set X, B.measurable E' ∧ E = Subtype.val ⁻¹' E'
```

**`restrict_iff`** had RHS `B.measurable A`, which is exactly the hypothesis `h`, so the iff degenerated to "every `E : Set A` is measurable in the restriction". With `A` measurable, the intended characterisation is that `E ∈ B↾A` iff its image is `B`-measurable:
```lean
(B.restrict A).measurable E ↔ B.measurable (Subtype.val '' E)
```
(`→` `Subtype.val '' (Subtype.val ⁻¹' E') = E' ∩ A`, measurable since `E'` and `A` are; `←` take `E' = Subtype.val '' E`.)

The σ-algebra `ConcreteSigmaAlgebra.restrict` in 1.4.2 is built on this definition, so it is corrected too.