### PR TITLE
Measure theory 1.4.2: fix generation Definition and open-balls Exercise numbers

### DIFF
--- a/Analysis/MeasureTheory/Section_1_4_2.lean
+++ b/Analysis/MeasureTheory/Section_1_4_2.lean
@@ -99,7 +99,7 @@ instance ConcreteSigmaAlgebra.instInfSet {X:Type*} : InfSet (ConcreteSigmaAlgebr
 def ConcreteSigmaAlgebra.generated_by {X:Type*} (F: Set (Set X)) : ConcreteSigmaAlgebra X :=
   sInf { B | ∀ E ∈ F, B.measurable E }
 
-/-- Definition 1.4.10 (Generation of algebras) -/
+/-- Definition 1.4.14 (Generation of σ-algebras) -/
 instance ConcreteSigmaAlgebra.instSupSet {X:Type*} : SupSet (ConcreteSigmaAlgebra X) :=
   {
       sSup S := ConcreteSigmaAlgebra.generated_by (⋃ B ∈ S, B.measurableSets)
@@ -144,7 +144,7 @@ theorem BorelSigmaAlgebra.generated_by_closed (d:ℕ) : BorelSigmaAlgebra (Eucli
 /-- Exercise 1.4.14 (iii) -/
 theorem BorelSigmaAlgebra.generated_by_compact (d:ℕ) : BorelSigmaAlgebra (EuclideanSpace' d) = ConcreteSigmaAlgebra.generated_by { K : Set (EuclideanSpace' d) | IsCompact K } := by sorry
 
-/-- Exercise 1.4.15 (iv) -/
+/-- Exercise 1.4.14 (iv) -/
 theorem BorelSigmaAlgebra.generated_by_open_balls (d:ℕ) : BorelSigmaAlgebra (EuclideanSpace' d) = ConcreteSigmaAlgebra.generated_by { B : Set (EuclideanSpace' d) | ∃ x₀ r, B = Metric.ball x₀ r } := by sorry
 
 /-- Exercise 1.4.14 (v) -/


### PR DESCRIPTION
Two docstring numbering fixes in the σ-algebra section:

- The generation-of-σ-algebras `SupSet`/`generated_by` instance is labeled `Definition 1.4.10 (Generation of algebras)`, which is the number for the *Boolean* algebra generation in §1.4.1. For σ-algebras this is **Definition 1.4.14 (Generation of σ-algebras)**.
- `BorelSigmaAlgebra.generated_by_open_balls` is labeled `Exercise 1.4.15 (iv)`, but "open balls" is part **(iv) of Exercise 1.4.14** (generators of the Borel σ-algebra). The surrounding parts (i), (ii), (iii), (v), (vi) are all already labeled `Exercise 1.4.14`.

Docstring-only change.

Made with [Cursor](https://cursor.com)