### PR TITLE
fix: Exercise 1.2.25 counterexample Cx typo

### DIFF
--- a/Analysis/MeasureTheory/Section_1_2_2.lean
+++ b/Analysis/MeasureTheory/Section_1_2_2.lean
@@ -1828,7 +1828,7 @@ noncomputable abbrev IsCurve {d:ℕ} (C: Set (EuclideanSpace' d)) : Prop := ∃ 
 /-- Exercise 1.2.25(i) -/
 theorem IsCurve.null {d:ℕ} (hd: d ≥ 2) {C: Set (EuclideanSpace' d)} (hC: IsCurve C) : IsNull C := by sorry
 
-example : ∃ (d:ℕ) (C: Set (EuclideanSpace' d)) (hC: IsCurve C), ¬ IsNull Cx := by
+example : ∃ (d:ℕ) (C: Set (EuclideanSpace' d)) (hC: IsCurve C), ¬ IsNull C := by
   sorry
 
 /-- Exercise 1.2.25 -/


### PR DESCRIPTION
## Summary
- `¬ IsNull Cx` referenced undefined `Cx`; should be bound curve `C`.

## Test plan
- [x] `lake build Analysis.MeasureTheory.Section_1_2_2`

Made with [Cursor](https://cursor.com)