### PR TITLE
fix: disambiguate Examples 6.4.3–6.4.4 and Prop 6.4.5 labels

### DIFF
--- a/Analysis/Section_6_4.lean
+++ b/Analysis/Section_6_4.lean
@@ -53,19 +53,19 @@ example : Example_6_4_3.LimitPoint 1 := by sorry
 noncomputable abbrev Example_6_4_4 : Sequence :=
   (fun (n:ℕ) ↦ (-1:ℝ)^n * (1 + (10:ℝ)^(-(n:ℤ)-1)))
 
-/-- Example 6.4.4 -/
+/-- Example 6.4.4 (a) -/
 example : (0.1:ℝ).Adherent Example_6_4_4 1 := by sorry
 
-/-- Example 6.4.4 -/
+/-- Example 6.4.4 (b) -/
 example : (0.1:ℝ).ContinuallyAdherent Example_6_4_4 1 := by sorry
 
-/-- Example 6.4.4 -/
+/-- Example 6.4.4 (c) -/
 example : Example_6_4_4.LimitPoint 1 := by sorry
 
-/-- Example 6.4.4 -/
+/-- Example 6.4.4 (d) -/
 example : Example_6_4_4.LimitPoint (-1) := by sorry
 
-/-- Example 6.4.4 -/
+/-- Example 6.4.4 (e) -/
 example : ¬ Example_6_4_4.LimitPoint 0 := by sorry
 
 /-- Proposition 6.4.5 / Exercise 6.4.1 -/

--- a/Analysis/Section_6_4.lean
+++ b/Analysis/Section_6_4.lean
@@ -68,11 +68,11 @@ example : Example_6_4_4.LimitPoint (-1) := by sorry
 /-- Example 6.4.4 (e) -/
 example : ¬ Example_6_4_4.LimitPoint 0 := by sorry
 
-/-- Proposition 6.4.5 / Exercise 6.4.1 -/
+/-- Proposition 6.4.5 (a) / Exercise 6.4.1 -/
 theorem Sequence.limit_point_of_limit {a:Sequence} {x:ℝ} (h: a.TendsTo x) : a.LimitPoint x := by
   sorry
 
-/-- Proposition 6.4.5 / Exercise 6.4.1 -/
+/-- Proposition 6.4.5 (b) / Exercise 6.4.1 -/
 theorem Sequence.limit_point_of_limit_unique {a:Sequence} {x y:ℝ} (h: a.TendsTo x) (hy: a.LimitPoint y) : x = y := by
   sorry
 

--- a/Analysis/Section_6_4.lean
+++ b/Analysis/Section_6_4.lean
@@ -38,16 +38,16 @@ theorem Sequence.limit_point_def (a:Sequence) (x:ℝ) :
 
 noncomputable abbrev Example_6_4_3 : Sequence := (fun (n:ℕ) ↦ 1 - (10:ℝ)^(-(n:ℤ)-1))
 
-/-- Example 6.4.3 -/
+/-- Example 6.4.3 (a) -/
 example : (0.1:ℝ).Adherent Example_6_4_3 0.8 := by sorry
 
-/-- Example 6.4.3 -/
+/-- Example 6.4.3 (b) -/
 example : ¬ (0.1:ℝ).ContinuallyAdherent Example_6_4_3 0.8 := by sorry
 
-/-- Example 6.4.3 -/
+/-- Example 6.4.3 (c) -/
 example : (0.1:ℝ).ContinuallyAdherent Example_6_4_3 1 := by sorry
 
-/-- Example 6.4.3 -/
+/-- Example 6.4.3 (d) -/
 example : Example_6_4_3.LimitPoint 1 := by sorry
 
 noncomputable abbrev Example_6_4_4 : Sequence :=


### PR DESCRIPTION
## Summary
- Split Example 6.4.3 into (a)–(d) and Example 6.4.4 into (a)–(e).
- Split Proposition 6.4.5 / Exercise 6.4.1 into (a)/(b).

Continues the accepted Verso label-disambiguation cleanup.

## Test plan
- [ ] CI build green

Made with [Cursor](https://cursor.com)