### PR TITLE
Measure theory 1.2.2: correct Exercise 1.2.16 name to 'Criteria for finite measure'

### DIFF
--- a/Analysis/MeasureTheory/Section_1_2_2.lean
+++ b/Analysis/MeasureTheory/Section_1_2_2.lean
@@ -1674,7 +1674,7 @@ example {d:ℕ} (E: Set (EuclideanSpace' d)) : ∃ (F: Set (EuclideanSpace' d)),
 theorem Lebesgue_measure.eq {d:ℕ} {E: Set (EuclideanSpace' d)} (hE: LebesgueMeasurable E): Lebesgue_measure E = sSup { M | ∃ K, K ⊆ E ∧ IsCompact K ∧ M = Lebesgue_measure K} := by
   sorry
 
-/-- Exercise 1.2.16 (Criteria for measurability)-/
+/-- Exercise 1.2.16 (Criteria for finite measure)-/
 theorem LebesgueMeasurable.finite_TFAE {d:ℕ} (E: Set (EuclideanSpace' d)) :
     [
       LebesgueMeasurable E ∧ Lebesgue_measure E < ⊤,


### PR DESCRIPTION
`LebesgueMeasurable.finite_TFAE` is docstring-labeled `Exercise 1.2.16 (Criteria for measurability)`, but in the book Exercise 1.2.16 is titled **"Criteria for finite measure"** (Exercise 1.2.7 is the one titled "Criteria for measurability"). This also matches the statement itself, whose first condition is `LebesgueMeasurable E ∧ Lebesgue_measure E < ⊤` and whose name is `finite_TFAE`.

Docstring-only change.

Made with [Cursor](https://cursor.com)