### PR TITLE
fix: Ch 7–11 Verso doc periods and Cor. 7.5.3 labels

### DIFF
--- a/Analysis/Section_10_1.lean
+++ b/Analysis/Section_10_1.lean
@@ -122,7 +122,7 @@ theorem _root_.ContinuousWithinAt.of_differentiableWithinAt {X: Set ℝ} {x₀ :
   ContinuousWithinAt f X x₀ := by
   sorry
 
-/-Definition 10.1.11 (Differentiability on a domain)-/
+/-Definition 10.1.11 (Differentiability on a domain). -/
 #check DifferentiableOn.eq_1
 
 /-- Corollary 10.1.12 -/

--- a/Analysis/Section_11_1.lean
+++ b/Analysis/Section_11_1.lean
@@ -411,7 +411,7 @@ example : ∃ P P' : Partition (Icc 1 4),
   P' ≤ P := by
   sorry
 
-/-- Definition 11.1.16 (Common refinement)-/
+/-- Definition 11.1.16 (Common refinement). -/
 noncomputable instance Partition.instMax (I: BoundedInterval) : Max (Partition I) where
   max P P' := {
     intervals := Finset.image₂ (fun J K ↦ J ∩ K) P.intervals P'.intervals

--- a/Analysis/Section_11_10.lean
+++ b/Analysis/Section_11_10.lean
@@ -175,7 +175,7 @@ theorem PiecewiseConstantOn.RS_integ_of_comp {a b:ℝ} (hab: a < b) {φ f:ℝ �
     exact this h1.2
   ext; apply (P.exists_unique _ h3).unique <;> simp [J.property, K.property, mem_iff, h1, h2]
 
-/-- Proposition 11.10.6 (Change of variables formula II)-/
+/-- Proposition 11.10.6 (Change of variables formula II). -/
 theorem RS_integ_of_comp {a b:ℝ} (hab: a < b) {φ f: ℝ → ℝ}
   (hφ_cont: Continuous φ) (hφ_mono: Monotone φ) (hf: IntegrableOn f (Icc (φ a) (φ b))) :
   RS_IntegrableOn (f ∘ φ) (Icc a b) φ ∧
@@ -205,7 +205,7 @@ theorem RS_integ_of_comp {a b:ℝ} (hab: a < b) {φ f: ℝ → ℝ}
     lower_RS_integral_le_upper hfφ_bdd hφ_mono
   refine ⟨ ⟨ hfφ_bdd, ?_ ⟩, ?_ ⟩ <;> linarith
 
-/-- Proposition 11.10.7 (Change of variables formula III)-/
+/-- Proposition 11.10.7 (Change of variables formula III). -/
 theorem integ_of_comp {a b:ℝ} (hab: a < b) {φ f: ℝ → ℝ}
   (hφ_diff: DifferentiableOn ℝ φ (Icc a b))
   (hφ_cont: Continuous φ) (hφ_mono: Monotone φ)

--- a/Analysis/Section_11_2.lean
+++ b/Analysis/Section_11_2.lean
@@ -161,7 +161,7 @@ theorem PiecewiseConstantOn.div {f g: ℝ → ℝ} {I: BoundedInterval}
   PiecewiseConstantOn (f / g) I := by
   sorry
 
-/-- Definition 11.2.9 (Piecewise constant integral I)-/
+/-- Definition 11.2.9 (Piecewise constant integral I). -/
 noncomputable abbrev PiecewiseConstantWith.integ (f:ℝ → ℝ) {I: BoundedInterval} (P: Partition I)  :
   ℝ := ∑ J ∈ P.intervals, constant_value_on f (J:Set ℝ) * |J|ₗ
 

--- a/Analysis/Section_11_3.lean
+++ b/Analysis/Section_11_3.lean
@@ -27,7 +27,7 @@ abbrev MinorizesOn (g f:ℝ → ℝ) (I: BoundedInterval) : Prop := ∀ x ∈ (I
 
 theorem MinorizesOn.iff (g f:ℝ → ℝ) (I: BoundedInterval) : MinorizesOn g f I ↔ MajorizesOn f g I := by rfl
 
-/-- Definition 11.3.2 (Upper and lower Riemann integrals )-/
+/-- Definition 11.3.2 (Upper and lower Riemann integrals ). -/
 noncomputable abbrev upper_integral (f:ℝ → ℝ) (I: BoundedInterval) : ℝ :=
   sInf ((PiecewiseConstantOn.integ · I) '' {g | MajorizesOn g f I ∧ PiecewiseConstantOn g I})
 

--- a/Analysis/Section_11_4.lean
+++ b/Analysis/Section_11_4.lean
@@ -98,7 +98,7 @@ lemma nonneg_of_le_const_mul_eps {x C:ℝ} (h: ∀ ε>0, x ≤ C * ε) : x ≤ 0
     linarith
   specialize h 1 ?_ <;> grind
 
-/-- Theorem 11.4.3 (Max and min preserve integrability)-/
+/-- Theorem 11.4.3 (Max and min preserve integrability). -/
 theorem IntegrableOn.max {I: BoundedInterval} {f g:ℝ → ℝ} (hf: IntegrableOn f I) (hg: IntegrableOn g I) :
   IntegrableOn (f ⊔ g) I  := by
   -- This proof is written to follow the structure of the original text.

--- a/Analysis/Section_11_8.lean
+++ b/Analysis/Section_11_8.lean
@@ -239,7 +239,7 @@ theorem Partition.sum_of_α_length  {I: BoundedInterval} (P: Partition I) (α: �
   ∑ J ∈ P.intervals, α[J]ₗ = α[I]ₗ := by
   sorry
 
-/-- Definition 11.8.5 (Piecewise constant RS integral)-/
+/-- Definition 11.8.5 (Piecewise constant RS integral). -/
 noncomputable abbrev PiecewiseConstantWith.RS_integ (f:ℝ → ℝ) {I: BoundedInterval} (P: Partition I) (α: ℝ → ℝ)   :
   ℝ := ∑ J ∈ P.intervals, constant_value_on f (J:Set ℝ) * α[J]ₗ
 
@@ -341,7 +341,7 @@ theorem PiecewiseConstantOn.RS_integ_of_join {I J K: BoundedInterval} (hIJK: K.j
   RS_integ f K α = RS_integ f I α + RS_integ f J α := by
   sorry
 
-/-- Analogue of Definition 11.3.2 (Upper and lower Riemann integrals )-/
+/-- Analogue of Definition 11.3.2 (Upper and lower Riemann integrals ). -/
 noncomputable abbrev upper_RS_integral (f:ℝ → ℝ) (I: BoundedInterval) (α: ℝ → ℝ): ℝ :=
   sInf ((PiecewiseConstantOn.RS_integ · I α) '' {g | MajorizesOn g f I ∧ PiecewiseConstantOn g I})
 

--- a/Analysis/Section_11_9.lean
+++ b/Analysis/Section_11_9.lean
@@ -25,7 +25,7 @@ Main constructions and results of this section:
 namespace Chapter11
 open Chapter9 Chapter10 BoundedInterval
 
-/-- Theorem 11.9.1 (First Fundamental Theorem of Calculus)-/
+/-- Theorem 11.9.1 (First Fundamental Theorem of Calculus). -/
 theorem cts_of_integ {a b:ℝ} {f:ℝ → ℝ} (hf: IntegrableOn f (Icc a b)) :
   ContinuousOn (fun x => integ f (Icc a x)) (.Icc a b) := by
   -- This proof is written to follow the structure of the original text.

--- a/Analysis/Section_7_1.lean
+++ b/Analysis/Section_7_1.lean
@@ -267,7 +267,7 @@ theorem finite_series_of_finite_series {XX YY:Type*} (X: Finset XX) (Y: Finset Y
       . sorry
       sorry
 
-/-- Corollary 7.1.14 (Fubini's theorem for finite series)-/
+/-- Corollary 7.1.14 (Fubini's theorem for finite series). -/
 theorem finite_series_refl {XX YY:Type*} (X: Finset XX) (Y: Finset YY) (f: XX × YY → ℝ) :
     ∑ z ∈ X.product Y, f z = ∑ z ∈ Y.product X, f (z.2, z.1) := by
   set h : Y.product X → X.product Y :=

--- a/Analysis/Section_7_5.lean
+++ b/Analysis/Section_7_5.lean
@@ -175,7 +175,7 @@ theorem Series.ratio_ineq {c:ℤ → ℝ} (m:ℤ) (hpos: ∀ n ≥ m, c n > 0) :
       . apply (continuous_const_rpow (by positivity)).tendsto'; simp
       exact tendsto_inv_atTop_zero.comp tendsto_intCast_atTop_atTop
 
-/-- Corollary 7.5.3 (Ratio test)-/
+/-- Corollary 7.5.3 (Ratio test, convergence). -/
 theorem Series.ratio_test_pos {s : Series} (hnon: ∀ n ≥ s.m, s.seq n ≠ 0)
   (h : atTop.limsup (fun n ↦ ((|s.seq (n+1)| / |s.seq n|:ℝ):EReal)) < 1) : s.absConverges := by
     apply Series.root_test_pos (lt_of_le_of_lt _ h)
@@ -183,7 +183,7 @@ theorem Series.ratio_test_pos {s : Series} (hnon: ∀ n ≥ s.m, s.seq n ≠ 0)
     convert hnon using 1 with n
     simp
 
-/-- Corollary 7.5.3 (Ratio test)-/
+/-- Corollary 7.5.3 (Ratio test, divergence). -/
 theorem Series.ratio_test_neg {s : Series} (hnon: ∀ n ≥ s.m, s.seq n ≠ 0)
   (h : atTop.liminf (fun n ↦ ((|s.seq (n+1)| / |s.seq n|:ℝ):EReal)) > 1) : s.diverges := by
     apply Series.root_test_neg (lt_of_lt_of_le h _)

--- a/Analysis/Section_9_1.lean
+++ b/Analysis/Section_9_1.lean
@@ -318,7 +318,7 @@ theorem Q_unbounded : ¬ Bornology.IsBounded ((fun n:ℚ ↦ (n:ℝ)) '' .univ) 
 /-- Example 9.1.23 -/
 theorem R_unbounded : ¬ Bornology.IsBounded (.univ: Set ℝ) := by sorry
 
-/-- Theorem 9.1.24 / Exercise 9.1.13 (Heine-Borel theorem for the line)-/
+/-- Theorem 9.1.24 / Exercise 9.1.13 (Heine-Borel theorem for the line). -/
 theorem Heine_Borel (X: Set ℝ) :
   IsClosed X ∧ Bornology.IsBounded X ↔ ∀ a : ℕ → ℝ, (∀ n, a n ∈ X) →
   (∃ n : ℕ → ℕ, StrictMono n

--- a/Analysis/Section_9_2.lean
+++ b/Analysis/Section_9_2.lean
@@ -20,7 +20,7 @@ namespace Chapter9
 open Classical in
 noncomputable abbrev function_example : ℝ → ℝ := fun x ↦ if x ∈ ((fun y:ℚ ↦ (y:ℝ)) '' .univ) then 1 else 0
 
-/-- Definition 9.2.1 (Arithmetic operations on functions)-/
+/-- Definition 9.2.1 (Arithmetic operations on functions). -/
 theorem add_func_eval (f g: ℝ → ℝ) (x: ℝ) : (f + g) x = f x + g x := rfl
 
 theorem sub_func_eval (f g: ℝ → ℝ) (x: ℝ) : (f - g) x = f x - g x := rfl

--- a/Analysis/Section_9_3.lean
+++ b/Analysis/Section_9_3.lean
@@ -65,7 +65,7 @@ example: ¬(0.1:ℝ).CloseFn (.Icc 1 3) (fun x ↦ x^2) 9 := by
 example: (0.1:ℝ).CloseNear (.Icc 1 3) (fun x ↦ x^2) 9 3 := by
   sorry
 
-/-- Definition 9.3.6 (Convergence of functions at a point)-/
+/-- Definition 9.3.6 (Convergence of functions at a point). -/
 abbrev Convergesto (X:Set ℝ) (f: ℝ → ℝ) (L:ℝ) (x₀:ℝ) : Prop := ∀ ε > (0:ℝ), ε.CloseNear X f L x₀
 
 /-- Connection with Mathlib filter convergence concepts -/


### PR DESCRIPTION
## Summary
- Malformed `)-/` → `). -/` in 13 Section files.
- Split duplicate Corollary 7.5.3 (convergence/divergence).

## Test plan
- [x] CI Build book

Made with [Cursor](https://cursor.com)