### PR TITLE
fix: disambiguate duplicate Verso labels in Section 5.6

### DIFF
--- a/Analysis/Section_5_6.lean
+++ b/Analysis/Section_5_6.lean
@@ -40,28 +40,28 @@ lemma Real.pow_of_coe (q: ℚ) (n:ℕ) : (q:Real) ^ n = (q ^ n:ℚ) := by induct
 to be a `Field`), but the spirit of the exercises is to adapt the proofs of
 Proposition 4.3.10 that you previously established. -/
 
-/-- Analogue of Proposition 4.3.10(a) -/
+/-- Analogue of Proposition 4.3.10(a) (sum of exponents) -/
 theorem Real.pow_add (x:Real) (m n:ℕ) : x^n * x^m = x^(n+m) := by sorry
 
-/-- Analogue of Proposition 4.3.10(a) -/
+/-- Analogue of Proposition 4.3.10(a) (product of exponents) -/
 theorem Real.pow_mul (x:Real) (m n:ℕ) : (x^n)^m = x^(n*m) := by sorry
 
-/-- Analogue of Proposition 4.3.10(a) -/
+/-- Analogue of Proposition 4.3.10(a) (power of a product) -/
 theorem Real.mul_pow (x y:Real) (n:ℕ) : (x*y)^n = x^n * y^n := by sorry
 
 /-- Analogue of Proposition 4.3.10(b) -/
 theorem Real.pow_eq_zero (x:Real) (n:ℕ) (hn : 0 < n) : x^n = 0 ↔ x = 0 := by sorry
 
-/-- Analogue of Proposition 4.3.10(c) -/
+/-- Analogue of Proposition 4.3.10(c) (nonnegativity) -/
 theorem Real.pow_nonneg {x:Real} (n:ℕ) (hx: x ≥ 0) : x^n ≥ 0 := by sorry
 
-/-- Analogue of Proposition 4.3.10(c) -/
+/-- Analogue of Proposition 4.3.10(c) (positivity) -/
 theorem Real.pow_pos {x:Real} (n:ℕ) (hx: x > 0) : x^n > 0 := by sorry
 
-/-- Analogue of Proposition 4.3.10(c) -/
+/-- Analogue of Proposition 4.3.10(c) (monotone, non-strict) -/
 theorem Real.pow_ge_pow (x y:Real) (n:ℕ) (hxy: x ≥ y) (hy: y ≥ 0) : x^n ≥ y^n := by sorry
 
-/-- Analogue of Proposition 4.3.10(c) -/
+/-- Analogue of Proposition 4.3.10(c) (monotone, strict) -/
 theorem Real.pow_gt_pow (x y:Real) (n:ℕ) (hxy: x > y) (hy: y ≥ 0) (hn: n > 0) : x^n > y^n := by sorry
 
 /-- Analogue of Proposition 4.3.10(d) -/
@@ -75,19 +75,19 @@ lemma Real.zpow_zero (x: Real) : x ^ (0:ℤ) = 1 := by rfl
 
 lemma Real.zpow_neg {x:Real} (n:ℕ) : x^(-n:ℤ) = 1 / (x^n) := by simp
 
-/-- Analogue of Proposition 4.3.12(a) -/
+/-- Analogue of Proposition 4.3.12(a) (sum of exponents) -/
 theorem Real.zpow_add (x:Real) (n m:ℤ) (hx: x ≠ 0): x^n * x^m = x^(n+m) := by sorry
 
-/-- Analogue of Proposition 4.3.12(a) -/
+/-- Analogue of Proposition 4.3.12(a) (product of exponents) -/
 theorem Real.zpow_mul (x:Real) (n m:ℤ) : (x^n)^m = x^(n*m) := by sorry
 
-/-- Analogue of Proposition 4.3.12(a) -/
+/-- Analogue of Proposition 4.3.12(a) (power of a product) -/
 theorem Real.mul_zpow (x y:Real) (n:ℤ) : (x*y)^n = x^n * y^n := by sorry
 
-/-- Analogue of Proposition 4.3.12(b) -/
+/-- Analogue of Proposition 4.3.12(b) (positivity) -/
 theorem Real.zpow_pos {x:Real} (n:ℤ) (hx: x > 0) : x^n > 0 := by sorry
 
-/-- Analogue of Proposition 4.3.12(b) -/
+/-- Analogue of Proposition 4.3.12(b) (monotone) -/
 theorem Real.zpow_ge_zpow {x y:Real} {n:ℤ} (hxy: x ≥ y) (hy: y > 0) (hn: n > 0): x^n ≥ y^n := by sorry
 
 theorem Real.zpow_ge_zpow_ofneg {x y:Real} {n:ℤ} (hxy: x ≥ y) (hy: y > 0) (hn: n < 0) : x^n ≤ y^n := by
@@ -129,10 +129,10 @@ theorem Real.rootset_bddAbove {x:Real} (n:ℕ) (hn: n ≥ 1) : BddAbove { y:Real
 theorem Real.eq_root_iff_pow_eq {x y:Real} (hx: x ≥ 0) (hy: y ≥ 0) {n:ℕ} (hn: n ≥ 1) :
   y = x.root n ↔ y^n = x := by sorry
 
-/-- Lemma 5.6.6 (c) / Exercise 5.6.1 -/
+/-- Lemma 5.6.6 (c) (nonnegativity) / Exercise 5.6.1 -/
 theorem Real.root_nonneg {x:Real} (hx: x ≥ 0) {n:ℕ} (hn: n ≥ 1) : x.root n ≥ 0 := by sorry
 
-/-- Lemma 5.6.6 (c) / Exercise 5.6.1 -/
+/-- Lemma 5.6.6 (c) (positivity) / Exercise 5.6.1 -/
 theorem Real.root_pos {x:Real} (hx: x ≥ 0) {n:ℕ} (hn: n ≥ 1) : x.root n > 0 ↔ x > 0 := by sorry
 
 theorem Real.pow_of_root {x:Real} (hx: x ≥ 0) {n:ℕ} (hn: n ≥ 1) :
@@ -144,13 +144,13 @@ theorem Real.root_of_pow {x:Real} (hx: x ≥ 0) {n:ℕ} (hn: n ≥ 1) :
 /-- Lemma 5.6.6 (d) / Exercise 5.6.1 -/
 theorem Real.root_mono {x y:Real} (hx: x ≥ 0) (hy: y ≥ 0) {n:ℕ} (hn: n ≥ 1) : x > y ↔ x.root n > y.root n := by sorry
 
-/-- Lemma 5.6.6 (e) / Exercise 5.6.1 -/
+/-- Lemma 5.6.6 (e) (base greater than one) / Exercise 5.6.1 -/
 theorem Real.root_mono_of_gt_one {x : Real} (hx: x > 1) {k l: ℕ} (hkl: k > l) (hl: l ≥ 1) : x.root k < x.root l := by sorry
 
-/-- Lemma 5.6.6 (e) / Exercise 5.6.1 -/
+/-- Lemma 5.6.6 (e) (base less than one) / Exercise 5.6.1 -/
 theorem Real.root_mono_of_lt_one {x : Real} (hx0: 0 < x) (hx: x < 1) {k l: ℕ} (hkl: k > l) (hl: l ≥ 1) : x.root k > x.root l := by sorry
 
-/-- Lemma 5.6.6 (e) / Exercise 5.6.1 -/
+/-- Lemma 5.6.6 (e) (base one) / Exercise 5.6.1 -/
 theorem Real.root_of_one {k: ℕ} (hk: k ≥ 1): (1:Real).root k = 1 := by sorry
 
 /-- Lemma 5.6.6 (f) / Exercise 5.6.1 -/
@@ -217,11 +217,11 @@ theorem Real.ratPow_eq_pow {x:Real} (hx: x > 0) (n:ℤ) : x^(n:ℚ) = x^n := by 
 theorem Real.ratPow_pos {x:Real} (hx: x > 0) (q:ℚ) : x^q > 0 := by
   sorry
 
-/-- Lemma 5.6.9(b) / Exercise 5.6.2 -/
+/-- Lemma 5.6.9(b) (sum of exponents) / Exercise 5.6.2 -/
 theorem Real.ratPow_add {x:Real} (hx: x > 0) (q r:ℚ) : x^(q+r) = x^q * x^r := by
   sorry
 
-/-- Lemma 5.6.9(b) / Exercise 5.6.2 -/
+/-- Lemma 5.6.9(b) (product of exponents) / Exercise 5.6.2 -/
 theorem Real.ratPow_ratPow {x:Real} (hx: x > 0) (q r:ℚ) : (x^q)^r = x^(q*r) := by
   sorry
 
@@ -233,11 +233,11 @@ theorem Real.ratPow_neg {x:Real} (hx: x > 0) (q:ℚ) : x^(-q) = 1 / x^q := by
 theorem Real.ratPow_mono {x y:Real} (hx: x > 0) (hy: y > 0) {q:ℚ} (h: q > 0) : x > y ↔ x^q > y^q := by
   sorry
 
-/-- Lemma 5.6.9(e) / Exercise 5.6.2 -/
+/-- Lemma 5.6.9(e) (base greater than one) / Exercise 5.6.2 -/
 theorem Real.ratPow_mono_of_gt_one {x:Real} (hx: x > 1) {q r:ℚ} : x^q > x^r ↔ q > r := by
   sorry
 
-/-- Lemma 5.6.9(e) / Exercise 5.6.2 -/
+/-- Lemma 5.6.9(e) (base less than one) / Exercise 5.6.2 -/
 theorem Real.ratPow_mono_of_lt_one {x:Real} (hx0: 0 < x) (hx: x < 1) {q r:ℚ} : x^q > x^r ↔ q < r := by
   sorry
 


### PR DESCRIPTION
Section 5.6 has eight groups of declarations sharing one docstring:

- `Analogue of Proposition 4.3.10(a)` — 3 (`pow_add`, `pow_mul`, `mul_pow`)
- `Analogue of Proposition 4.3.10(c)` — 4 (nonnegativity, positivity, non-strict and strict monotonicity)
- `Analogue of Proposition 4.3.12(a)` — 3 (the `zpow` versions of the above)
- `Analogue of Proposition 4.3.12(b)` — 2
- `Lemma 5.6.6 (c) / Exercise 5.6.1` — 2
- `Lemma 5.6.6 (e) / Exercise 5.6.1` — 3
- `Lemma 5.6.9(b) / Exercise 5.6.2` — 2
- `Lemma 5.6.9(e) / Exercise 5.6.2` — 2

#616 disambiguated the Chapter 5.4/5.6 *exercise* labels; these are the statement labels in the same file. Each now names the case it covers while keeping the statement number. Docstrings only.

Checked: no duplicate one-line docstrings remain, all edited lines within 100 characters.

`lake build Analysis.Section_5_6` succeeds locally — `✔ [3271/3271] Built Analysis.Section_5_6 (39s)`, `Build completed successfully`.