### PR TITLE
fix: ContinuousOn 1/x on [0,1], serve.py 404, Ex. 11.3.1 labels

### DIFF
--- a/Analysis/Section_11_3.lean
+++ b/Analysis/Section_11_3.lean
@@ -177,12 +177,12 @@ theorem lower_integ_eq_sup_lower_sum {f:ℝ → ℝ} {I:BoundedInterval} (hf: Bd
   lower_integral f I = sSup (.range (fun P : Partition I ↦ lower_riemann_sum f P)) := by
   sorry
 
-/-- Exercise 11.3.1 -/
+/-- Exercise 11.3.1 (i) -/
 theorem MajorizesOn.trans {f g h: ℝ → ℝ} {I: BoundedInterval}
   (hfg: MajorizesOn f g I) (hgh: MajorizesOn g h I) : MajorizesOn f h I := by
   sorry
 
-/-- Exercise 11.3.1 -/
+/-- Exercise 11.3.1 (ii) -/
 theorem MajorizesOn.anti_symm {f g: ℝ → ℝ} {I: BoundedInterval}:
   (∀ x ∈ (I:Set ℝ), f x = g x) ↔ MajorizesOn f g I ∧ MajorizesOn g f I := by
   sorry

--- a/Analysis/Section_11_5.lean
+++ b/Analysis/Section_11_5.lean
@@ -83,7 +83,7 @@ theorem integ_of_uniform_cts {I: BoundedInterval} {f:ℝ → ℝ} (hf: UniformCo
 theorem integ_of_cts {a b:ℝ} {f:ℝ → ℝ} (hf: ContinuousOn f (Icc a b)) :
   IntegrableOn f (Icc a b) := integ_of_uniform_cts (UniformContinuousOn.of_continuousOn hf)
 
-example : ContinuousOn (fun x:ℝ ↦ 1/x) (Icc 0 1) := by sorry
+example : ¬ ContinuousOn (fun x:ℝ ↦ 1/x) (Icc 0 1) := by sorry
 
 example : ¬ IntegrableOn (fun x:ℝ ↦ 1/x) (Icc 0 1) := by sorry
 

--- a/serve.py
+++ b/serve.py
@@ -39,9 +39,9 @@ class CustomHTTPRequestHandler(SimpleHTTPRequestHandler):
         elif path.startswith('/analysis/'):
             rel_path = path[len('/analysis/'):]
             return os.path.join(BOOK_SITE, rel_path)
-        # Otherwise, serve nothing (could return a non-existent path)
+        # Otherwise, serve nothing (return a non-existent path → 404)
         else:
-            raise FileNotFoundError(f"File not found: {path}")
+            return os.path.join(BOOK_SITE, '.missing')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- After Cor. 11.5.2, `1/x` on `Icc 0 1` is not continuous (the old positive claim was false).
- `serve.py` returns a missing path for non-`/analysis` URLs instead of raising (clean 404).
- Split duplicate Exercise 11.3.1 Verso labels into (i)/(ii).

Branches: `fix/section-11-5-one-over-x-cts`, `fix/serve-non-analysis-404`, `fix/section-11-3-exercise-labels`.

## Test plan
- [ ] `lake build Analysis.Section_11_5 Analysis.Section_11_3`
- [ ] `python3 -c` smoke: non-`/analysis` path resolves under site root to `.missing`
- [ ] CI Build book