### PR TITLE
fix: ContinuousOn 1/x on [0,1] is false; split Ex. 11.3.1 labels

### DIFF
--- a/Analysis/Section_11_3.lean
+++ b/Analysis/Section_11_3.lean
@@ -177,12 +177,12 @@ theorem lower_integ_eq_sup_lower_sum {f:ℝ → ℝ} {I:BoundedInterval} (hf: Bd
   lower_integral f I = sSup (.range (fun P : Partition I ↦ lower_riemann_sum f P)) := by
   sorry
 
-/-- Exercise 11.3.1 -/
+/-- Exercise 11.3.1 (i) -/
 theorem MajorizesOn.trans {f g h: ℝ → ℝ} {I: BoundedInterval}
   (hfg: MajorizesOn f g I) (hgh: MajorizesOn g h I) : MajorizesOn f h I := by
   sorry
 
-/-- Exercise 11.3.1 -/
+/-- Exercise 11.3.1 (ii) -/
 theorem MajorizesOn.anti_symm {f g: ℝ → ℝ} {I: BoundedInterval}:
   (∀ x ∈ (I:Set ℝ), f x = g x) ↔ MajorizesOn f g I ∧ MajorizesOn g f I := by
   sorry

--- a/Analysis/Section_11_5.lean
+++ b/Analysis/Section_11_5.lean
@@ -83,7 +83,7 @@ theorem integ_of_uniform_cts {I: BoundedInterval} {f:ℝ → ℝ} (hf: UniformCo
 theorem integ_of_cts {a b:ℝ} {f:ℝ → ℝ} (hf: ContinuousOn f (Icc a b)) :
   IntegrableOn f (Icc a b) := integ_of_uniform_cts (UniformContinuousOn.of_continuousOn hf)
 
-example : ContinuousOn (fun x:ℝ ↦ 1/x) (Icc 0 1) := by sorry
+example : ¬ ContinuousOn (fun x:ℝ ↦ 1/x) (Icc 0 1) := by sorry
 
 example : ¬ IntegrableOn (fun x:ℝ ↦ 1/x) (Icc 0 1) := by sorry
 


### PR DESCRIPTION
## Summary
- Negate the false example `ContinuousOn (1/x) (Icc 0 1)` in §11.5 (singularity at 0).
- Disambiguate the two Exercise 11.3.1 Verso docs as (i)/(ii).

Replaces the Lean portion of conflicted #602 (serve.py hardening already landed in #605).

## Test plan
- [ ] CI Build book
- [ ] Spot-check literate HTML labels for Exercise 11.3.1


Made with [Cursor](https://cursor.com)