### PR TITLE
fix: disambiguate Ex. 3.5.4/3.5.5 Verso labels

### DIFF
--- a/Analysis/Section_3_5.lean
+++ b/Analysis/Section_3_5.lean
@@ -435,17 +435,17 @@ theorem SetTheory.Set.inter_prod (A B C:Set) : (A ∩ B) ×ˢ C = (A ×ˢ C) ∩
 /-- Exercise 3.5.4 (f) -/
 theorem SetTheory.Set.diff_prod (A B C:Set) : (A \ B) ×ˢ C = (A ×ˢ C) \ (B ×ˢ C) := by sorry
 
-/-- Exercise 3.5.5 -/
+/-- Exercise 3.5.5 (a) -/
 theorem SetTheory.Set.inter_of_prod (A B C D:Set) :
     (A ×ˢ B) ∩ (C ×ˢ D) = (A ∩ C) ×ˢ (B ∩ D) := by sorry
 
-/-- Exercise 3.5.5 -/
+/-- Exercise 3.5.5 (b) -/
 def SetTheory.Set.union_of_prod :
   Decidable (∀ (A B C D:Set), (A ×ˢ B) ∪ (C ×ˢ D) = (A ∪ C) ×ˢ (B ∪ D)) := by
   -- the first line of this construction should be `apply isTrue` or `apply isFalse`.
   sorry
 
-/-- Exercise 3.5.5 -/
+/-- Exercise 3.5.5 (c) -/
 def SetTheory.Set.diff_of_prod :
   Decidable (∀ (A B C D:Set), (A ×ˢ B) \ (C ×ˢ D) = (A \ C) ×ˢ (B \ D)) := by
   -- the first line of this construction should be `apply isTrue` or `apply isFalse`.

--- a/Analysis/Section_3_5.lean
+++ b/Analysis/Section_3_5.lean
@@ -417,22 +417,22 @@ theorem SetTheory.Set.tuple_trans {I:Set} {X: I → Set} {a b c: ∀ i, X i}
   (hab: tuple a = tuple b) (hbc : tuple b = tuple c) :
     tuple a = tuple c := by sorry
 
-/-- Exercise 3.5.4 -/
+/-- Exercise 3.5.4 (a) -/
 theorem SetTheory.Set.prod_union (A B C:Set) : A ×ˢ (B ∪ C) = (A ×ˢ B) ∪ (A ×ˢ C) := by sorry
 
-/-- Exercise 3.5.4 -/
+/-- Exercise 3.5.4 (b) -/
 theorem SetTheory.Set.prod_inter (A B C:Set) : A ×ˢ (B ∩ C) = (A ×ˢ B) ∩ (A ×ˢ C) := by sorry
 
-/-- Exercise 3.5.4 -/
+/-- Exercise 3.5.4 (c) -/
 theorem SetTheory.Set.prod_diff (A B C:Set) : A ×ˢ (B \ C) = (A ×ˢ B) \ (A ×ˢ C) := by sorry
 
-/-- Exercise 3.5.4 -/
+/-- Exercise 3.5.4 (d) -/
 theorem SetTheory.Set.union_prod (A B C:Set) : (A ∪ B) ×ˢ C = (A ×ˢ C) ∪ (B ×ˢ C) := by sorry
 
-/-- Exercise 3.5.4 -/
+/-- Exercise 3.5.4 (e) -/
 theorem SetTheory.Set.inter_prod (A B C:Set) : (A ∩ B) ×ˢ C = (A ×ˢ C) ∩ (B ×ˢ C) := by sorry
 
-/-- Exercise 3.5.4 -/
+/-- Exercise 3.5.4 (f) -/
 theorem SetTheory.Set.diff_prod (A B C:Set) : (A \ B) ×ˢ C = (A ×ˢ C) \ (B ×ˢ C) := by sorry
 
 /-- Exercise 3.5.5 -/


### PR DESCRIPTION
## Summary
- Split six identical Exercise 3.5.4 docs into (a)–(f).
- Split three identical Exercise 3.5.5 docs into (a)–(c).

Continues the accepted Verso label-disambiguation cleanup.

## Test plan
- [ ] CI build green

Made with [Cursor](https://cursor.com)