### PR TITLE
fix: disambiguate Verso labels for 11.4.1, Ex. 1.1.8, Ex. 1.3.8(vi)

### DIFF
--- a/Analysis/MeasureTheory/Section_1_1_2.lean
+++ b/Analysis/MeasureTheory/Section_1_1_2.lean
@@ -671,16 +671,14 @@ lemma JordanMeasurable.measure_of_graph {d:ℕ} {B:Box d} {f: EuclideanSpace' d 
 lemma JordanMeasurable.undergraph {d:ℕ} {B:Box d} {f: EuclideanSpace' d → ℝ} (hf: ContinuousOn f B.toSet) : JordanMeasurable { p | ∃ x ∈ B.toSet, ∃ t:ℝ, EuclideanSpace'.prod_equiv d 1 p = ⟨ x, t ⟩ ∧ 0 ≤ t ∧ t ≤ f x } := by
   sorry
 
-/-- Exercise 1.1.8 -/
--- A triangle is Jordan measurable.
+/-- Exercise 1.1.8(i) (A triangle is Jordan measurable) -/
 lemma JordanMeasurable.triangle (T: Affine.Triangle ℝ (EuclideanSpace' 2)) : JordanMeasurable T.closedInterior := by
   sorry
 
 /-- The 2D wedge product (signed area parallelogram factor) of two vectors. -/
 abbrev EuclideanSpace'.plane_wedge (x y: EuclideanSpace' 2) := x 1 * y 0 - x 0 * y 1
 
-/-- Exercise 1.1.8 -/
--- The Jordan measure of a triangle equals half the absolute value of the wedge product of two edge vectors.
+/-- Exercise 1.1.8(ii) (Jordan measure of a triangle) -/
 lemma JordanMeasurable.measure_triangle (T: Affine.Triangle ℝ (EuclideanSpace' 2)) : (JordanMeasurable.triangle T).measure = |(T.points 1 - T.points 0).plane_wedge (T.points 2 - T.points 0)| / 2 := by
   sorry
 

--- a/Analysis/MeasureTheory/Section_1_3_2.lean
+++ b/Analysis/MeasureTheory/Section_1_3_2.lean
@@ -3302,7 +3302,7 @@ theorem RealMeasurable.comp_cts {d:ℕ} {f: EuclideanSpace' d → ℝ} (hf: Real
 
 theorem ComplexMeasurable.comp_cts {d:ℕ} {f: EuclideanSpace' d → ℂ} (hf: ComplexMeasurable f) {φ: ℂ → ℂ} (hφ: Continuous φ)  : ComplexMeasurable (φ ∘ f) := by sorry
 
-/-- Exercise 1.3.8(vi) -/
+/-- Exercise 1.3.8(vi) (Sum of measurable functions) -/
 theorem RealMeasurable.add {d:ℕ} {f g: EuclideanSpace' d → ℝ} (hf: RealMeasurable f) (hg: RealMeasurable g) : RealMeasurable (f + g) := by sorry
 
 theorem ComplexMeasurable.add {d:ℕ} {f g: EuclideanSpace' d → ℂ} (hf: ComplexMeasurable f) (hg: ComplexMeasurable g) : ComplexMeasurable (f + g) := by sorry
@@ -3312,7 +3312,7 @@ theorem RealMeasurable.sub {d:ℕ} {f g: EuclideanSpace' d → ℝ} (hf: RealMea
 
 theorem ComplexMeasurable.sub {d:ℕ} {f g: EuclideanSpace' d → ℂ} (hf: ComplexMeasurable f) (hg: ComplexMeasurable g) : ComplexMeasurable (f - g) := by sorry
 
-/-- Exercise 1.3.8(vi) -/
+/-- Exercise 1.3.8(viii) (Product of measurable functions) -/
 theorem RealMeasurable.mul {d:ℕ} {f g: EuclideanSpace' d → ℝ} (hf: RealMeasurable f) (hg: RealMeasurable g) : RealMeasurable (f * g) := by sorry
 
 theorem ComplexMeasurable.mul {d:ℕ} {f g: EuclideanSpace' d → ℂ} (hf: ComplexMeasurable f) (hg: ComplexMeasurable g) : ComplexMeasurable (f * g) := by sorry

--- a/Analysis/MeasureTheory/Section_1_3_2.lean
+++ b/Analysis/MeasureTheory/Section_1_3_2.lean
@@ -3307,12 +3307,12 @@ theorem RealMeasurable.add {d:ℕ} {f g: EuclideanSpace' d → ℝ} (hf: RealMea
 
 theorem ComplexMeasurable.add {d:ℕ} {f g: EuclideanSpace' d → ℂ} (hf: ComplexMeasurable f) (hg: ComplexMeasurable g) : ComplexMeasurable (f + g) := by sorry
 
-/-- Exercise 1.3.8(vii) (Difference of measurable functions) -/
+/-- Exercise 1.3.8(vi') (Difference of measurable functions) -/
 theorem RealMeasurable.sub {d:ℕ} {f g: EuclideanSpace' d → ℝ} (hf: RealMeasurable f) (hg: RealMeasurable g) : RealMeasurable (f - g) := by sorry
 
 theorem ComplexMeasurable.sub {d:ℕ} {f g: EuclideanSpace' d → ℂ} (hf: ComplexMeasurable f) (hg: ComplexMeasurable g) : ComplexMeasurable (f - g) := by sorry
 
-/-- Exercise 1.3.8(viii) (Product of measurable functions) -/
+/-- Exercise 1.3.8(vi'') (Product of measurable functions) -/
 theorem RealMeasurable.mul {d:ℕ} {f g: EuclideanSpace' d → ℝ} (hf: RealMeasurable f) (hg: RealMeasurable g) : RealMeasurable (f * g) := by sorry
 
 theorem ComplexMeasurable.mul {d:ℕ} {f g: EuclideanSpace' d → ℂ} (hf: ComplexMeasurable f) (hg: ComplexMeasurable g) : ComplexMeasurable (f * g) := by sorry

--- a/Analysis/MeasureTheory/Section_1_3_2.lean
+++ b/Analysis/MeasureTheory/Section_1_3_2.lean
@@ -3307,7 +3307,7 @@ theorem RealMeasurable.add {d:ℕ} {f g: EuclideanSpace' d → ℝ} (hf: RealMea
 
 theorem ComplexMeasurable.add {d:ℕ} {f g: EuclideanSpace' d → ℂ} (hf: ComplexMeasurable f) (hg: ComplexMeasurable g) : ComplexMeasurable (f + g) := by sorry
 
-/-- Exercise 1.3.8(vi) -/
+/-- Exercise 1.3.8(vii) (Difference of measurable functions) -/
 theorem RealMeasurable.sub {d:ℕ} {f g: EuclideanSpace' d → ℝ} (hf: RealMeasurable f) (hg: RealMeasurable g) : RealMeasurable (f - g) := by sorry
 
 theorem ComplexMeasurable.sub {d:ℕ} {f g: EuclideanSpace' d → ℂ} (hf: ComplexMeasurable f) (hg: ComplexMeasurable g) : ComplexMeasurable (f - g) := by sorry

--- a/Analysis/Section_11_4.lean
+++ b/Analysis/Section_11_4.lean
@@ -53,7 +53,7 @@ theorem IntegrableOn.const (c:ℝ) (I: BoundedInterval) :
   IntegrableOn (fun _ ↦ c) I ∧ integ (fun _ ↦ c) I = c * |I|ₗ := by
   sorry
 
-/-- Theorem 11.4.1(f) / Exercise 11.4.1 -/
+/-- Theorem 11.4.1(f') / Exercise 11.4.1 -/
 theorem IntegrableOn.const' {I: BoundedInterval} {f:ℝ → ℝ} (hf: ConstantOn f I) :
   IntegrableOn f I ∧ integ f I = (constant_value_on f I) * |I|ₗ := by
   sorry

--- a/Analysis/Section_11_4.lean
+++ b/Analysis/Section_11_4.lean
@@ -60,14 +60,14 @@ theorem IntegrableOn.const' {I: BoundedInterval} {f:ℝ → ℝ} (hf: ConstantOn
 
 
 open Classical in
-/-- Theorem 11.4.1 (g)  / Exercise 11.4.1 -/
+/-- Theorem 11.4.1(g) / Exercise 11.4.1 -/
 theorem IntegrableOn.of_extend {I J: BoundedInterval} (hIJ: I ⊆ J)
   {f: ℝ → ℝ} (h: IntegrableOn f I) :
   IntegrableOn (fun x ↦ if x ∈ I then f x else 0) J := by
   sorry
 
 open Classical in
-/-- Theorem 11.4.1 (g)  / Exercise 11.4.1 -/
+/-- Theorem 11.4.1(g') / Exercise 11.4.1 -/
 theorem IntegrableOn.of_extend' {I J: BoundedInterval} (hIJ: I ⊆ J)
   {f: ℝ → ℝ} (h: IntegrableOn f I) :
   integ (fun x ↦ if x ∈ I then f x else 0) J = integ f I := by


### PR DESCRIPTION
## Summary
- Theorem 11.4.1: distinct docs for `const`/`const'` as (f)/(f') and `of_extend`/`of_extend'` as (g)/(g').
- Exercise 1.1.8: (i) triangle measurable, (ii) measure formula.
- Exercise 1.3.8(vi): (vi)/(vi')/(vi'') for add/sub/mul.

## Test plan
- [ ] CI `lake build` + docs
- [ ] Spot-check Verso labels no longer collide for these decls