### PR TITLE
fix: JordanMeasurable.boolean_algebra.not_isSigmaAlgebra needs d ≥ 1

### DIFF
--- a/Analysis/MeasureTheory/Section_1_4_2.lean
+++ b/Analysis/MeasureTheory/Section_1_4_2.lean
@@ -41,7 +41,8 @@ theorem IsNull.boolean_algebra.isSigmaAlgebra (d:ℕ) : (IsNull.boolean_algebra 
 def IsNull.sigmaAlgebra (d:ℕ) : ConcreteSigmaAlgebra (EuclideanSpace' d) :=
   (IsNull.boolean_algebra.isSigmaAlgebra d).toSigmaAlgebra
 
-theorem JordanMeasurable.boolean_algebra.not_isSigmaAlgebra (d:ℕ) : ¬ (JordanMeasurable.boolean_algebra d).isSigmaAlgebra :=
+theorem JordanMeasurable.boolean_algebra.not_isSigmaAlgebra (d:ℕ) (hd: d ≥ 1) :
+  ¬ (JordanMeasurable.boolean_algebra d).isSigmaAlgebra :=
   by sorry
 
 /-- Exercise 1.4.12 -/


### PR DESCRIPTION
`EuclideanSpace' 0` is a one-point space, so its only subsets are `∅` and `univ`, both Jordan measurable. The Jordan algebra in dimension 0 is therefore the full power set, which is closed under countable unions — so `isSigmaAlgebra` *holds* at `d = 0` and the statement as formalized is false there.

Adding `(hd : d ≥ 1)` matches the convention already used by the neighbouring degenerate-dimension statements: the four Exercise 1.4.5 `_not_atomic` results in `Section_1_4_1.lean` and `JordanMeasurable.not_borel` further down this same file all carry `d ≥ 1`.

The body stays `sorry`, and no other declaration references this theorem, so nothing downstream changes.