### PR TITLE
fix: correct Definition 4.3.2 label for distance

### DIFF
--- a/Analysis/Section_4_3.lean
+++ b/Analysis/Section_4_3.lean
@@ -58,7 +58,7 @@ theorem abs_eq_abs (x: ℚ) : abs x = |x| := by
 abbrev dist (x y : ℚ) := |x - y|
 
 /--
-  Definition 4.2 (Distance).
+  Definition 4.3.2 (Distance).
   We avoid the Mathlib notion of distance here because it is real-valued.
 -/
 theorem dist_eq (x y: ℚ) : dist x y = |x-y| := rfl


### PR DESCRIPTION
## Summary
- Section 4.3 labeled distance as Definition 4.2; corrected to 4.3.2.

## Test plan
- [x] `lake build` / CI


Made with [Cursor](https://cursor.com)