### PR TITLE
fix: disambiguate duplicate subtraction doc labels

### DIFF
--- a/Analysis/Section_4_1.lean
+++ b/Analysis/Section_4_1.lean
@@ -215,7 +215,7 @@ instance Int.instCommRing : CommRing Int where
   zero_mul := by sorry
   mul_zero := by sorry
 
-/-- Definition of subtraction -/
+/-- Definition of subtraction (integers). -/
 theorem Int.sub_eq (a b:Int) : a - b = a + (-b) := by rfl
 
 theorem Int.sub_eq_formal_sub (a b:ℕ) : (a:Int) - (b:Int) = a —— b := by sorry

--- a/Analysis/Section_4_2.lean
+++ b/Analysis/Section_4_2.lean
@@ -237,7 +237,7 @@ instance Rat.instField : Field Rat where
 
 example : (3//4) / (5//6) = 9 // 10 := by sorry
 
-/-- Definition of subtraction -/
+/-- Definition of subtraction (rationals). -/
 theorem Rat.sub_eq (a b:Rat) : a - b = a + (-b) := by rfl
 
 def Rat.coe_int_hom : ℤ →+* Rat where


### PR DESCRIPTION
## Summary
- `Section_4_1.lean` and `Section_4_2.lean` both used `Definition of subtraction`.
- Disambiguated to `(integers)` and `(rationals)` for Verso cross-refs.

## Test plan
- [ ] CI `Build book`

Made with [Cursor](https://cursor.com)