### PR TITLE
fix: a finer partition generates the larger algebra (IsPartition.mono)

### DIFF
--- a/Analysis/MeasureTheory/Section_1_4_1.lean
+++ b/Analysis/MeasureTheory/Section_1_4_1.lean
@@ -161,7 +161,7 @@ def IsPartition.finer_than {I J X:Type*} {parts_I: I → Set X} {parts_J: J → 
 def IsPartition.mono {I J X:Type*} {parts_I: I → Set X} {parts_J: J → Set X}
   (hI: IsPartition parts_I) (hJ: IsPartition parts_J)
   (h_finer: hI.finer_than hJ) :
-  hI.to_ConcreteBooleanAlgebra ≤ hJ.to_ConcreteBooleanAlgebra :=
+  hI.to_ConcreteBooleanAlgebra ≥ hJ.to_ConcreteBooleanAlgebra :=
   by sorry
 
 def IsPartition.remove_empty {I X:Type*} {parts: I → Set X} (h_part: IsPartition parts) : IsPartition (fun (i:{i:I // parts i ≠ ∅}) ↦ parts i.val) :=


### PR DESCRIPTION
`IsPartition.mono` has the inequality backwards. `finer_than` says each I-atom sits inside a J-atom, so the I-algebra is the bigger one. As written it's false: the discrete partition is finer than the trivial one, so it would give ⊤ ≤ ⊥. It also disagreed with `DyadicCube'.boolean_algebra_mono` right below, which puts the finer scale on the larger side.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L2CvMw5eaDJWQebT6DcvfT)_