### PR TITLE
fix: close module doc blocks in Section_3_2 and Section_3_5

### DIFF
--- a/Analysis/Section_3_2.lean
+++ b/Analysis/Section_3_2.lean
@@ -24,7 +24,7 @@ Users of the companion who have completed the exercises in this section are welc
 
 - (Add tip here)
 
---/
+-/
 
 namespace Chapter3
 

--- a/Analysis/Section_3_5.lean
+++ b/Analysis/Section_3_5.lean
@@ -25,7 +25,7 @@ Users of the companion who have completed the exercises in this section are welc
 
 - (Add tip here)
 
---/
+-/
 
 namespace Chapter3
 


### PR DESCRIPTION
## Summary
- `Section_3_2.lean` and `Section_3_5.lean` opened `/-!` module docs but closed with `--/`.
- Corrected to `-/` so Verso can parse the section headers.

## Test plan
- [ ] CI `Build book`

Made with [Cursor](https://cursor.com)