### PR TITLE
Make build scripts exit when a command fails

### DIFF
--- a/build-web.sh
+++ b/build-web.sh
@@ -2,7 +2,7 @@
 
 # This script builds the project's web page, including documentation.
 
-set -o pipefail # stop if any command fails
+set -e -o pipefail # stop if a command or pipeline fails
 
 lake exe cache get
 lake -R -Kenv=dev build Analysis:docs

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 
 # This script builds the project's Lean code.
 
-set -o pipefail # stop if any command fails
+set -e -o pipefail # stop if a command or pipeline fails
 
 lake exe cache get
 lake build


### PR DESCRIPTION
Summary

- Make `build.sh` exit when a normal command fails.
- Apply the same failure handling to `build-web.sh`.
- Correct the comments to describe both ordinary-command and pipeline failures.

`set -o pipefail` only changes how a pipeline reports failure; it does not stop a script after a standalone command fails. Adding `set -e` ensures a failure from commands such as `lake exe cache get` is propagated instead of allowing the script to continue.

Testing

- Not run locally: this change only affects Bash startup options, and the current Windows environment has no usable Bash/WSL distribution.
- Please rely on the repository's GitHub Actions build for full validation.