### PR TITLE
fix: part-label Example 5.2.2 Verso docstrings

### DIFF
--- a/Analysis/Section_5_2.lean
+++ b/Analysis/Section_5_2.lean
@@ -36,14 +36,14 @@ namespace Chapter5
 lemma Rat.closeSeq_def (ε: ℚ) (a b: Sequence) :
     ε.CloseSeq a b ↔ ∀ n, n ≥ a.n₀ → n ≥ b.n₀ → ε.Close (a n) (b n) := by rfl
 
-/-- Example 5.2.2 -/
+/-- Example 5.2.2 (a) -/
 example : (0.1:ℚ).CloseSeq ((fun n:ℕ ↦ ((-1)^n:ℚ)):Sequence)
 ((fun n:ℕ ↦ ((1.1:ℚ) * (-1)^n)):Sequence) := by sorry
 
-/-- Example 5.2.2 -/
+/-- Example 5.2.2 (b) -/
 example : ¬ (0.1:ℚ).Steady ((fun n:ℕ ↦ ((-1)^n:ℚ)):Sequence) := by sorry
 
-/-- Example 5.2.2 -/
+/-- Example 5.2.2 (c) -/
 example : ¬ (0.1:ℚ).Steady ((fun n:ℕ ↦ ((1.1:ℚ) * (-1)^n)):Sequence) := by sorry
 
 /-- Definition 5.2.3 (Eventually ε-close sequences) -/


### PR DESCRIPTION
## Summary
- Disambiguate the three Example 5.2.2 statements as (a)/(b)/(c) so Verso labels do not collide.

## Test plan
- [ ] CI build green
- [ ] Labels match the three examples in Section 5.2


Made with [Cursor](https://cursor.com)