### PR TITLE
fix: correct docstring typos (Uppper->Upper, betweeen->between)

### DIFF
--- a/Analysis/Section_11_3.lean
+++ b/Analysis/Section_11_3.lean
@@ -27,7 +27,7 @@ abbrev MinorizesOn (g f:ℝ → ℝ) (I: BoundedInterval) : Prop := ∀ x ∈ (I
 
 theorem MinorizesOn.iff (g f:ℝ → ℝ) (I: BoundedInterval) : MinorizesOn g f I ↔ MajorizesOn f g I := by rfl
 
-/-- Definition 11.3.2 (Uppper and lower Riemann integrals )-/
+/-- Definition 11.3.2 (Upper and lower Riemann integrals )-/
 noncomputable abbrev upper_integral (f:ℝ → ℝ) (I: BoundedInterval) : ℝ :=
   sInf ((PiecewiseConstantOn.integ · I) '' {g | MajorizesOn g f I ∧ PiecewiseConstantOn g I})
 

--- a/Analysis/Section_11_8.lean
+++ b/Analysis/Section_11_8.lean
@@ -341,7 +341,7 @@ theorem PiecewiseConstantOn.RS_integ_of_join {I J K: BoundedInterval} (hIJK: K.j
   RS_integ f K α = RS_integ f I α + RS_integ f J α := by
   sorry
 
-/-- Analogue of Definition 11.3.2 (Uppper and lower Riemann integrals )-/
+/-- Analogue of Definition 11.3.2 (Upper and lower Riemann integrals )-/
 noncomputable abbrev upper_RS_integral (f:ℝ → ℝ) (I: BoundedInterval) (α: ℝ → ℝ): ℝ :=
   sInf ((PiecewiseConstantOn.RS_integ · I α) '' {g | MajorizesOn g f I ∧ PiecewiseConstantOn g I})
 

--- a/Analysis/Section_3_5.lean
+++ b/Analysis/Section_3_5.lean
@@ -166,7 +166,7 @@ noncomputable abbrev SetTheory.Set.curry_equiv {X Y Z:Set} : (X → Y → Z) ≃
   right_inv _ := by simp
 
 /-- Definition 3.5.6.  The indexing set {name}`I` plays the role of $`{ i : 1 ≤ i ≤ n }` in the text.
-    See Exercise 3.5.10 below for some connections betweeen this concept and the preceding notion
+    See Exercise 3.5.10 below for some connections between this concept and the preceding notion
     of Cartesian product and ordered pair.  -/
 abbrev SetTheory.Set.tuple {I:Set} {X: I → Set} (x: ∀ i, X i) : Object :=
   ((fun i ↦ ⟨ x i, by rw [mem_iUnion]; use i; exact (x i).property ⟩):I → iUnion I X)


### PR DESCRIPTION
Typo-only fixes in section docstrings; no statement or proof is changed.

- `Section_11_3.lean` (Definition 11.3.2 docstring): `Uppper` -> `Upper`
- `Section_11_8.lean` (analogue of Definition 11.3.2 docstring): `Uppper` -> `Upper`
- `Section_3_5.lean` docstring: `betweeen` -> `between`

Made with [Cursor](https://cursor.com)