### PR TITLE
fix: Exercise 1.2.2' should assume uniform convergence on [0,1]

### DIFF
--- a/Analysis/MeasureTheory/Section_1_2_0.lean
+++ b/Analysis/MeasureTheory/Section_1_2_0.lean
@@ -583,7 +583,10 @@ example : ∃ f: ℕ → ℝ → ℝ, ∃ F: ℝ → ℝ, ∃ M, ∀ n, ∀ x �
 
 /-- Exercise 1.2.2' -/
 -- Determine whether uniform convergence of uniformly bounded Riemann integrable functions preserves Riemann integrability (true or false).
-def Ex_1_2_2b : Decidable ( ∀ f: ℕ → ℝ → ℝ, ∀ F: ℝ → ℝ, (∃ M, ∀ n, ∀ x ∈ Set.Icc 0 1, |f n x| ≤ M) → (∀ x ∈ Set.Icc 0 1, TendstoUniformly f F Filter.atTop) → (∀ n, RiemannIntegrableOn (f n) (Icc 0 1)) → RiemannIntegrableOn F (Icc 0 1) ) := by
+def Ex_1_2_2b : Decidable ( ∀ f: ℕ → ℝ → ℝ, ∀ F: ℝ → ℝ,
+    (∃ M, ∀ n, ∀ x ∈ Set.Icc 0 1, |f n x| ≤ M) →
+    TendstoUniformlyOn f F Filter.atTop (Set.Icc 0 1) →
+    (∀ n, RiemannIntegrableOn (f n) (Icc 0 1)) → RiemannIntegrableOn F (Icc 0 1) ) := by
   -- the first line of this construction should be either `apply isTrue` or `apply isFalse`, depending on whether you believe the given statement to be true or false.
   sorry
 


### PR DESCRIPTION
`Ex_1_2_2b` (Exercise 1.2.2') states the uniform-convergence hypothesis as

```lean
(∀ x ∈ Set.Icc 0 1, TendstoUniformly f F Filter.atTop) →
```

`TendstoUniformly f F Filter.atTop` already quantifies over the whole domain, so
`x` does not occur in the body of that binder. Two consequences:

- the `∀ x ∈ Set.Icc 0 1` is vacuous — modulo `Icc 0 1` being nonempty it is just
  the inner proposition;
- what it actually assumes is uniform convergence **on all of ℝ**, while every
  other hypothesis and the conclusion are scoped to `Icc 0 1`.

Exercise 1.2.2' asks whether uniform convergence *on [0,1]* of uniformly bounded
Riemann integrable functions preserves Riemann integrability, so the hypothesis
should be `TendstoUniformlyOn f F Filter.atTop (Set.Icc 0 1)`.

The intended answer does not change — a uniform limit of Riemann integrable
functions on [0,1] is Riemann integrable, so this is still `isTrue` — but the old
form hands the solver a strictly stronger hypothesis than the exercise offers,
and states it about the wrong set.

I also wrapped the declaration to the 100-character limit from CONTRIBUTING; it
was a single 284-character line, and the neighbouring `example` for Exercise
1.2.2 is already wrapped the same way.

No Lean toolchain build was run for this — relying on the build CI on this PR.
