### PR TITLE
Measure theory 1.4.3: fix Exercise 1.4.26 (completion needs complete extension)

### DIFF
--- a/Analysis/MeasureTheory/Section_1_4_3.lean
+++ b/Analysis/MeasureTheory/Section_1_4_3.lean
@@ -319,7 +319,7 @@ theorem Measure.on_countable {X:Type*} [Countable X] [M: MeasurableSpace X] (hM:
 
 /-- Exercise 1.4.26 (Completion) -/
 theorem Measure.completion_lt {X:Type*} [M : MeasurableSpace X] (μ: Measure X) (M' : MeasurableSpace X) (μ' : @Measure X M')
-  (hMM' : M ≤ M') (hμ : ∀ E, M.MeasurableSet' E → μ E = μ' E) : ∀ E : Set X, @NullMeasurableSet X M E μ → (M'.MeasurableSet' E ∧ μ' E = μ.completion E)
+  (hcomplete : μ'.IsComplete) (hMM' : M ≤ M') (hμ : ∀ E, M.MeasurableSet' E → μ E = μ' E) : ∀ E : Set X, @NullMeasurableSet X M E μ → (M'.MeasurableSet' E ∧ μ' E = μ.completion E)
    := by sorry
 
 noncomputable def EuclideanSpace'.lebesgueMeasure (d:ℕ) := (FinitelyAdditiveMeasure.lebesgue_isCountablyAdditive d).toMeasure


### PR DESCRIPTION
Exercise 1.4.26 (`Measure.completion_lt`) is false as stated: with `M' = M` and `μ' = μ` the hypotheses `hMM'`/`hμ` hold trivially, yet any `μ`-null non-`M`-measurable set `E` satisfies `NullMeasurableSet M E μ` while `¬ M'.MeasurableSet' E`, so the conclusion fails. (Concretely, take `μ = 0`: every set is null-measurable but not every set is `M`-measurable.)

Tao's completion exercise asserts the completion is the *minimal complete* extension — i.e. any **complete** `(X, B', μ')` extending `(X, B, μ)` also extends the completion. Fix: add `hcomplete : μ'.IsComplete`.