### PR TITLE
fix: malformed Example 9.8.4 Verso doc comment

### DIFF
--- a/Analysis/Section_9_8.lean
+++ b/Analysis/Section_9_8.lean
@@ -72,7 +72,7 @@ theorem MonotoneOn.exist_inverse {a b:ℝ} (h: a < b) (f: ℝ → ℝ) (hcont: C
    := by
   sorry
 
-/-- Example 9.8.4-/
+/-- Example 9.8.4 -/
 example {R :ℝ} (hR: R > 0) {n:ℕ} (hn: n > 0) : ∃ g : ℝ → ℝ, ∀ x ∈ Set.Icc 0 (R^n), (g x)^n = x := by
   set f : ℝ → ℝ := fun x ↦ x^n
   have hcont : ContinuousOn f (.Icc 0 R) := by fun_prop


### PR DESCRIPTION
## Summary
- `Example 9.8.4-/` missing space before `-/` terminator.

## Test plan
- [ ] `lake build` (doc-only)

Made with [Cursor](https://cursor.com)