### PR TITLE
Measure theory 1.4.3: fix Exercise 1.4.24(i) (limit set measurability)

### DIFF
--- a/Analysis/MeasureTheory/Section_1_4_3.lean
+++ b/Analysis/MeasureTheory/Section_1_4_3.lean
@@ -294,7 +294,7 @@ theorem Measure.downwards_mono_counter : ∃ (X:Type) (M: MeasurableSpace X) (μ
 
 /-- Exercise 1.4.24 (i) (Dominated convergence for sets) -/
 theorem Measure.measurable_of_lim {X:Type*} [MeasurableSpace X] (μ: Measure X) {E : ℕ → Set X} (hE: ∀ n, Measurable (E n))
-  {E' : Set X} (hlim : PointwiseConvergesTo E E') : Measurable E := by sorry
+  {E' : Set X} (hlim : PointwiseConvergesTo E E') : Measurable E' := by sorry
 
 /-- Exercise 1.4.24 (ii) (Dominated convergence for sets) -/
 theorem Measure.measure_of_lim {X:Type*} [MeasurableSpace X] (μ: Measure X) {E : ℕ → Set X} (hE: ∀ n, Measurable (E n))


### PR DESCRIPTION
Exercise 1.4.24(i) (`Measure.measurable_of_lim`) concluded `Measurable E`, but `E : ℕ → Set X` is the *sequence* of sets, so this is a vacuous statement about the sequence-as-function (ℕ carries the ⊤ σ-algebra). The exercise asserts that the **pointwise limit** `E'` is measurable. Fix: conclude `Measurable E'`.