### PR TITLE
fix: Definition 10.1.11 doc, Prop 3.1.27(a)/(c) labels, Ex. 9.1.9

### DIFF
--- a/Analysis/Section_10_1.lean
+++ b/Analysis/Section_10_1.lean
@@ -122,7 +122,7 @@ theorem _root_.ContinuousWithinAt.of_differentiableWithinAt {X: Set ℝ} {x₀ :
   ContinuousWithinAt f X x₀ := by
   sorry
 
-/-Definition 10.1.11 (Differentiability on a domain). -/
+-- Definition 10.1.11 (Differentiability on a domain)
 #check DifferentiableOn.eq_1
 
 /-- Corollary 10.1.12 -/

--- a/Analysis/Section_3_1.lean
+++ b/Analysis/Section_3_1.lean
@@ -300,17 +300,17 @@ theorem SetTheory.Set.union_assoc (A B C:Set) : (A ∪ B) ∪ C = A ∪ (B ∪ C
     rw [mem_union]; tauto
   sorry
 
-/-- Proposition 3.1.27(c) -/
+/-- Proposition 3.1.27(c) (Union idempotent). -/
 @[simp]
 theorem SetTheory.Set.union_self (A:Set) : A ∪ A = A := by
   sorry
 
-/-- Proposition 3.1.27(a) -/
+/-- Proposition 3.1.27(a) (Union with empty). -/
 @[simp]
 theorem SetTheory.Set.union_empty (A:Set) : A ∪ ∅ = A := by
   sorry
 
-/-- Proposition 3.1.27(a) -/
+/-- Proposition 3.1.27(a) (Empty with union). -/
 @[simp]
 theorem SetTheory.Set.empty_union (A:Set) : ∅ ∪ A = A := by
   sorry
@@ -489,7 +489,7 @@ theorem SetTheory.Set.subset_union {A X: Set} (hAX: A ⊆ X) : A ∪ X = X := by
 /-- Proposition 3.1.27(b) (Union absorption). -/
 theorem SetTheory.Set.union_subset {A X: Set} (hAX: A ⊆ X) : X ∪ A = X := by sorry
 
-/-- Proposition 3.1.27(c) -/
+/-- Proposition 3.1.27(c) (Intersection idempotent). -/
 @[simp]
 theorem SetTheory.Set.inter_self (A:Set) : A ∩ A = A := by
   sorry

--- a/Analysis/Section_9_1.lean
+++ b/Analysis/Section_9_1.lean
@@ -347,11 +347,11 @@ example {I:Type} (X: I → Set ℝ) (hX: ∀ i, IsClosed (X i)) :
   IsClosed (⋂ i, X i) := by
   sorry
 
-/-- Exercise 9.1.9 -/
+/-- Exercise 9.1.9 (i) -/
 example {X:Set ℝ} {x:ℝ} (hx: AdherentPt x X) : LimitPt x X ∨ IsolatedPt x X := by
   sorry
 
-/-- Exercise 9.1.9 -/
+/-- Exercise 9.1.9 (ii) -/
 example {X:Set ℝ} {x:ℝ} : ¬ (LimitPt x X ∧ IsolatedPt x X) := by
   sorry
 


### PR DESCRIPTION
## Summary
- Definition 10.1.11: replace malformed `/-Definition … -/` with a line comment before `#check`.
- Finish Proposition 3.1.27 label splits for leftover (a) and (c) (missed by #575).
- Split duplicate Exercise 9.1.9 Verso labels into (i)/(ii).

Branches: `fix/section-10-1-definition-doc-v2`, `fix/section-3-1-prop-327-ac-labels`, `fix/section-9-1-exercise-9-1-9-labels`.

Supersedes #570.

## Test plan
- [ ] `lake build Analysis.Section_10_1 Analysis.Section_3_1 Analysis.Section_9_1`
- [ ] CI Build book