### PR TITLE
fix: Exercise 1.4.28(ii) needs μ(E) < ⊤, like part (i)

### DIFF
--- a/Analysis/MeasureTheory/Section_1_4_3.lean
+++ b/Analysis/MeasureTheory/Section_1_4_3.lean
@@ -337,5 +337,5 @@ theorem BooleanAlgebra.approx_finite {X:Type*} {B: ConcreteBooleanAlgebra X} (μ
   ∃ F : Set X, B.measurable F ∧ μ (symmDiff E F) < ENNReal.ofReal ε := by sorry
 
 /-- Exercise 1.4.28(ii) (Approximation by an algebra) -/
-theorem BooleanAlgebra.approx_sigma_finite {X:Type*} {B: ConcreteBooleanAlgebra X} (μ: @Measure X (ConcreteSigmaAlgebra.generated_by B.measurableSets).measurableSpace) (hσfin: ∃ A : ℕ → Set X, (∀ n, B.measurable (A n) ∧ μ (A n) < ⊤) ∧ ⋃ n, A n = ⊤) : ∀ (ε : ℝ) (hε: ε>0) (E : Set X) (hE: (ConcreteSigmaAlgebra.generated_by B.measurableSets).measurable E),
+theorem BooleanAlgebra.approx_sigma_finite {X:Type*} {B: ConcreteBooleanAlgebra X} (μ: @Measure X (ConcreteSigmaAlgebra.generated_by B.measurableSets).measurableSpace) (hσfin: ∃ A : ℕ → Set X, (∀ n, B.measurable (A n) ∧ μ (A n) < ⊤) ∧ ⋃ n, A n = ⊤) : ∀ (ε : ℝ) (hε: ε>0) (E : Set X) (hE: (ConcreteSigmaAlgebra.generated_by B.measurableSets).measurable E) (hEfin: μ E < ⊤),
   ∃ F : Set X, B.measurable F ∧ μ (symmDiff E F) < ENNReal.ofReal ε := by sorry


### PR DESCRIPTION
approx_sigma_finite drops part (i)'s `hfin : μ univ < ⊤` in favor of σ-finiteness of the algebra's generating sequence, but places no bound on `μ E` itself. Part (i) gets `μ E < ⊤` for free from `μ univ < ⊤`; part (ii) needs it stated explicitly.

Counterexample: X = ℝ, B = finite unions of integer-endpoint intervals, μ = Lebesgue. μ is σ-finite over B via A n = [-n,n), but E = ⋃ₙ [2n, 2n+1) is in σ(B) with μ E = ∞. Every F ∈ B is determined by finitely many integer breakpoints, so E Δ F contains infinitely many unit intervals for any such F, and μ(E Δ F) = ∞ for every choice — no F gets within any finite ε.

Added the missing `hEfin : μ E < ⊤` hypothesis.

Note: I wasn't able to complete a local `lake build` for this one (network contention on my machine during the mathlib4 fetch) — this is a minimal, single-hypothesis, statement-only change with no proof body (`sorry`), hand-checked against the type signature and the already-compiling sibling `approx_finite` above it. Happy to iterate if CI (build_book.yml) flags anything.