### PR TITLE
fix: label Example 11.5.5 / Cor. 11.5.2 sharpness; tidy Lusin docstring

### DIFF
--- a/Analysis/MeasureTheory/Section_1_3_5.lean
+++ b/Analysis/MeasureTheory/Section_1_3_5.lean
@@ -1568,7 +1568,7 @@ example : ∃ (d:ℕ) (f : EuclideanSpace' d → ℝ),
 def LocallyComplexAbsolutelyIntegrable {d:ℕ} (f: EuclideanSpace' d → ℂ) : Prop :=
   ∀ (S: Set (EuclideanSpace' d)), LebesgueMeasurable S ∧ Bornology.IsBounded S → ComplexAbsolutelyIntegrableOn f S
 
-/-- Exercise 1.3.23 (Lusin's theorem only requires local absolute integrability ). -/
+/-- Exercise 1.3.23 (Lusin's theorem only requires local absolute integrability). -/
 theorem LocallyComplexAbsolutelyIntegrable.approx_by_continuous_outside_small {d:ℕ} {f : EuclideanSpace' d → ℂ}
   (hf: LocallyComplexAbsolutelyIntegrable f)
   (ε : ℝ) (hε : 0 < ε) :

--- a/Analysis/Section_11_5.lean
+++ b/Analysis/Section_11_5.lean
@@ -83,8 +83,10 @@ theorem integ_of_uniform_cts {I: BoundedInterval} {f:ℝ → ℝ} (hf: UniformCo
 theorem integ_of_cts {a b:ℝ} {f:ℝ → ℝ} (hf: ContinuousOn f (Icc a b)) :
   IntegrableOn f (Icc a b) := integ_of_uniform_cts (UniformContinuousOn.of_continuousOn hf)
 
+/-- Corollary 11.5.2 (sharpness) (a) -/
 example : ¬ ContinuousOn (fun x:ℝ ↦ 1/x) (Icc 0 1) := by sorry
 
+/-- Corollary 11.5.2 (sharpness) (b) -/
 example : ¬ IntegrableOn (fun x:ℝ ↦ 1/x) (Icc 0 1) := by sorry
 
 open PiecewiseConstantOn ConstantOn in

--- a/Analysis/Section_11_5.lean
+++ b/Analysis/Section_11_5.lean
@@ -203,14 +203,19 @@ noncomputable abbrev f_11_5_5 : ℝ → ℝ := fun x ↦
   else if x = 2 then 7
   else x^3
 
+/-- Example 11.5.5 (a) -/
 example : ¬ ContinuousOn f_11_5_5 (Icc 1 3) := by sorry
 
+/-- Example 11.5.5 (b) -/
 example : ContinuousOn f_11_5_5 (Ico 1 2) := by sorry
 
+/-- Example 11.5.5 (c) -/
 example : ContinuousOn f_11_5_5 (Icc 2 2) := by sorry
 
+/-- Example 11.5.5 (d) -/
 example : ContinuousOn f_11_5_5 (Ioc 2 3) := by sorry
 
+/-- Example 11.5.5 (e) -/
 example : PiecewiseContinuousOn f_11_5_5 (Icc 1 3) := by sorry
 
 /-- Proposition 11.5.6 / Exercise 11.5.1 -/


### PR DESCRIPTION
## Summary
- Part-label Example 11.5.5 (a)–(e)
- Label the two `1/x` examples as Corollary 11.5.2 (sharpness) (a)/(b) — they formalize the remark after the corollary, not Exercise 11.5.1
- Tidy the Exercise 1.3.23 Lusin docstring spacing

## Test plan
- [ ] CI build green