### PR TITLE
fix: disambiguate duplicate Verso labels in MeasureTheory Section 1.1.3

### DIFF
--- a/Analysis/MeasureTheory/Section_1_1_3.lean
+++ b/Analysis/MeasureTheory/Section_1_1_3.lean
@@ -264,7 +264,7 @@ lemma eq_of_length_zero_of_Icc {I : BoundedInterval}
     rw [h_empty] at h_nonempty
     exact Set.not_nonempty_empty h_nonempty
 
-/-- Definition 1.1.15 (Riemann integrability) -/
+/-- Definition 1.1.15 (Riemann integrability, Riemann sums converge) -/
 -- For a Riemann integrable function, the Riemann sums converge to the integral value.
 lemma riemann_integral_of_integrable {f:ℝ → ℝ} {I: BoundedInterval} (h: RiemannIntegrableOn f I) : riemann_integral_eq f I (riemannIntegral f I) := by
   -- Strategy: Since `h : RiemannIntegrableOn f I` means `∃ R, riemann_integral_eq f I R`,
@@ -277,7 +277,7 @@ lemma riemann_integral_of_integrable {f:ℝ → ℝ} {I: BoundedInterval} (h: Ri
   -- In the `then` branch, we have `h.2.choose = h.2.choose` by reflexivity
   · rfl
 
-/-- Definition 1.1.15 (Riemann integrability) -/
+/-- Definition 1.1.15 (Riemann integrability, characterization) -/
 -- Characterization of the Riemann integral: R is the integral iff the Riemann sums converge to R.
 lemma riemann_integral_eq_iff_of_integrable {f:ℝ → ℝ} {I: BoundedInterval} (h: RiemannIntegrableOn f I) (R:ℝ): riemann_integral_eq f I R ↔ R = riemannIntegral f I := by
   constructor
@@ -752,30 +752,30 @@ def PiecewiseConstantOn (f: ℝ → ℝ) (I: BoundedInterval) : Prop := ∃ F: P
 def PiecewiseConstantFunction.integral {I: BoundedInterval} (g: PiecewiseConstantFunction I) : ℝ :=
   ∑ J : g.T, g.c J * |J|ₗ
 
-/-- Exercise 1.1.20 (Piecewise constant functions) -/
+/-- Exercise 1.1.20 (Piecewise constant functions, integral well-defined) -/
 -- The integral is well-defined: different representations of the same piecewise constant function have the same integral.
 theorem PiecewiseConstantFunction.integral_eq (f: ℝ → ℝ) {I: BoundedInterval} (F F': PiecewiseConstantFunction I) (hF: F.agreesWith f) (hF': F'.agreesWith f) : F.integral = F'.integral := by sorry
 
 -- The integral of a piecewise constant function on I.
 noncomputable def PiecewiseConstantOn.integral (f: ℝ → ℝ) {I: BoundedInterval} (h: PiecewiseConstantOn f I) : ℝ := h.choose.integral
 
-/-- Exercise 1.1.20 (Piecewise constant functions) -/
+/-- Exercise 1.1.20 (Piecewise constant functions, integral of a representation) -/
 -- The integral of a piecewise constant function equals the integral of any of its representations.
 theorem PiecewiseConstantOn.integral_eq (f: ℝ → ℝ) {I: BoundedInterval} (h: PiecewiseConstantOn f I) (F: PiecewiseConstantFunction I) (hF: F.agreesWith f) : h.integral = F.integral := by sorry
 
-/-- Exercise 1.1.21 (a) (Linearity of the piecewise constant integral) -/
+/-- Exercise 1.1.21 (a) (Linearity, scalar multiple is piecewise constant) -/
 -- A scalar multiple of a piecewise constant function is piecewise constant.
 theorem PiecewiseConstantOn.smul {I: BoundedInterval} (c:ℝ) {f: ℝ → ℝ} (h: PiecewiseConstantOn f I) : PiecewiseConstantOn (c • f) I := by sorry
 
-/-- Exercise 1.1.21 (a) (Linearity of the piecewise constant integral) -/
+/-- Exercise 1.1.21 (a) (Linearity, integral of a scalar multiple) -/
 -- The integral is linear: integral(c * f) = c * integral(f).
 theorem PiecewiseConstantFunction.integral_smul {I:BoundedInterval} (c:ℝ) {f: ℝ → ℝ} (h: PiecewiseConstantOn f I) : (h.smul c).integral = c • h.integral := by sorry
 
-/-- Exercise 1.1.21 (a) (Linearity of the piecewise constant integral) -/
+/-- Exercise 1.1.21 (a) (Linearity, sum is piecewise constant) -/
 -- The sum of two piecewise constant functions is piecewise constant.
 theorem PiecewiseConstantOn.add {I: BoundedInterval} {f g: ℝ → ℝ} (hf: PiecewiseConstantOn f I) (hg: PiecewiseConstantOn g I) : PiecewiseConstantOn (f + g) I := by sorry
 
-/-- Exercise 1.1.21 (a) (Linearity of the piecewise constant integral) -/
+/-- Exercise 1.1.21 (a) (Linearity, integral of a sum) -/
 -- The integral is linear: integral(f + g) = integral(f) + integral(g).
 theorem PiecewiseConstantFunction.integral_add {I: BoundedInterval} {f g: ℝ → ℝ} (hf: PiecewiseConstantOn f I) (hg: PiecewiseConstantOn g I) : (hf.add hg).integral = hf.integral + hg.integral := by sorry
 
@@ -783,19 +783,19 @@ theorem PiecewiseConstantFunction.integral_add {I: BoundedInterval} {f g: ℝ �
 -- The integral is monotone: if f ≤ g pointwise, then integral(f) ≤ integral(g).
 theorem PiecewiseConstantFunction.integral_mono {I: BoundedInterval} {f g: ℝ → ℝ} (hf: PiecewiseConstantOn f I) (hg: PiecewiseConstantOn g I) (hmono: ∀ x ∈ I.toSet, f x ≤ g x): hf.integral ≤ hg.integral := by sorry
 
-/-- Exercise 1.1.21 (c) (Piecewise constant integral of indicator functions) -/
+/-- Exercise 1.1.21 (c) (Indicator functions, indicator is piecewise constant) -/
 -- The indicator function of an elementary set is piecewise constant.
 theorem PiecewiseConstantOn.indicator_of_elem (I: BoundedInterval) {E:Set ℝ} (hE: IsElementary (Real.equiv_EuclideanSpace' '' E) ) : PiecewiseConstantOn E.indicator' I := by sorry
 
-/-- Exercise 1.1.21 (c) (Piecewise constant integral of indicator functions) -/
+/-- Exercise 1.1.21 (c) (Indicator functions, integral of an indicator) -/
 -- The integral of an indicator function of an elementary set equals its elementary measure.
 theorem PiecewiseConstantFunction.integral_of_elem {I: BoundedInterval} {E:Set ℝ} (hE: IsElementary (Real.equiv_EuclideanSpace' '' E) ) (hsub: E ⊆ I.toSet) : (PiecewiseConstantOn.indicator_of_elem I hE).integral = hE.measure := by sorry
 
-/-- Definition 1.1.6 (Darboux integral) -/
+/-- Definition 1.1.6 (Darboux integral, lower) -/
 -- The lower Darboux integral: supremum of integrals of piecewise constant functions that underestimate f.
 noncomputable def LowerDarbouxIntegral (f:ℝ → ℝ) (I: BoundedInterval) : ℝ := sSup { R | ∃ g: PiecewiseConstantFunction I, g.integral = R ∧ ∀ x ∈ I.toSet, g.f x ≤ f x }
 
-/-- Definition 1.1.6 (Darboux integral) -/
+/-- Definition 1.1.6 (Darboux integral, upper) -/
 -- The upper Darboux integral: infimum of integrals of piecewise constant functions that overestimate f.
 noncomputable def UpperDarbouxIntegral (f:ℝ → ℝ) (I: BoundedInterval) : ℝ := sInf { R | ∃ h: PiecewiseConstantFunction I, h.integral = R ∧ ∀ x ∈ I.toSet, f x ≤ h.f x }
 
@@ -906,7 +906,7 @@ lemma UpperDarbouxIntegral.bddBelow {f:ℝ → ℝ} {I: BoundedInterval} (M: ℝ
   rw [PiecewiseConstantFunction.integral_mkConst] at h_mono
   exact h_mono
 
-/-- Definition 1.1.6 (Darboux integral) -/
+/-- Definition 1.1.6 (Darboux integral, lower is at most upper) -/
 -- For any bounded function, the lower Darboux integral is at most the upper Darboux integral.
 lemma lower_darboux_le_upper_darboux {f:ℝ → ℝ} {I: BoundedInterval} (hbound: ∃ M, ∀ x ∈ I, |f x| ≤ M) : LowerDarbouxIntegral f I ≤ UpperDarbouxIntegral f I := by
   obtain ⟨M, hM⟩ := hbound
@@ -942,7 +942,7 @@ lemma lower_darboux_le_upper_darboux {f:ℝ → ℝ} {I: BoundedInterval} (hboun
         linarith
       exact PiecewiseConstantFunction.integral_mono' g h h_pointwise
 
-/-- Definition 1.1.6 (Darboux integral) -/
+/-- Definition 1.1.6 (Darboux integral, integrability) -/
 -- A function is Darboux integrable if it is bounded on a nonempty closed interval and its
 -- lower and upper Darboux integrals coincide. Nonemptiness matches {name}`RiemannIntegrableOn`.
 noncomputable def DarbouxIntegrableOn (f:ℝ → ℝ) (I: BoundedInterval) : Prop :=
@@ -973,7 +973,7 @@ lemma UpperDarbouxIntegral.bddBelow_neg {f:ℝ → ℝ} {I: BoundedInterval} (M:
   rw [PiecewiseConstantFunction.integral_mkConst] at h_mono
   exact h_mono
 
-/-- Definition 1.1.6 (Darboux integral) -/
+/-- Definition 1.1.6 (Darboux integral, negation) -/
 -- For the negation of a function, the upper Darboux integral of -f equals minus the lower Darboux integral of f.
 lemma UpperDarbouxIntegral.neg {f:ℝ → ℝ} {I: BoundedInterval} (hbound: ∃ M, ∀ x ∈ I, |f x| ≤ M) : UpperDarbouxIntegral (-f) I = -LowerDarbouxIntegral f I := by
   obtain ⟨M, hM⟩ := hbound
@@ -1034,11 +1034,11 @@ lemma UpperDarbouxIntegral.neg {f:ℝ → ℝ} {I: BoundedInterval} (hbound: ∃
         le_csSup h_bdd h_neg_in_set
       linarith
 
-/-- Exercise 1.1.22 -/
+/-- Exercise 1.1.22 (Riemann and Darboux integrability agree) -/
 -- Riemann integrability is equivalent to Darboux integrability for bounded functions.
 lemma RiemannIntegrableOn.iff_darbouxIntegrable {f:ℝ → ℝ} {I: BoundedInterval} (hbound: ∃ M, ∀ x ∈ I, |f x| ≤ M) : RiemannIntegrableOn f I ↔ DarbouxIntegrableOn f I := by sorry
 
-/-- Exercise 1.1.22 -/
+/-- Exercise 1.1.22 (the two integrals agree) -/
 -- For Riemann integrable functions, the Riemann integral equals the Darboux integral.
 lemma riemann_integral_eq_darboux_integral {f:ℝ → ℝ} {I: BoundedInterval} (hf: RiemannIntegrableOn f I) : riemannIntegral f I = darbouxIntegral f I := by sorry
 
@@ -1100,19 +1100,19 @@ theorem riemann_integral_unique {I: BoundedInterval} (integ: (ℝ → ℝ) → �
   (hindicator: ∀ (E:Set ℝ) (hE: JordanMeasurable (Real.equiv_EuclideanSpace' '' E) ) (hsub: E ⊆ I.toSet), integ E.indicator' = hE.measure) :
   ∀ f, RiemannIntegrableOn f I → integ f = riemannIntegral f I := by sorry
 
-/-- Exercise 1.1.25 (Area interpretation of Riemann integral) -/
+/-- Exercise 1.1.25 (Area interpretation, region under the graph) -/
 -- The region under the graph of a Riemann integrable function is Jordan measurable.
 theorem RiemannIntegrableOn.measurable_upper {I: BoundedInterval}
   {f: ℝ → ℝ} (hfint: RiemannIntegrableOn f I) :
   JordanMeasurable { p:EuclideanSpace' 2 | p 0 ∈ I.toSet ∧ 0 ≤ p 1 ∧ p 1 ≤ f (p 0) } := by sorry
 
-/-- Exercise 1.1.25 (Area interpretation of Riemann integral) -/
+/-- Exercise 1.1.25 (Area interpretation, region below the graph) -/
 -- The region below the graph of a Riemann integrable function is Jordan measurable.
 theorem RiemannIntegrableOn.measurable_lower {I: BoundedInterval}
   {f: ℝ → ℝ} (hfint: RiemannIntegrableOn f I) :
   JordanMeasurable { p:EuclideanSpace' 2 | p 0 ∈ I.toSet ∧ f (p 0) ≤ p 1 ∧ p 1 ≤ 0 } := by sorry
 
-/-- Exercise 1.1.25 (Area interpretation of Riemann integral) -/
+/-- Exercise 1.1.25 (Area interpretation, integrability criterion) -/
 -- A function is Riemann integrable iff the regions above and below its graph are both Jordan measurable.
 theorem JordanMeasurable.iff_integrable {I: BoundedInterval} (hI: I = Icc I.a I.b)
   {f: ℝ → ℝ} (hf: ∃ M, ∀ x ∈ I.toSet, |f x| ≤ M) : RiemannIntegrableOn f I ↔
@@ -1120,7 +1120,7 @@ theorem JordanMeasurable.iff_integrable {I: BoundedInterval} (hI: I = Icc I.a I.
   JordanMeasurable { p:EuclideanSpace' 2 | p 0 ∈ I.toSet ∧ f (p 0) ≤ p 1 ∧ p 1 ≤ 0 }
   := by sorry
 
-/-- Exercise 1.1.25 (Area interpretation of Riemann integral) -/
+/-- Exercise 1.1.25 (Area interpretation, integral as a difference of measures) -/
 -- The Riemann integral equals the difference between the measures of the upper and lower regions.
 theorem RiemannIntegrableOn.eq_measure {I: BoundedInterval}
   {f: ℝ → ℝ} (hfint: RiemannIntegrableOn f I) :


### PR DESCRIPTION
Seven groups of sibling declarations in `MeasureTheory/Section_1_1_3.lean` share a docstring:

| Label | Count |
| --- | --- |
| `Definition 1.1.6 (Darboux integral)` | 5 |
| `Exercise 1.1.21 (a) (Linearity of the piecewise constant integral)` | 4 |
| `Exercise 1.1.25 (Area interpretation of Riemann integral)` | 4 |
| `Definition 1.1.15 (Riemann integrability)` | 2 |
| `Exercise 1.1.20 (Piecewise constant functions)` | 2 |
| `Exercise 1.1.21 (c) (Piecewise constant integral of indicator functions)` | 2 |
| `Exercise 1.1.22` | 2 |

Same convention as #624: keep the statement number, name the case in the parenthetical. The case names are not invented — each is taken from the `--` comment already sitting between the docstring and the declaration (e.g. "The lower Darboux integral: …" → `(Darboux integral, lower)`).

The two long labels were shortened to `(Linearity, …)` and `(Area interpretation, …)` so the lines stay inside the 100-character limit; the exercise number still identifies the statement.

Checked: no duplicate one-line docstrings remain in the file, all edited lines within 100 characters.

`lake build Analysis.MeasureTheory.Section_1_1_3` succeeds locally — `✔ [3281/3281] Built (19s)`, `Build completed successfully`.

Chosen to avoid the files our other open PRs touch (#647 Section_1_3_2, #648 Section_1_1_2, #649/#650 Section_1_2_0, #646 Section_1_4_2), so this does not collide with any of them.