### PR TITLE
fix: drop superfluous boundedness hypothesis in Ex 1.3.8(iii)/(iv)

### DIFF
--- a/Analysis/MeasureTheory/Section_1_3_2.lean
+++ b/Analysis/MeasureTheory/Section_1_3_2.lean
@@ -3283,18 +3283,18 @@ theorem UnsignedSimpleFunction.iff' {d:ℕ} {f: EuclideanSpace' d → EReal} (hf
 
 /-- Exercise 1.3.8(iii) -/
 theorem RealMeasurable.aeEqual {d:ℕ} {f g: EuclideanSpace' d → ℝ} (hf: RealMeasurable f)
-    (hg : ∃ M : ℝ, ∀ x, |g x| ≤ M) (heq: AlmostEverywhereEqual f g) : RealMeasurable g := by sorry
+    (heq: AlmostEverywhereEqual f g) : RealMeasurable g := by sorry
 
 theorem ComplexMeasurable.aeEqual {d:ℕ} {f g: EuclideanSpace' d → ℂ} (hf: ComplexMeasurable f)
-    (hg : ∃ M : ℝ, ∀ x, ‖g x‖ ≤ M) (heq: AlmostEverywhereEqual f g) : ComplexMeasurable g := by sorry
+    (heq: AlmostEverywhereEqual f g) : ComplexMeasurable g := by sorry
 
 /-- Exercise 1.3.8(iv) -/
 theorem RealMeasurable.aeLimit {d:ℕ} {f: EuclideanSpace' d → ℝ} (g: ℕ → EuclideanSpace' d → ℝ)
-    (hf : ∀ n, RealMeasurable (g n)) (hfn : ∃ M : ℝ, ∀ x, |f x| ≤ M)
+    (hf : ∀ n, RealMeasurable (g n))
     (heq: PointwiseAeConvergesTo g f) : RealMeasurable f := by sorry
 
 theorem ComplexMeasurable.aeLimit {d:ℕ} {f: EuclideanSpace' d → ℂ} (g: ℕ → EuclideanSpace' d → ℂ)
-    (hf : ∀ n, ComplexMeasurable (g n)) (hfn : ∃ M : ℝ, ∀ x, ‖f x‖ ≤ M)
+    (hf : ∀ n, ComplexMeasurable (g n))
     (heq: PointwiseAeConvergesTo g f) : ComplexMeasurable f := by sorry
 
 /-- Exercise 1.3.8(v) -/


### PR DESCRIPTION
RealMeasurable.aeEqual/aeLimit and their Complex twins carried an extraneous `|g x| ≤ M` / `‖g x‖ ≤ M` hypothesis with no counterpart in Tao's Exercise 1.3.8, and `RealMeasurable`/`ComplexMeasurable` (unlike `UnsignedMeasurable`) impose no sign/unsignedness restriction that would make such a bound needed.

Comparing against the already-correct unsigned analogues just above (`UnsignedMeasurable.aeEqual`/`aeLimit`) makes the mismatch clear: those take `hg : Unsigned g` / `hfn : Unsigned f`, because `UnsignedMeasurable` bakes `Unsigned` into its own definition, so concluding `UnsignedMeasurable g` needs `Unsigned g` re-asserted. `RealMeasurable` has no such built-in restriction to re-assert, so the real/complex versions need no extra hypothesis at all — the boundedness assumption looks like a stray, unrelated hypothesis rather than a deliberate port of that pattern.

Dropped the four now-superfluous hypotheses.

Note: as with my other PR open right now, I wasn't able to complete a local `lake build` this round due to network contention on my machine — this is a minimal, statement-only change (deleting unused hypothesis binders, no proof body) checked directly against the pattern used by the neighboring, already-compiling unsigned theorems. Happy to iterate on CI (build_book.yml) feedback.