### PR TITLE
fix: dirac_isCountablyAdditive needs a sigma-algebra hypothesis

### DIFF
--- a/Analysis/MeasureTheory/Section_1_4_3.lean
+++ b/Analysis/MeasureTheory/Section_1_4_3.lean
@@ -179,7 +179,7 @@ def CountablyAdditiveMeasure.restrict_alg {X:Type*} {B B': ConcreteSigmaAlgebra 
   }
 
 /-- Example 1.4.29 (Dirac measure) -/
-theorem FinitelyAdditiveMeasure.dirac_isCountablyAdditive {X:Type*} (x₀:X) (B: ConcreteBooleanAlgebra X) : (FinitelyAdditiveMeasure.dirac x₀ B).isCountablyAdditive :=
+theorem FinitelyAdditiveMeasure.dirac_isCountablyAdditive {X:Type*} (x₀:X) (B: ConcreteBooleanAlgebra X) (hB: B.isSigmaAlgebra) : (FinitelyAdditiveMeasure.dirac x₀ B).isCountablyAdditive :=
   by sorry
 
 /-- Example 1.4.29 (Counting measure) -/


### PR DESCRIPTION
`isCountablyAdditive` carries `B.isSigmaAlgebra` as its first conjunct, so Example 1.4.29 as stated claimed every concrete Boolean algebra is a σ-algebra — which `JordanMeasurable.boolean_algebra.not_isSigmaAlgebra` refutes a section earlier. added the hypothesis. `counting_isCountablyAdditive` is fine as is since its algebra is ⊤.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L2CvMw5eaDJWQebT6DcvfT)_