### PR TITLE
fix: scope Exercise 1.2.2's boundedness hypothesis to its own conjunct

### DIFF
--- a/Analysis/MeasureTheory/Section_1_2_0.lean
+++ b/Analysis/MeasureTheory/Section_1_2_0.lean
@@ -575,7 +575,8 @@ example :
 
 /-- Exercise 1.2.2 -/
 -- The pointwise limit of uniformly bounded Riemann integrable functions need not be Riemann integrable.
-example : ∃ f: ℕ → ℝ → ℝ, ∃ F: ℝ → ℝ, ∃ M, ∀ n, ∀ x ∈ Set.Icc 0 1, |f n x| ≤ M ∧
+example : ∃ f: ℕ → ℝ → ℝ, ∃ F: ℝ → ℝ,
+    (∃ M, ∀ n, ∀ x ∈ Set.Icc 0 1, |f n x| ≤ M) ∧
     (∀ x ∈ Set.Icc 0 1, Filter.atTop.Tendsto (fun n ↦ f n x) (nhds (F x))) ∧
     (∀ n, RiemannIntegrableOn (f n) (Icc 0 1)) ∧
     ¬ RiemannIntegrableOn F (Icc 0 1) := by


### PR DESCRIPTION
Exercise 1.2.2 currently reads

```lean
example : ∃ f: ℕ → ℝ → ℝ, ∃ F: ℝ → ℝ, ∃ M, ∀ n, ∀ x ∈ Set.Icc 0 1, |f n x| ≤ M ∧
    (∀ x ∈ Set.Icc 0 1, Filter.atTop.Tendsto (fun n ↦ f n x) (nhds (F x))) ∧
    (∀ n, RiemannIntegrableOn (f n) (Icc 0 1)) ∧
    ¬ RiemannIntegrableOn F (Icc 0 1) := by
```

`∧` binds tighter than the preceding binders, so `∀ n, ∀ x ∈ Icc 0 1` scopes over
the entire four-way conjunction rather than over `|f n x| ≤ M` alone. The three
later conjuncts mention neither `n` nor that `x` — the second rebinds its own
`x`, the third rebinds its own `n`, shadowing the outer one — so each is
re-asserted once per `(n, x)` pair.

Since `ℕ` and `Icc 0 1` are both nonempty this is *equivalent* to the intended
statement, so nothing becomes provable or unprovable here. The cost is only that
a reader has to notice that equivalence before they can see what the exercise is
asking, and the shadowed `∀ n` invites a misreading of the third conjunct.

The fix parenthesises the boundedness hypothesis as its own conjunct, which is
how Exercise 1.2.2' immediately below already writes exactly the same hypothesis:

```lean
(∃ M, ∀ n, ∀ x ∈ Set.Icc 0 1, |f n x| ≤ M) → ...
```

so the two neighbouring statements now agree on the shape of the shared
hypothesis.

Independent of #649, which touches Exercise 1.2.2' a few lines below; the changed
lines are disjoint, so the two merge in either order.

No Lean toolchain build was run for this — relying on the build CI on this PR.
