### PR TITLE
fix: duplicate Exercise 9.1.6 doc label on closure_of_subset_closure

### DIFF
--- a/Analysis/Section_9_1.lean
+++ b/Analysis/Section_9_1.lean
@@ -104,7 +104,7 @@ theorem closure_inter (X Y:Set ℝ): closure (X ∩ Y) ⊆ closure X ∩ closure
 /-- Lemma 9.1.11 / Exercise 9.1.1 -/
 theorem closure_subset {X Y:Set ℝ} (h: X ⊆ Y): closure X ⊆ closure Y := by sorry
 
-/-- Exercise 9.1.6 -/
+/-- Lemma 9.1.11 / Exercise 9.1.1 -/
 theorem closure_of_subset_closure {X Y:Set ℝ} (h: X ⊆ Y) (h' : Y ⊆ closure X): closure Y = closure X := by sorry
 
 /-- Lemma 9.1.12 -/


### PR DESCRIPTION
## Summary
- `closure_of_subset_closure` was labeled Exercise 9.1.6 but is a closure-property lemma (Ex. 9.1.1).
- Actual Ex. 9.1.6 (closed `Y`, `X ⊆ Y` ⇒ `closure X ⊆ Y`) is unchanged below.

## Test plan
- [ ] `lake build` (doc-only)

Made with [Cursor](https://cursor.com)