### PR TITLE
fix: label Ex. 1.2.2' and Ex. 9.2.1 (a)–(d)

### DIFF
--- a/Analysis/MeasureTheory/Section_1_2_0.lean
+++ b/Analysis/MeasureTheory/Section_1_2_0.lean
@@ -573,7 +573,7 @@ example :
 
 
 
-/-- Exercise 1.2.2 (i) -/
+/-- Exercise 1.2.2 -/
 -- The pointwise limit of uniformly bounded Riemann integrable functions need not be Riemann integrable.
 example : ∃ f: ℕ → ℝ → ℝ, ∃ F: ℝ → ℝ, ∃ M, ∀ n, ∀ x ∈ Set.Icc 0 1, |f n x| ≤ M ∧
     (∀ x ∈ Set.Icc 0 1, Filter.atTop.Tendsto (fun n ↦ f n x) (nhds (F x))) ∧
@@ -581,7 +581,7 @@ example : ∃ f: ℕ → ℝ → ℝ, ∃ F: ℝ → ℝ, ∃ M, ∀ n, ∀ x �
     ¬ RiemannIntegrableOn F (Icc 0 1) := by
   sorry
 
-/-- Exercise 1.2.2 (ii) -/
+/-- Exercise 1.2.2' -/
 -- Determine whether uniform convergence of uniformly bounded Riemann integrable functions preserves Riemann integrability (true or false).
 def Ex_1_2_2b : Decidable ( ∀ f: ℕ → ℝ → ℝ, ∀ F: ℝ → ℝ, (∃ M, ∀ n, ∀ x ∈ Set.Icc 0 1, |f n x| ≤ M) → (∀ x ∈ Set.Icc 0 1, TendstoUniformly f F Filter.atTop) → (∀ n, RiemannIntegrableOn (f n) (Icc 0 1)) → RiemannIntegrableOn F (Icc 0 1) ) := by
   -- the first line of this construction should be either `apply isTrue` or `apply isFalse`, depending on whether you believe the given statement to be true or false.

--- a/Analysis/MeasureTheory/Section_1_2_0.lean
+++ b/Analysis/MeasureTheory/Section_1_2_0.lean
@@ -573,7 +573,7 @@ example :
 
 
 
-/-- Exercise 1.2.2 -/
+/-- Exercise 1.2.2 (i) -/
 -- The pointwise limit of uniformly bounded Riemann integrable functions need not be Riemann integrable.
 example : ∃ f: ℕ → ℝ → ℝ, ∃ F: ℝ → ℝ, ∃ M, ∀ n, ∀ x ∈ Set.Icc 0 1, |f n x| ≤ M ∧
     (∀ x ∈ Set.Icc 0 1, Filter.atTop.Tendsto (fun n ↦ f n x) (nhds (F x))) ∧
@@ -581,7 +581,7 @@ example : ∃ f: ℕ → ℝ → ℝ, ∃ F: ℝ → ℝ, ∃ M, ∀ n, ∀ x �
     ¬ RiemannIntegrableOn F (Icc 0 1) := by
   sorry
 
-/-- Exercise 1.2.2 -/
+/-- Exercise 1.2.2 (ii) -/
 -- Determine whether uniform convergence of uniformly bounded Riemann integrable functions preserves Riemann integrability (true or false).
 def Ex_1_2_2b : Decidable ( ∀ f: ℕ → ℝ → ℝ, ∀ F: ℝ → ℝ, (∃ M, ∀ n, ∀ x ∈ Set.Icc 0 1, |f n x| ≤ M) → (∀ x ∈ Set.Icc 0 1, TendstoUniformly f F Filter.atTop) → (∀ n, RiemannIntegrableOn (f n) (Icc 0 1)) → RiemannIntegrableOn F (Icc 0 1) ) := by
   -- the first line of this construction should be either `apply isTrue` or `apply isFalse`, depending on whether you believe the given statement to be true or false.

--- a/Analysis/Section_9_2.lean
+++ b/Analysis/Section_9_2.lean
@@ -51,20 +51,22 @@ example : f_9_2_2 ∘ g_9_2_2 = fun x ↦ 4*x^2 := by grind
 
 example : g_9_2_2 ∘ f_9_2_2 = fun x ↦ 2*x^2 := by grind
 
-/-- Exercise 9.2.1. -/
+/-- Exercise 9.2.1 (a) -/
 def Exercise_9_2_1a : Decidable (∀ (f g h : ℝ → ℝ), (f+g) ∘ h = f ∘ h + g ∘ h) := by
   -- The first line of this construction should be `apply isTrue` or `apply isFalse`.
   sorry
 
-/-- Exercise 9.2.1. -/
+/-- Exercise 9.2.1 (b) -/
 def Exercise_9_2_1b : Decidable (∀ (f g h : ℝ → ℝ), f ∘ (g + h) = f ∘ g + f ∘ h) := by
   -- The first line of this construction should be `apply isTrue` or `apply isFalse`.
   sorry
 
+/-- Exercise 9.2.1 (c) -/
 def Exercise_9_2_1c : Decidable (∀ (f g h : ℝ → ℝ), (f+g) * h = f * h + g * h) := by
   -- The first line of this construction should be `apply isTrue` or `apply isFalse`.
   sorry
 
+/-- Exercise 9.2.1 (d) -/
 def Exercise_9_2_1d : Decidable (∀ (f g h : ℝ → ℝ), f * (g+h) = f * g + f * h) := by
   -- The first line of this construction should be `apply isTrue` or `apply isFalse`.
   sorry


### PR DESCRIPTION
## Summary
- Label the two halves of Exercise 1.2.2 as `Exercise 1.2.2` / `Exercise 1.2.2'` (primed, not invented `(i)/(ii)`), matching 7a9e513.
- Add missing `(a)`–`(d)` docstrings on Exercise 9.2.1.
- Exercise 1.2.22 left to #632 (`(iii)` → `(ii')`).

## Test plan
- [x] CI Build book
