### PR TITLE
Fix malformed section header comments in Section_1_2_1

### DIFF
--- a/Analysis/MeasureTheory/Section_1_2_1.lean
+++ b/Analysis/MeasureTheory/Section_1_2_1.lean
@@ -3159,9 +3159,9 @@ example {d:ℕ} {hd: 0 < d} : ∃ (S:Type) (E: S → Set (EuclideanSpace' d)), �
   rw [h_cube, h_sum]
   simp
 
--- ========================================================================
---  Start of Helpers for remark 1.2.8 -/
--- ========================================================================
+/- ========================================================================
+   Start of Helpers for remark 1.2.8
+   ======================================================================== -/
 
 /-- The distance on {lean}`EuclideanSpace' 1` equals the distance in ℝ via {name}`EuclideanSpace'.equiv_Real` -/
 lemma EuclideanSpace'_dist_eq_Real_dist (x y : EuclideanSpace' 1) :
@@ -3551,9 +3551,9 @@ lemma U_lebesgue_le (ε : ℝ) (hε : 0 < ε) :
     _ ≤ ((2 * ε : ℝ) : EReal) := h_sum_bound
 
 end Remark_1_2_8
--- ========================================================================
---  End of Helpers for remark 1.2.8 -/
--- ========================================================================
+/- ========================================================================
+   End of Helpers for remark 1.2.8
+   ======================================================================== -/
 
 /-- Remark 1.2.8: There exists a bounded open set that is not Jordan measurable.
     Proof sketch: Take U = ⋃\_\{n\} (q\_n - ε/2^\{n+1\}, q\_n + ε/2^\{n+1\}) where \{q\_n\} enumerates ℚ ∩ \[0,1\].


### PR DESCRIPTION
## Summary
Remark 1.2.8 helper boundaries used `-- ... -/` line comments with a stray `-/` terminator instead of `/- ... -/` block comments.

## Test plan
- [x] Comment-only change; no proof signatures affected

Made with [Cursor](https://cursor.com)