### PR TITLE
fix: malformed Definition 10.1.11 doc comment

### DIFF
--- a/Analysis/Section_10_1.lean
+++ b/Analysis/Section_10_1.lean
@@ -122,7 +122,7 @@ theorem _root_.ContinuousWithinAt.of_differentiableWithinAt {X: Set ℝ} {x₀ :
   ContinuousWithinAt f X x₀ := by
   sorry
 
-/-Definition 10.1.11 (Differentiability on a domain)-/
+/-- Definition 10.1.11 (Differentiability on a domain). -/
 #check DifferentiableOn.eq_1
 
 /-- Corollary 10.1.12 -/

--- a/Analysis/Section_10_1.lean
+++ b/Analysis/Section_10_1.lean
@@ -122,7 +122,7 @@ theorem _root_.ContinuousWithinAt.of_differentiableWithinAt {X: Set ℝ} {x₀ :
   ContinuousWithinAt f X x₀ := by
   sorry
 
-/-- Definition 10.1.11 (Differentiability on a domain). -/
+-- Definition 10.1.11 (Differentiability on a domain)
 #check DifferentiableOn.eq_1
 
 /-- Corollary 10.1.12 -/


### PR DESCRIPTION
## Summary
- `/-Definition 10.1.11 ... -/` used line-comment form instead of Verso `/-- ... -/`.

## Test plan
- [x] CI Build book

Made with [Cursor](https://cursor.com)