### PR TITLE
Section 11.5: correct Exercise 11.5.1 continuity statement

### DIFF
--- a/Analysis/Section_11_5.lean
+++ b/Analysis/Section_11_5.lean
@@ -83,8 +83,10 @@ theorem integ_of_uniform_cts {I: BoundedInterval} {f:ℝ → ℝ} (hf: UniformCo
 theorem integ_of_cts {a b:ℝ} {f:ℝ → ℝ} (hf: ContinuousOn f (Icc a b)) :
   IntegrableOn f (Icc a b) := integ_of_uniform_cts (UniformContinuousOn.of_continuousOn hf)
 
-example : ContinuousOn (fun x:ℝ ↦ 1/x) (Icc 0 1) := by sorry
+/-- Exercise 11.5.1 -/
+example : ¬ ContinuousOn (fun x:ℝ ↦ 1/x) (Icc 0 1) := by sorry
 
+/-- Exercise 11.5.1 -/
 example : ¬ IntegrableOn (fun x:ℝ ↦ 1/x) (Icc 0 1) := by sorry
 
 open PiecewiseConstantOn ConstantOn in


### PR DESCRIPTION
Extracted from #617, which also carried unrelated docstring changes.

`example : ContinuousOn (fun x:ℝ ↦ 1/x) (Icc 0 1)` was false, so the `sorry` was unprovable: with Lean's `1/0 = 0` the function is discontinuous at `0` within `Icc 0 1`. Negating it matches the exercise's intent — the point of Exercise 11.5.1 is that Corollary 11.5.2 does not apply, and that `1/x` is not Riemann integrable there either.

Also adds the `Exercise 11.5.1` docstring label to both parts, which they lacked.

Credit to @Chessing234, who spotted this in #617.