### PR TITLE
fix: Exercise 1.3.8(ii) should be the real/complex simple function characterization

### DIFF
--- a/Analysis/MeasureTheory/Section_1_3_2.lean
+++ b/Analysis/MeasureTheory/Section_1_3_2.lean
@@ -3279,7 +3279,9 @@ theorem Continuous.RealMeasurable {d:ℕ} {f: EuclideanSpace' d → ℝ} (hf: Co
 theorem Continuous.ComplexMeasurable {d:ℕ} {f: EuclideanSpace' d → ℂ} (hf: Continuous f) : ComplexMeasurable f := by sorry
 
 /-- Exercise 1.3.8(ii) -/
-theorem UnsignedSimpleFunction.iff' {d:ℕ} {f: EuclideanSpace' d → EReal} (hf: Unsigned f) : UnsignedSimpleFunction f ↔ UnsignedMeasurable f ∧ Finite (f '' Set.univ) := by sorry
+theorem RealSimpleFunction.iff {d:ℕ} {f: EuclideanSpace' d → ℝ} : RealSimpleFunction f ↔ RealMeasurable f ∧ Finite (f '' Set.univ) := by sorry
+
+theorem ComplexSimpleFunction.iff {d:ℕ} {f: EuclideanSpace' d → ℂ} : ComplexSimpleFunction f ↔ ComplexMeasurable f ∧ Finite (f '' Set.univ) := by sorry
 
 /-- Exercise 1.3.8(iii) -/
 theorem RealMeasurable.aeEqual {d:ℕ} {f g: EuclideanSpace' d → ℝ} (hf: RealMeasurable f)


### PR DESCRIPTION
Exercise 1.3.8 asks for the real- and complex-valued analogues of the unsigned results, and every other part in that block comes as a `Real`/`Complex` pair — (i) `Continuous.RealMeasurable`/`Continuous.ComplexMeasurable`, (iii) `aeEqual`, (iv) `aeLimit`, (v) `comp_cts`, (vi) `add`/`sub`/`mul`.

Part (ii), `UnsignedSimpleFunction.iff'`, was instead a character-for-character copy of Exercise 1.3.5's unsigned statement (`UnsignedSimpleFunction.iff`, line 1752 of the same file). So the real/complex analogue was missing and 1.3.5 was posed twice.

Replaced with the two intended statements:

```lean
theorem RealSimpleFunction.iff {d:ℕ} {f: EuclideanSpace' d → ℝ} :
  RealSimpleFunction f ↔ RealMeasurable f ∧ Finite (f '' Set.univ)

theorem ComplexSimpleFunction.iff {d:ℕ} {f: EuclideanSpace' d → ℂ} :
  ComplexSimpleFunction f ↔ ComplexMeasurable f ∧ Finite (f '' Set.univ)
```

Both bodies stay `sorry`. `UnsignedSimpleFunction.iff'` was not referenced anywhere in the repository, so nothing downstream changes.