### PR TITLE
fix: replace --/ with -/ in one-line doc comments

### DIFF
--- a/Analysis/Section_3_4.lean
+++ b/Analysis/Section_3_4.lean
@@ -136,7 +136,7 @@ instance SetTheory.Set.inst_coe_of_fun {X Y:Set} : CoeOut (X → Y) Object where
 theorem SetTheory.Set.coe_of_fun_inj {X Y:Set} (f g:X → Y) : (f:Object) = (g:Object) ↔ f = g := by
   simp [coe_of_fun]
 
-/-- Axiom 3.11 (Power set axiom) --/
+/-- Axiom 3.11 (Power set axiom) -/
 @[simp]
 theorem SetTheory.Set.powerset_axiom {X Y:Set} (F:Object) :
     F ∈ (X ^ Y) ↔ ∃ f: Y → X, f = F := SetTheory.powerset_axiom X Y F

--- a/Analysis/Section_5_4.lean
+++ b/Analysis/Section_5_4.lean
@@ -275,7 +275,7 @@ theorem Real.LIM_mono {a b:ℕ → ℚ} (ha: (a:Sequence).IsCauchy) (hb: (b:Sequ
   have := LIM_of_nonneg (a := b - a) (by intro n; simp [hmono n]) (Sequence.IsCauchy.sub hb ha)
   rw [←Real.LIM_sub hb ha] at this; linarith
 
-/-- Remark 5.4.11 --/
+/-- Remark 5.4.11 -/
 theorem Real.LIM_mono_fail :
     ∃ (a b:ℕ → ℚ), (a:Sequence).IsCauchy
     ∧ (b:Sequence).IsCauchy

--- a/Analysis/Section_7_1.lean
+++ b/Analysis/Section_7_1.lean
@@ -230,7 +230,7 @@ theorem finite_series_of_le' {X':Type*} (f g: X' → ℝ) (X: Finset X') (h: ∀
 theorem abs_finite_series_le' {X':Type*} (f: X' → ℝ) (X: Finset X') :
     |∑ x ∈ X, f x| ≤ ∑ x ∈ X, |f x| := by sorry
 
-/-- Lemma 7.1.13 --/
+/-- Lemma 7.1.13 -/
 theorem finite_series_of_finite_series {XX YY:Type*} (X: Finset XX) (Y: Finset YY)
   (f: XX × YY → ℝ) :
     ∑ x ∈ X, ∑ y ∈ Y, f (x, y) = ∑ z ∈ X.product Y, f z := by

--- a/Analysis/Section_8_1.lean
+++ b/Analysis/Section_8_1.lean
@@ -222,7 +222,7 @@ theorem CountablyInfinite.union {A:Type} {X Y: Set A} (hX: CountablyInfinite X) 
   CountablyInfinite (X ∪ Y: Set A) := by
   sorry
 
-/-- Corollary 8.1.11 --/
+/-- Corollary 8.1.11 -/
 theorem Int.countablyInfinite : CountablyInfinite ℤ := by
   -- This proof is written to follow the structure of the original text.
   have h1 : CountablyInfinite {n:ℤ | n ≥ 0} := by


### PR DESCRIPTION
## Summary
- One-line docs in Sections 3.4, 5.4, 7.1, 8.1 closed with `--/` instead of `-/`.

## Test plan
- [x] CI build


Made with [Cursor](https://cursor.com)