### PR TITLE
Measure theory 1.4.1: fix Exercise number for null algebra not atomic

### DIFF
--- a/Analysis/MeasureTheory/Section_1_4_1.lean
+++ b/Analysis/MeasureTheory/Section_1_4_1.lean
@@ -217,7 +217,7 @@ def JordanMeasurable.boolean_algebra_not_atomic (d:ℕ) (hd: d ≥ 1) : ¬ (Jord
 def LebesgueMeasurable.boolean_algebra_not_atomic (d:ℕ) (hd: d ≥ 1) : ¬ (LebesgueMeasurable.boolean_algebra d).isAtomic :=
   by sorry
 
-/-- Exercise 1.4.6 (Null algebra not atomic) -/
+/-- Exercise 1.4.5 (Null algebra not atomic) -/
 def IsNull.boolean_algebra_not_atomic (d:ℕ) (hd: d ≥ 1) : ¬ (IsNull.boolean_algebra d).isAtomic :=
   by sorry
 


### PR DESCRIPTION
The "null algebra is not atomic" result is docstring-labeled `Exercise 1.4.6`, but in the book this is part of **Exercise 1.4.5** ("Show that the elementary, Jordan, Lebesgue, and null algebras are not atomic algebras"). The three sibling results above it (`elementary_boolean_algebra_not_atomic`, `JordanMeasurable.boolean_algebra_not_atomic`, `LebesgueMeasurable.boolean_algebra_not_atomic`) are all correctly labeled `Exercise 1.4.5`; the null case was the odd one out.

`Exercise 1.4.6` is a separate exercise (Intersection of algebras), which is already correctly labeled on the following declaration.

Docstring-only change.

Made with [Cursor](https://cursor.com)