### PR TITLE
fix: complement the union, not the existential, in generated_by_eq

### DIFF
--- a/Analysis/MeasureTheory/Section_1_4_1.lean
+++ b/Analysis/MeasureTheory/Section_1_4_1.lean
@@ -268,6 +268,6 @@ instance EuclideanSpace'.elementary_boolean_algebra_generated_by_boxes (d:ℕ) :
 /-- Exercise 1.4.9 (Recursive definition of generated Boolean algebra). -/
 def ConcreteBooleanAlgebra.generated_by_eq {X:Type*} (F: Set (Set X)) :
   (ConcreteBooleanAlgebra.generated_by F).measurableSets =
-  ⋃ n, Nat.rec (motive := fun _ ↦ Set (Set X)) F (fun n G ↦ { E: Set X | (∃ S: Finset G, E = ⋃ (H:S), H) ∨ (∃ S: Finset G, E = (⋃ (H:S), H))ᶜ }) n := by sorry
+  ⋃ n, Nat.rec (motive := fun _ ↦ Set (Set X)) F (fun n G ↦ { E: Set X | (∃ S: Finset G, E = ⋃ (H:S), H) ∨ (∃ S: Finset G, E = (⋃ (H:S), H)ᶜ) }) n := by sorry
 
   

--- a/Analysis/MeasureTheory/Section_1_4_2.lean
+++ b/Analysis/MeasureTheory/Section_1_4_2.lean
@@ -158,7 +158,7 @@ open Ordinal in
 def ConcreteSigmaAlgebra.generated_by_eq {X:Type*} (F: Set (Set X)) :
   (ConcreteSigmaAlgebra.generated_by F).measurableSets =
   ⋃ α < ω₁,
-  Ordinal.limitRecOn (motive := fun _ ↦ Set (Set X)) α F (fun n G ↦ { E: Set X | (∃ S: Set G, Countable S ∧ E = ⋃ (H:S), H) ∨ (∃ S: Set G, Countable S ∧ E = (⋃ (H:S), H))ᶜ }) (fun α _ G ↦ ⋃ (β : Ordinal) (h : β < α), G β h) := by sorry
+  Ordinal.limitRecOn (motive := fun _ ↦ Set (Set X)) α F (fun n G ↦ { E: Set X | (∃ S: Set G, Countable S ∧ E = ⋃ (H:S), H) ∨ (∃ S: Set G, Countable S ∧ E = (⋃ (H:S), H)ᶜ) }) (fun α _ G ↦ ⋃ (β : Ordinal) (h : β < α), G β h) := by sorry
 
 open Cardinal in
 /-- Exercise 1.4.16 -/


### PR DESCRIPTION
in Exercises 1.4.9 and 1.4.15 the closing paren of the second disjunct sits before the `ᶜ`, so it lands on the `∃` (Prop is a BooleanAlgebra, so it elaborates as `¬`) rather than on the union. each stage then reads `P ∨ ¬P` and collapses to all of `Set X`, instead of the finite/countable unions from the previous stage together with their complements.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L2CvMw5eaDJWQebT6DcvfT)_