### PR TITLE
fix: continuous const/id examples; 1/x not continuous on [0,1]

### DIFF
--- a/Analysis/Section_11_5.lean
+++ b/Analysis/Section_11_5.lean
@@ -88,25 +88,22 @@ example : ¬ ContinuousOn (fun x:ℝ ↦ 1/x) (Icc 0 1) := by
   -- restriction cannot be continuous at the left endpoint. (The false
   -- `ContinuousOn` claim was flipped to `¬` in #613; this closes the sorry.)
   intro h
-  have hc := h (by simp : (0 : ℝ) ∈ Icc 0 1)
-  rw [Metric.continuousWithinAt_iff] at hc
-  obtain ⟨δ, hδ, hδclose⟩ := hc 1 (by norm_num)
+  have hc := Metric.continuousWithinAt_iff.mp (h 0 (by simp)) 1 (by norm_num)
+  obtain ⟨δ, hδ, hδclose⟩ := hc
   set x : ℝ := min (δ / 2) (1 / 2)
   have hxpos : 0 < x := lt_min (half_pos hδ) (by norm_num)
   have hx_le_half : x ≤ 1 / 2 := min_le_right _ _
   have hxI : x ∈ Icc 0 1 := ⟨hxpos.le, le_trans hx_le_half (by norm_num)⟩
   have hdist : dist x (0 : ℝ) < δ := by
     have : x ≤ δ / 2 := min_le_left _ _
-    simp [Real.dist_eq, abs_of_pos hxpos]
+    simp [Real.dist_eq, abs_of_nonneg hxpos.le]
     linarith
   have hclose := hδclose hxI hdist
-  -- Goal contradiction: `|1/x - 0| < 1`, but `1/x ≥ 2`.
-  have hge : (2 : ℝ) ≤ |((1 : ℝ) / x) - 0| := by
-    have : (1 : ℝ) / x ≥ 2 := by
-      have := (one_div_le_one_div hxpos (by norm_num : (0 : ℝ) < 1 / 2)).mpr hx_le_half
-      -- `1/(1/2) = 2`
-      simpa using this
-    simpa [abs_of_pos (one_div_pos.mpr hxpos)] using this
+  -- `|1/x - 1/0| = |1/x|` and `x ≤ 1/2` ⇒ `1/x ≥ 2`, contradicting `< 1`.
+  have hge : (2 : ℝ) ≤ |((1 : ℝ) / x) - ((1 : ℝ) / 0)| := by
+    have : (2 : ℝ) ≤ 1 / x := by
+      simpa using (one_div_le_one_div hxpos (by norm_num : (0 : ℝ) < 1 / 2)).mpr hx_le_half
+    simpa [div_zero, abs_of_pos (one_div_pos.mpr hxpos)] using this
   linarith
 
 example : ¬ IntegrableOn (fun x:ℝ ↦ 1/x) (Icc 0 1) := by sorry

--- a/Analysis/Section_11_5.lean
+++ b/Analysis/Section_11_5.lean
@@ -102,7 +102,9 @@ example : ¬ ContinuousOn (fun x:ℝ ↦ 1/x) (Icc 0 1) := by
   -- `|1/x - 1/0| = |1/x|` and `x ≤ 1/2` ⇒ `1/x ≥ 2`, contradicting `< 1`.
   have hge : (2 : ℝ) ≤ |((1 : ℝ) / x) - ((1 : ℝ) / 0)| := by
     have : (2 : ℝ) ≤ 1 / x := by
-      simpa using (one_div_le_one_div hxpos (by norm_num : (0 : ℝ) < 1 / 2)).mpr hx_le_half
+      -- `0 < 1/2`, `0 < x`, `x ≤ 1/2` ⇒ `1/(1/2) ≤ 1/x`
+      simpa using
+        (one_div_le_one_div (by norm_num : (0 : ℝ) < 1 / 2) hxpos).mp hx_le_half
     simpa [div_zero, abs_of_pos (one_div_pos.mpr hxpos)] using this
   linarith
 

--- a/Analysis/Section_11_5.lean
+++ b/Analysis/Section_11_5.lean
@@ -83,7 +83,31 @@ theorem integ_of_uniform_cts {I: BoundedInterval} {f:ℝ → ℝ} (hf: UniformCo
 theorem integ_of_cts {a b:ℝ} {f:ℝ → ℝ} (hf: ContinuousOn f (Icc a b)) :
   IntegrableOn f (Icc a b) := integ_of_uniform_cts (UniformContinuousOn.of_continuousOn hf)
 
-example : ¬ ContinuousOn (fun x:ℝ ↦ 1/x) (Icc 0 1) := by sorry
+example : ¬ ContinuousOn (fun x:ℝ ↦ 1/x) (Icc 0 1) := by
+  -- At 0, Lean has `1/0 = 0`, but `1/x` is unbounded on `(0,1]`, so the
+  -- restriction cannot be continuous at the left endpoint. (The false
+  -- `ContinuousOn` claim was flipped to `¬` in #613; this closes the sorry.)
+  intro h
+  have hc := h (by simp : (0 : ℝ) ∈ Icc 0 1)
+  rw [Metric.continuousWithinAt_iff] at hc
+  obtain ⟨δ, hδ, hδclose⟩ := hc 1 (by norm_num)
+  set x : ℝ := min (δ / 2) (1 / 2)
+  have hxpos : 0 < x := lt_min (half_pos hδ) (by norm_num)
+  have hx_le_half : x ≤ 1 / 2 := min_le_right _ _
+  have hxI : x ∈ Icc 0 1 := ⟨hxpos.le, le_trans hx_le_half (by norm_num)⟩
+  have hdist : dist x (0 : ℝ) < δ := by
+    have : x ≤ δ / 2 := min_le_left _ _
+    simp [Real.dist_eq, abs_of_pos hxpos]
+    linarith
+  have hclose := hδclose hxI hdist
+  -- Goal contradiction: `|1/x - 0| < 1`, but `1/x ≥ 2`.
+  have hge : (2 : ℝ) ≤ |((1 : ℝ) / x) - 0| := by
+    have : (1 : ℝ) / x ≥ 2 := by
+      have := (one_div_le_one_div hxpos (by norm_num : (0 : ℝ) < 1 / 2)).mpr hx_le_half
+      -- `1/(1/2) = 2`
+      simpa using this
+    simpa [abs_of_pos (one_div_pos.mpr hxpos)] using this
+  linarith
 
 example : ¬ IntegrableOn (fun x:ℝ ↦ 1/x) (Icc 0 1) := by sorry
 

--- a/Analysis/Section_9_3.lean
+++ b/Analysis/Section_9_3.lean
@@ -172,8 +172,10 @@ theorem Convergesto.id (E:Set ℝ) (x₀:ℝ)
   intro ε hε
   refine ⟨ε, hε, ?_⟩
   intro x hx
-  have hxIoo : x ∈ Set.Ioo (x₀ - ε) (x₀ + ε) := hx.2
-  exact abs_sub_lt_iff.mpr ⟨by linarith [hxIoo.1], by linarith [hxIoo.2]⟩
+  -- Avoid `(fun x ↦ x) x` in the abs goal so linarith sees `x - x₀`.
+  have : |x - x₀| < ε :=
+    abs_lt.mpr ⟨by linarith [hx.2.1], by linarith [hx.2.2]⟩
+  simpa using this
 
 theorem Convergesto.sq (E:Set ℝ) (x₀:ℝ)
   : Convergesto E (fun x ↦ x^2) (x₀^2) x₀ := by

--- a/Analysis/Section_9_3.lean
+++ b/Analysis/Section_9_3.lean
@@ -162,11 +162,18 @@ theorem Convergesto.div {E:Set ℝ} {f g: ℝ → ℝ} {L M:ℝ} {x₀:ℝ} (hM:
 
 theorem Convergesto.const (E:Set ℝ) (x₀:ℝ) (c:ℝ)
   : Convergesto E (fun _ ↦ c) c x₀ := by
-  sorry
+  intro ε hε
+  refine ⟨1, by norm_num, ?_⟩
+  intro x hx
+  simpa using hε
 
 theorem Convergesto.id (E:Set ℝ) (x₀:ℝ)
   : Convergesto E (fun x ↦ x) x₀ x₀ := by
-  sorry
+  intro ε hε
+  refine ⟨ε, hε, ?_⟩
+  intro x hx
+  have hxIoo : x ∈ Set.Ioo (x₀ - ε) (x₀ + ε) := hx.2
+  exact abs_sub_lt_iff.mpr ⟨by linarith [hxIoo.1], by linarith [hxIoo.2]⟩
 
 theorem Convergesto.sq (E:Set ℝ) (x₀:ℝ)
   : Convergesto E (fun x ↦ x^2) (x₀^2) x₀ := by

--- a/Analysis/Section_9_4.lean
+++ b/Analysis/Section_9_4.lean
@@ -30,16 +30,31 @@ theorem ContinuousWithinAt.iff (X:Set ℝ) (f: ℝ → ℝ)  (x₀:ℝ) :
 #check continuousWithinAt_univ
 
 /-- Example 9.4.2. -/
-example (c x₀:ℝ) : ContinuousWithinAt (fun x ↦ c) .univ x₀ := by sorry
+example (c x₀:ℝ) : ContinuousWithinAt (fun x ↦ c) .univ x₀ := by
+  rw [ContinuousWithinAt.iff]
+  exact Convergesto.const _ _ _
 
-example (c x₀:ℝ) : ContinuousAt (fun x ↦ c) x₀ := by sorry
+example (c x₀:ℝ) : ContinuousAt (fun x ↦ c) x₀ := by
+  rw [← continuousWithinAt_univ]
+  exact ContinuousWithinAt.iff _ _ _ |>.mpr (Convergesto.const _ _ _)
 
-example (c:ℝ) : ContinuousOn (fun x:ℝ ↦ c) .univ := by sorry
+example (c:ℝ) : ContinuousOn (fun x:ℝ ↦ c) .univ := by
+  intro x hx
+  rw [ContinuousWithinAt.iff]
+  exact Convergesto.const _ _ _
 
-example (c:ℝ) : Continuous (fun x:ℝ ↦ c) := by sorry
+example (c:ℝ) : Continuous (fun x:ℝ ↦ c) := by
+  rw [continuous_iff_continuousOn_univ]
+  intro x hx
+  rw [ContinuousWithinAt.iff]
+  exact Convergesto.const _ _ _
 
 /-- Example 9.4.3. -/
-example : Continuous (fun x:ℝ ↦ x) := by sorry
+example : Continuous (fun x:ℝ ↦ x) := by
+  rw [continuous_iff_continuousOn_univ]
+  intro x hx
+  rw [ContinuousWithinAt.iff]
+  exact Convergesto.id _ _
 
 /-- Example 9.4.4. -/
 example {x₀:ℝ} (h: x₀ ≠ 0) : ContinuousAt Real.sign x₀ := by sorry

--- a/Analysis/Section_9_4.lean
+++ b/Analysis/Section_9_4.lean
@@ -44,14 +44,14 @@ example (c:ℝ) : ContinuousOn (fun x:ℝ ↦ c) .univ := by
   exact Convergesto.const _ _ _
 
 example (c:ℝ) : Continuous (fun x:ℝ ↦ c) := by
-  rw [continuous_iff_continuousOn_univ]
+  rw [← continuousOn_univ]
   intro x hx
   rw [ContinuousWithinAt.iff]
   exact Convergesto.const _ _ _
 
 /-- Example 9.4.3. -/
 example : Continuous (fun x:ℝ ↦ x) := by
-  rw [continuous_iff_continuousOn_univ]
+  rw [← continuousOn_univ]
   intro x hx
   rw [ContinuousWithinAt.iff]
   exact Convergesto.id _ _


### PR DESCRIPTION
## Summary
- Prove `Convergesto.const` / `Convergesto.id` and fill Examples 9.4.2–9.4.3 (constant and identity continuity).
- Prove `¬ ContinuousOn (fun x ↦ 1/x) (Icc 0 1)`, closing the sorry left after #613 corrected the false positive claim.

## Test plan
- [ ] CI build
