### PR TITLE
fix: disambiguate Verso labels for 3.6.14, 6.4.12, 6.2, and 4.4.2

### DIFF
--- a/Analysis/Section_3_6.lean
+++ b/Analysis/Section_3_6.lean
@@ -275,7 +275,7 @@ theorem SetTheory.Set.card_insert {X:Set} (hX: X.finite) {x:Object} (hx: x ∉ X
 theorem SetTheory.Set.card_union {X Y:Set} (hX: X.finite) (hY: Y.finite) :
     (X ∪ Y).finite ∧ (X ∪ Y).card ≤ X.card + Y.card := by sorry
 
-/-- Proposition 3.6.14 (b) / Exercise 3.6.4 -/
+/-- Proposition 3.6.14 (b') / Exercise 3.6.4 -/
 theorem SetTheory.Set.card_union_disjoint {X Y:Set} (hX: X.finite) (hY: Y.finite)
   (hdisj: Disjoint X Y) : (X ∪ Y).card = X.card + Y.card := by sorry
 

--- a/Analysis/Section_3_6.lean
+++ b/Analysis/Section_3_6.lean
@@ -291,7 +291,7 @@ theorem SetTheory.Set.card_ssubset {X Y:Set} (hX: X.finite) (hY: Y ⊂ X) :
 theorem SetTheory.Set.card_image {X Y:Set} (hX: X.finite) (f: X → Y) :
     (image f X).finite ∧ (image f X).card ≤ X.card := by sorry
 
-/-- Proposition 3.6.14 (d) / Exercise 3.6.4 -/
+/-- Proposition 3.6.14 (d') / Exercise 3.6.4 -/
 theorem SetTheory.Set.card_image_inj {X Y:Set} (hX: X.finite) {f: X → Y}
   (hf: Function.Injective f) : (image f X).card = X.card := by sorry
 

--- a/Analysis/Section_3_6.lean
+++ b/Analysis/Section_3_6.lean
@@ -283,7 +283,7 @@ theorem SetTheory.Set.card_union_disjoint {X Y:Set} (hX: X.finite) (hY: Y.finite
 theorem SetTheory.Set.card_subset {X Y:Set} (hX: X.finite) (hY: Y ⊆ X) :
     Y.finite ∧ Y.card ≤ X.card := by sorry
 
-/-- Proposition 3.6.14 (c) / Exercise 3.6.4 -/
+/-- Proposition 3.6.14 (c') / Exercise 3.6.4 -/
 theorem SetTheory.Set.card_ssubset {X Y:Set} (hX: X.finite) (hY: Y ⊂ X) :
     Y.card < X.card := by sorry
 

--- a/Analysis/Section_4_4.lean
+++ b/Analysis/Section_4_4.lean
@@ -53,7 +53,7 @@ def Int.infinite_descent : Decidable (∃ a:ℕ → ℤ, ∀ n, a (n+1) < a n) :
   -- the first line of this construction should be either `apply isTrue` or `apply isFalse`.
   sorry
 
-/-- Exercise 4.4.2 (b) -/
+/-- Exercise 4.4.2 (b') -/
 def Rat.pos_infinite_descent : Decidable (∃ a:ℕ → {x: ℚ // 0 < x}, ∀ n, a (n+1) < a n) := by
   -- the first line of this construction should be either `apply isTrue` or `apply isFalse`.
   sorry

--- a/Analysis/Section_6_2.lean
+++ b/Analysis/Section_6_2.lean
@@ -83,7 +83,7 @@ theorem EReal.trichotomy (x y:EReal) : x < y ∨ x = y ∨ x > y := by sorry
 /-- Proposition 6.2.5(b') / Exercise 6.2.1 -/
 theorem EReal.not_lt_and_eq (x y:EReal) : ¬ (x < y ∧ x = y) := by sorry
 
-/-- Proposition 6.2.5(b) / Exercise 6.2.1 -/
+/-- Proposition 6.2.5(b'') / Exercise 6.2.1 -/
 theorem EReal.not_gt_and_eq (x y:EReal) : ¬ (x > y ∧ x = y) := by sorry
 
 /-- Proposition 6.2.5(b) / Exercise 6.2.1 -/

--- a/Analysis/Section_6_2.lean
+++ b/Analysis/Section_6_2.lean
@@ -80,7 +80,7 @@ theorem EReal.refl (x:EReal) : x ≤ x := by sorry
 /-- Proposition 6.2.5(b) / Exercise 6.2.1 -/
 theorem EReal.trichotomy (x y:EReal) : x < y ∨ x = y ∨ x > y := by sorry
 
-/-- Proposition 6.2.5(b) / Exercise 6.2.1 -/
+/-- Proposition 6.2.5(b') / Exercise 6.2.1 -/
 theorem EReal.not_lt_and_eq (x y:EReal) : ¬ (x < y ∧ x = y) := by sorry
 
 /-- Proposition 6.2.5(b) / Exercise 6.2.1 -/

--- a/Analysis/Section_6_2.lean
+++ b/Analysis/Section_6_2.lean
@@ -86,7 +86,7 @@ theorem EReal.not_lt_and_eq (x y:EReal) : ¬ (x < y ∧ x = y) := by sorry
 /-- Proposition 6.2.5(b'') / Exercise 6.2.1 -/
 theorem EReal.not_gt_and_eq (x y:EReal) : ¬ (x > y ∧ x = y) := by sorry
 
-/-- Proposition 6.2.5(b) / Exercise 6.2.1 -/
+/-- Proposition 6.2.5(b''') / Exercise 6.2.1 -/
 theorem EReal.not_lt_and_gt (x y:EReal) : ¬ (x < y ∧ x > y) := by sorry
 
 /-- Proposition 6.2.5(c) / Exercise 6.2.1 -/

--- a/Analysis/Section_6_2.lean
+++ b/Analysis/Section_6_2.lean
@@ -164,7 +164,7 @@ example (E: Set EReal) : sSup E < sInf E ↔ E = ∅ := by sorry
 /-- Theorem 6.2.11 (a) / Exercise 6.2.2 -/
 theorem EReal.mem_le_sup (E: Set EReal) {x:EReal} (hx: x ∈ E) : x ≤ sSup E := by sorry
 
-/-- Theorem 6.2.11 (a) / Exercise 6.2.2 -/
+/-- Theorem 6.2.11 (a') / Exercise 6.2.2 -/
 theorem EReal.mem_ge_inf (E: Set EReal) {x:EReal} (hx: x ∈ E) : sInf E ≤ x := by sorry
 
 /-- Theorem 6.2.11 (b) / Exercise 6.2.2 -/

--- a/Analysis/Section_6_4.lean
+++ b/Analysis/Section_6_4.lean
@@ -178,7 +178,7 @@ theorem Sequence.inf_le_liminf (a:Sequence) : a.inf ≤ a.liminf := by sorry
 /-- Proposition 6.4.12(c') / Exercise 6.4.3 -/
 theorem Sequence.liminf_le_limsup (a:Sequence) : a.liminf ≤ a.limsup := by sorry
 
-/-- Proposition 6.4.12(c) / Exercise 6.4.3 -/
+/-- Proposition 6.4.12(c'') / Exercise 6.4.3 -/
 theorem Sequence.limsup_le_sup (a:Sequence) : a.limsup ≤ a.sup := by sorry
 
 /-- Proposition 6.4.12(d) / Exercise 6.4.3 -/

--- a/Analysis/Section_6_4.lean
+++ b/Analysis/Section_6_4.lean
@@ -167,7 +167,7 @@ theorem Sequence.lt_limsup_bounds {a:Sequence} {x:EReal} (h: x < a.limsup) {N:�
   choose n hn hxn _ using exists_between_lt_sup hx
   grind
 
-/-- Proposition 6.4.12(b) -/
+/-- Proposition 6.4.12(b') -/
 theorem Sequence.gt_liminf_bounds {a:Sequence} {x:EReal} (h: x > a.liminf) {N:ℤ} (hN: N ≥ a.m) :
     ∃ n ≥ N, a n < x := by
   sorry

--- a/Analysis/Section_6_4.lean
+++ b/Analysis/Section_6_4.lean
@@ -154,7 +154,7 @@ theorem Sequence.gt_limsup_bounds {a:Sequence} {x:EReal} (h: x > a.limsup) :
   convert lt_of_le_of_lt ((a.from N).le_sup hn') ha using 1
   grind
 
-/-- Proposition 6.4.12(a) -/
+/-- Proposition 6.4.12(a') -/
 theorem Sequence.lt_liminf_bounds {a:Sequence} {y:EReal} (h: y < a.liminf) :
     ∃ N ≥ a.m, ∀ n ≥ N, a n > y := by
   sorry

--- a/Analysis/Section_6_4.lean
+++ b/Analysis/Section_6_4.lean
@@ -191,7 +191,7 @@ theorem Sequence.limit_point_of_limsup {a:Sequence} {L_plus:ℝ} (h: a.limsup = 
     a.LimitPoint L_plus := by
   sorry
 
-/-- Proposition 6.4.12(e) / Exercise 6.4.3 -/
+/-- Proposition 6.4.12(e') / Exercise 6.4.3 -/
 theorem Sequence.limit_point_of_liminf {a:Sequence} {L_minus:ℝ} (h: a.liminf = L_minus) :
     a.LimitPoint L_minus := by
   sorry

--- a/Analysis/Section_6_4.lean
+++ b/Analysis/Section_6_4.lean
@@ -175,7 +175,7 @@ theorem Sequence.gt_liminf_bounds {a:Sequence} {x:EReal} (h: x > a.liminf) {N:�
 /-- Proposition 6.4.12(c) / Exercise 6.4.3 -/
 theorem Sequence.inf_le_liminf (a:Sequence) : a.inf ≤ a.liminf := by sorry
 
-/-- Proposition 6.4.12(c) / Exercise 6.4.3 -/
+/-- Proposition 6.4.12(c') / Exercise 6.4.3 -/
 theorem Sequence.liminf_le_limsup (a:Sequence) : a.liminf ≤ a.limsup := by sorry
 
 /-- Proposition 6.4.12(c) / Exercise 6.4.3 -/


### PR DESCRIPTION
## Summary
- Proposition 3.6.14: `(b)/(b')`, `(c)/(c')`, `(d)/(d')` for the card_union / subset / image pairs.
- Proposition 6.4.12: `(a)/(a')`, `(b)/(b')`, `(c)/(c')/(c'')`, `(e)/(e')` for limsup/liminf bound lemmas.
- Section 6.2: Theorem 6.2.11 `(a)/(a')`; Proposition 6.2.5 `(b)/(b')/(b'')/(b''')`.
- Exercise 4.4.2: `(b)/(b')` for `Int` vs `Rat` infinite descent.

Branches: `fix/section-3-6-prop-3-6-14-labels`, `fix/section-6-4-prop-6-4-12-labels`, `fix/section-6-2-thm-6-2-11-labels`, `fix/section-4-4-exercise-4-4-2-labels`.

## Test plan
- [x] `lake build Analysis.Section_3_6 Analysis.Section_4_4 Analysis.Section_6_2 Analysis.Section_6_4`
- [ ] CI Build book

Made with [Cursor](https://cursor.com)