### PR TITLE
fix: restore determinant scaling factor to measure_linear

### DIFF
--- a/Analysis/MeasureTheory/Section_1_1_2.lean
+++ b/Analysis/MeasureTheory/Section_1_1_2.lean
@@ -735,7 +735,7 @@ lemma JordanMeasurable.linear {d:ℕ} (T: EuclideanSpace' d ≃ₗ[ℝ] Euclidea
 /-- Exercise 1.1.11 (2) -/
 -- The measure of a linear image of a Jordan measurable set equals the original measure (up to determinant scaling).
 lemma JordanMeasurable.measure_linear {d:ℕ} (T: EuclideanSpace' d ≃ₗ[ℝ] EuclideanSpace' d) :
-∃ D > 0, ∀ (E: Set (EuclideanSpace' d)) (hE: JordanMeasurable E), (linear T hE).measure = hE.measure := by sorry
+∃ D > 0, ∀ (E: Set (EuclideanSpace' d)) (hE: JordanMeasurable E), (linear T hE).measure = D * hE.measure := by sorry
 
 /-- An invertible matrix defines a linear equivalence on Euclidean space. -/
 noncomputable def Matrix.linear_equiv {d:ℕ} (A: Matrix (Fin d) (Fin d) ℝ) [Invertible A] :


### PR DESCRIPTION
exercise 1.1.11(2): `measure_linear`'s conclusion dropped the `D` it existentially introduces, so as stated it claims linear maps preserve jordan measure exactly. counterexample: `x ↦ 2x` on `[0,1]` doubles the measure. the elementary-set version right above (`measure_linear_of_elem`) and `measure_linear_det` right below both already assume/use the `D *` factor, and the doc comment says "up to determinant scaling" - so this just brings the statement in line with its neighbors.