### PR TITLE
fix: disambiguate Exercises 6.4.8, 6.5.1, and 8.5.8 Verso labels

### DIFF
--- a/Analysis/Section_6_4.lean
+++ b/Analysis/Section_6_4.lean
@@ -317,10 +317,10 @@ def Sequence.tendsTo_real_iff :
 /-- This definition is needed for Exercises 6.4.8 and 6.4.9. -/
 abbrev Sequence.ExtendedLimitPoint (a:Sequence) (x:EReal) : Prop := if x = ⊤ then ¬ a.BddAbove else if x = ⊥ then ¬ a.BddBelow else a.LimitPoint x.toReal
 
-/-- Exercise 6.4.8 -/
+/-- Exercise 6.4.8 (i) -/
 theorem Sequence.extended_limit_point_of_limsup (a:Sequence) : a.ExtendedLimitPoint a.limsup := by sorry
 
-/-- Exercise 6.4.8 -/
+/-- Exercise 6.4.8 (ii) -/
 theorem Sequence.extended_limit_point_of_liminf (a:Sequence) : a.ExtendedLimitPoint a.liminf := by sorry
 
 theorem Sequence.extended_limit_point_le_limsup {a:Sequence} {L:EReal} (h:a.ExtendedLimitPoint L): L ≤ a.limsup := by sorry

--- a/Analysis/Section_6_5.lean
+++ b/Analysis/Section_6_5.lean
@@ -88,12 +88,12 @@ theorem Sequence.lim_of_roots {x:ℝ} (hx: x > 0) :
     ((fun (n:ℕ) ↦ x^(1/(n+1:ℝ))):Sequence).TendsTo 1 := by
   sorry
 
-/-- Exercise 6.5.1 -/
+/-- Exercise 6.5.1 (i) -/
 theorem Sequence.lim_of_rat_power_decay {q:ℚ} (hq: q > 0) :
     (fun (n:ℕ) ↦ 1/((n+1:ℝ)^(q:ℝ)):Sequence).TendsTo 0 := by
   sorry
 
-/-- Exercise 6.5.1 -/
+/-- Exercise 6.5.1 (ii) -/
 theorem Sequence.lim_of_rat_power_growth {q:ℚ} (hq: q > 0) :
     (fun (n:ℕ) ↦ ((n+1:ℝ)^(q:ℝ)):Sequence).Divergent := by
   sorry

--- a/Analysis/Section_8_5.lean
+++ b/Analysis/Section_8_5.lean
@@ -123,12 +123,13 @@ example : ¬ WellFoundedLT ℤ := by sorry
 example : ¬ WellFoundedLT ℚ := by sorry
 example : ¬ WellFoundedLT ℝ := by sorry
 
-/-- Exercise 8.5.8 -/
+/-- Exercise 8.5.8 (i) -/
 theorem IsMax.ofFinite {X:Type} [LinearOrder X] [Finite X] [Nonempty X] : ∃ x:X, IsMax x := by sorry
 
+/-- Exercise 8.5.8 (ii) -/
 theorem IsMin.ofFinite {X:Type} [LinearOrder X] [Finite X] [Nonempty X] : ∃ x:X, IsMin x := by sorry
 
-/-- Exercise 8.5.8 -/
+/-- Exercise 8.5.8 (iii) -/
 theorem WellFoundedLT.ofFinite {X:Type} [LinearOrder X] [Finite X] : WellFoundedLT X := by sorry
 
 example {X:Type} [LinearOrder X] [WellFoundedLT X] (A: Set X) : WellFoundedLT A := by sorry


### PR DESCRIPTION
## Summary
- Exercise 6.4.8: split limsup/liminf ExtendedLimitPoint labels into (i)/(ii).
- Exercise 6.5.1: split power-decay / power-growth labels into (i)/(ii).
- Exercise 8.5.8: label IsMax/IsMin/WellFoundedLT.ofFinite as (i)/(ii)/(iii).

Branches: `fix/section-6-4-exercise-6-4-8-labels`, `fix/section-6-5-exercise-6-5-1-labels`, `fix/section-8-5-exercise-8-5-8-labels`.

## Test plan
- [ ] `lake build Analysis.Section_6_4 Analysis.Section_6_5 Analysis.Section_8_5`
- [ ] CI Build book