### PR TITLE
fix: Exercise 1.1.7(i) needs a closed box

### DIFF
--- a/Analysis/MeasureTheory/Section_1_1_2.lean
+++ b/Analysis/MeasureTheory/Section_1_1_2.lean
@@ -660,15 +660,22 @@ lemma JordanMeasurable.measure_of_translate {d:ℕ} {E: Set (EuclideanSpace' d)}
   · exact eq_outer hE;
 
 /-- Exercise 1.1.7 (i) (Regions under graphs are Jordan measurable) -/
-lemma JordanMeasurable.graph {d:ℕ} {B:Box d} {f: EuclideanSpace' d → ℝ} (hf: ContinuousOn f B.toSet) : JordanMeasurable { p | ∃ x ∈ B.toSet, EuclideanSpace'.prod_equiv d 1 p = ⟨ x, f x ⟩ } := by
+lemma JordanMeasurable.graph {d:ℕ} {B:Box d} (hB: IsClosed B.toSet) {f: EuclideanSpace' d → ℝ}
+  (hf: ContinuousOn f B.toSet) :
+  JordanMeasurable { p | ∃ x ∈ B.toSet, EuclideanSpace'.prod_equiv d 1 p = ⟨ x, f x ⟩ } := by
   sorry
 
 /-- Exercise 1.1.7 (i) (Regions under graphs are Jordan measurable) -/
-lemma JordanMeasurable.measure_of_graph {d:ℕ} {B:Box d} {f: EuclideanSpace' d → ℝ} (hf: ContinuousOn f B.toSet) : (JordanMeasurable.graph hf).measure = 0 := by
+lemma JordanMeasurable.measure_of_graph {d:ℕ} {B:Box d} (hB: IsClosed B.toSet)
+  {f: EuclideanSpace' d → ℝ} (hf: ContinuousOn f B.toSet) :
+  (JordanMeasurable.graph hB hf).measure = 0 := by
   sorry
 
 /-- Exercise 1.1.7 (i) (Regions under graphs are Jordan measurable) -/
-lemma JordanMeasurable.undergraph {d:ℕ} {B:Box d} {f: EuclideanSpace' d → ℝ} (hf: ContinuousOn f B.toSet) : JordanMeasurable { p | ∃ x ∈ B.toSet, ∃ t:ℝ, EuclideanSpace'.prod_equiv d 1 p = ⟨ x, t ⟩ ∧ 0 ≤ t ∧ t ≤ f x } := by
+lemma JordanMeasurable.undergraph {d:ℕ} {B:Box d} (hB: IsClosed B.toSet)
+  {f: EuclideanSpace' d → ℝ} (hf: ContinuousOn f B.toSet) :
+  JordanMeasurable
+    { p | ∃ x ∈ B.toSet, ∃ t:ℝ, EuclideanSpace'.prod_equiv d 1 p = ⟨ x, t ⟩ ∧ 0 ≤ t ∧ t ≤ f x } := by
   sorry
 
 /-- Exercise 1.1.8(i) (A triangle is Jordan measurable) -/


### PR DESCRIPTION
A `Box d` is a product of `BoundedInterval`s, which need not be closed, and `ContinuousOn f B.toSet` over a non-closed box does not force `f` to be bounded.

Counterexample to the statement as formalized: take `d = 1`, `B.side 0 = Ioo 0 1`, and `f x = 1 / x 0` (away from 0, so `ContinuousOn f B.toSet` holds). Then

```
{ p | ∃ x ∈ B.toSet, prod_equiv 1 1 p = ⟨x, f x⟩ }
```

is unbounded in its second coordinate, and so is the region under it. `JordanMeasurable` carries a boundedness field, so neither set is Jordan measurable and both `graph` and `undergraph` are false.

Adding `(hB : IsClosed B.toSet)` makes `B.toSet` compact, so a continuous `f` is bounded and uniformly continuous there — the closed-box hypothesis the textbook exercise uses. `IsClosed B.toSet` is how closed boxes are already spelled in `Section_1_2_1.lean`.

`measure_of_graph` picks up the hypothesis too since it refers to `JordanMeasurable.graph`. All three bodies stay `sorry`, and none of the three lemmas is referenced elsewhere in the repository.