### PR TITLE
fix: disambiguate Verso labels in Section 9.1

### DIFF
--- a/Analysis/Section_9_1.lean
+++ b/Analysis/Section_9_1.lean
@@ -92,19 +92,19 @@ theorem closure_def' (X:Set ℝ) (x :ℝ) : x ∈ closure X ↔ AdherentPt x X :
 theorem AdherentPt_def (x:ℝ) (X:Set ℝ) : AdherentPt x X = ClusterPt x (.principal X) := by
   rw [←closure_def', mem_closure_iff_clusterPt]
 
-/-- Lemma 9.1.11 / Exercise 9.1.1 -/
+/-- Lemma 9.1.11 / Exercise 9.1.1 (subset) -/
 theorem subset_closure (X:Set ℝ): X ⊆ closure X := by sorry
 
-/-- Lemma 9.1.11 / Exercise 9.1.1 -/
+/-- Lemma 9.1.11 / Exercise 9.1.1 (union) -/
 theorem closure_union (X Y:Set ℝ): closure (X ∪ Y) = closure X ∪ closure Y := by sorry
 
-/-- Lemma 9.1.11 / Exercise 9.1.1 -/
+/-- Lemma 9.1.11 / Exercise 9.1.1 (inter) -/
 theorem closure_inter (X Y:Set ℝ): closure (X ∩ Y) ⊆ closure X ∩ closure Y := by sorry
 
-/-- Lemma 9.1.11 / Exercise 9.1.1 -/
+/-- Lemma 9.1.11 / Exercise 9.1.1 (monotonicity) -/
 theorem closure_subset {X Y:Set ℝ} (h: X ⊆ Y): closure X ⊆ closure Y := by sorry
 
-/-- Lemma 9.1.11 / Exercise 9.1.1 -/
+/-- Lemma 9.1.11 / Exercise 9.1.1 (sandwich) -/
 theorem closure_of_subset_closure {X Y:Set ℝ} (h: X ⊆ Y) (h' : Y ⊆ closure X): closure Y = closure X := by sorry
 
 /-- Lemma 9.1.12 -/
@@ -149,17 +149,17 @@ theorem closure_of_Iic {a:ℝ} : closure (.Iic a) = .Iic a := by
 
 theorem closure_of_R : closure (.univ: Set ℝ) = .univ := by sorry
 
-/-- Lemma 9.1.13 / Exercise 9.1.2 -/
+/-- Lemma 9.1.13 / Exercise 9.1.2 (N) -/
 theorem closure_of_N :
   closure ((fun n:ℕ ↦ (n:ℝ)) '' .univ) = ((fun n:ℕ ↦ (n:ℝ)) '' .univ) := by
     sorry
 
-/-- Lemma 9.1.13 / Exercise 9.1.2 -/
+/-- Lemma 9.1.13 / Exercise 9.1.2 (Z) -/
 theorem closure_of_Z :
   closure ((fun n:ℤ ↦ (n:ℝ)) '' .univ) = ((fun n:ℤ ↦ (n:ℝ)) '' .univ) := by
     sorry
 
-/-- Lemma 9.1.13 / Exercise 9.1.2 -/
+/-- Lemma 9.1.13 / Exercise 9.1.2 (Q) -/
 theorem closure_of_Q :
   closure ((fun n:ℚ ↦ (n:ℝ)) '' .univ) = .univ := by
     sorry
@@ -179,40 +179,40 @@ theorem isClosed_def (X:Set ℝ): IsClosed X ↔ closure X = X :=
 theorem isClosed_def' (X:Set ℝ): IsClosed X ↔ ∀ x, AdherentPt x X → x ∈ X := by
   simp [isClosed_def, subset_antisymm_iff, subset_closure]; simp [closure_def]; rfl
 
-/-- Examples 9.1.16 -/
+/-- Examples 9.1.16 (Icc) -/
 theorem Icc_closed {a b:ℝ} : IsClosed (.Icc a b) := by sorry
 
-/-- Examples 9.1.16 -/
+/-- Examples 9.1.16 (Ici) -/
 theorem Ici_closed (a:ℝ) : IsClosed (.Ici a) := by sorry
 
-/-- Examples 9.1.16 -/
+/-- Examples 9.1.16 (Iic) -/
 theorem Iic_closed (a:ℝ) : IsClosed (.Iic a) := by sorry
 
-/-- Examples 9.1.16 -/
+/-- Examples 9.1.16 (R) -/
 theorem R_closed : IsClosed (.univ : Set ℝ) := by sorry
 
-/-- Examples 9.1.16 -/
+/-- Examples 9.1.16 (Ico) -/
 theorem Ico_not_closed {a b:ℝ} (h: a < b) : ¬ IsClosed (.Ico a b) := by sorry
 
-/-- Examples 9.1.16 -/
+/-- Examples 9.1.16 (Ioc) -/
 theorem Ioc_not_closed {a b:ℝ} (h: a < b) : ¬ IsClosed (.Ioc a b) := by sorry
 
-/-- Examples 9.1.16 -/
+/-- Examples 9.1.16 (Ioo) -/
 theorem Ioo_not_closed {a b:ℝ} (h: a < b) : ¬ IsClosed (.Ioo a b) := by sorry
 
-/-- Examples 9.1.16 -/
+/-- Examples 9.1.16 (Ioi) -/
 theorem Ioi_not_closed (a:ℝ) : ¬ IsClosed (.Ioi a) := by sorry
 
-/-- Examples 9.1.16 -/
+/-- Examples 9.1.16 (Iio) -/
 theorem Iio_not_closed (a:ℝ) : ¬ IsClosed (.Iio a) := by sorry
 
-/-- Examples 9.1.16 -/
+/-- Examples 9.1.16 (N) -/
 theorem N_closed : IsClosed ((fun n:ℕ ↦ (n:ℝ)) '' .univ) := by sorry
 
-/-- Examples 9.1.16 -/
+/-- Examples 9.1.16 (Z) -/
 theorem Z_closed : IsClosed ((fun n:ℤ ↦ (n:ℝ)) '' .univ) := by sorry
 
-/-- Examples 9.1.16 -/
+/-- Examples 9.1.16 (Q) -/
 theorem Q_not_closed : ¬ IsClosed ((fun n:ℚ ↦ (n:ℝ)) '' .univ) := by sorry
 
 /-- Corollary 9.1.17 -/
@@ -300,22 +300,22 @@ theorem isBounded_def (X: Set ℝ) : Bornology.IsBounded X ↔ ∃ M > 0, X ⊆ 
     peel hC with x hx hC; rw [abs_le'] at hC; simp [hC.1]; linarith [le_max_left C 1]
   intro ⟨ M, hM, hXM ⟩; use M; intro x hx; specialize hXM hx; simp_all [abs_le']; linarith [hXM.1]
 
-/-- Example 9.1.23 -/
+/-- Example 9.1.23 (Icc) -/
 theorem Icc_bounded (a b:ℝ) : Bornology.IsBounded (.Icc a b) := by sorry
 
-/-- Example 9.1.23 -/
+/-- Example 9.1.23 (Ici) -/
 theorem Ici_unbounded (a: ℝ) : ¬ Bornology.IsBounded (.Ici a) := by sorry
 
-/-- Example 9.1.23 -/
+/-- Example 9.1.23 (N) -/
 theorem N_unbounded : ¬ Bornology.IsBounded ((fun n:ℕ ↦ (n:ℝ)) '' .univ) := by sorry
 
-/-- Example 9.1.23 -/
+/-- Example 9.1.23 (Z) -/
 theorem Z_unbounded : ¬ Bornology.IsBounded ((fun n:ℤ ↦ (n:ℝ)) '' .univ) := by sorry
 
-/-- Example 9.1.23 -/
+/-- Example 9.1.23 (Q) -/
 theorem Q_unbounded : ¬ Bornology.IsBounded ((fun n:ℚ ↦ (n:ℝ)) '' .univ) := by sorry
 
-/-- Example 9.1.23 -/
+/-- Example 9.1.23 (R) -/
 theorem R_unbounded : ¬ Bornology.IsBounded (.univ: Set ℝ) := by sorry
 
 /-- Theorem 9.1.24 / Exercise 9.1.13 (Heine-Borel theorem for the line). -/


### PR DESCRIPTION
## Summary
- Split duplicate Verso exercise doc labels in Section 9.1 so each exercise part has a unique label for the HTML build.

## Test plan
- [ ] CI / docs build passes
- [ ] Spot-check Section 9.1 exercise anchors in the rendered book


Made with [Cursor](https://cursor.com)