### PR TITLE
fix: exit build scripts when a standalone command fails

### DIFF
--- a/build-web.sh
+++ b/build-web.sh
@@ -2,7 +2,7 @@
 
 # This script builds the project's web page, including documentation.
 
-set -o pipefail # stop if any command fails
+set -e -o pipefail # stop if a command or pipeline fails
 
 lake exe cache get
 lake -R -Kenv=dev build Analysis:docs

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 
 # This script builds the project's Lean code.
 
-set -o pipefail # stop if any command fails
+set -e -o pipefail # stop if a command or pipeline fails
 
 lake exe cache get
 lake build


### PR DESCRIPTION
## Summary
- Add `set -e` to `build.sh` and `build-web.sh` alongside `set -o pipefail`.
- `pipefail` only affects pipeline exit status; a failed `lake exe cache get` was not aborting the script.

Fixes #588.

## Test plan
- [x] Shell-only change; no Lean sources touched.
- [ ] CI `Build book` workflow.

Made with [Cursor](https://cursor.com)