### PR TITLE
feat(MeasureTheory): elementary sets are Jordan measurable

### DIFF
--- a/Analysis/MeasureTheory/Section_1_1_2.lean
+++ b/Analysis/MeasureTheory/Section_1_1_2.lean
@@ -260,6 +260,41 @@ theorem JordanMeasurable.equiv {d:ℕ} {E: Set (EuclideanSpace' d)} (hE: Bornolo
   ∀ ε>0, ∃ A, ∃ hA: IsElementary A, Jordan_outer_measure (symmDiff E A) ≤ ε].TFAE := by
   sorry
 
+/-- An elementary set is bounded: it is a finite union of boxes, and each box sits inside
+the closed ball of radius the norm of its corner. -/
+theorem IsElementary.isBounded {d:ℕ} {E: Set (EuclideanSpace' d)} (hE: IsElementary E) :
+    Bornology.IsBounded E := by
+  classical
+  obtain ⟨S, rfl⟩ := hE
+  rw [Bornology.isBounded_biUnion_finset]
+  intro B _
+  -- each coordinate of a point of `B` is trapped between the endpoints of that side
+  set M : ℝ := Real.sqrt (∑ i, (max |(B.side i).a| |(B.side i).b|)^2) with hM
+  rw [Metric.isBounded_iff_subset_closedBall 0]
+  refine ⟨M, fun x hx ↦ ?_⟩
+  rw [Metric.mem_closedBall, dist_zero_right]
+  have hcoord (i : Fin d) : |x i| ≤ max |(B.side i).a| |(B.side i).b| := by
+    have hxi : x i ∈ ((B.side i : BoundedInterval) : Set ℝ) := hx i
+    have hsub := (B.side i).subset_Icc
+    rw [BoundedInterval.subset_iff] at hsub
+    have hmem := hsub hxi
+    simp only [BoundedInterval.set_Icc, Set.mem_Icc] at hmem
+    rcases abs_cases (x i) with ⟨h, -⟩ | ⟨h, -⟩
+    · calc |x i| = x i := h
+        _ ≤ (B.side i).b := hmem.2
+        _ ≤ |(B.side i).b| := le_abs_self _
+        _ ≤ _ := le_max_right _ _
+    · calc |x i| = -x i := h
+        _ ≤ -(B.side i).a := by linarith [hmem.1]
+        _ ≤ |(B.side i).a| := neg_le_abs _
+        _ ≤ _ := le_max_left _ _
+  rw [EuclideanSpace'.norm_eq, hM]
+  apply Real.sqrt_le_sqrt
+  refine Finset.sum_le_sum (fun i _ ↦ ?_)
+  calc (x i)^2 = |x i|^2 := (sq_abs _).symm
+    _ ≤ (max |(B.side i).a| |(B.side i).b|)^2 := by
+        nlinarith [hcoord i, abs_nonneg (x i)]
+
 /-- Every elementary set is Jordan measurable. -/
 theorem IsElementary.jordanMeasurable {d:ℕ} {E: Set (EuclideanSpace' d)} (hE: IsElementary E) : JordanMeasurable E := by
   sorry
@@ -277,8 +312,6 @@ theorem JordanMeasurable.empty (d:ℕ) : JordanMeasurable (∅: Set (EuclideanSp
 theorem JordanMeasurable.mes_of_empty (d:ℕ) : (JordanMeasurable.empty d).measure = 0 := by
   sorry
 
-
-/-- Exercise 1.1.6 (i) (Boolean closure) -/
 theorem JordanMeasurable.union {d:ℕ} {E F : Set (EuclideanSpace' d)}
   (hE: JordanMeasurable E) (hF: JordanMeasurable F) : JordanMeasurable (E ∪ F) := by
   -- Since $E$ and $F$ are both Jordan measurable, they are bounded.

--- a/Analysis/MeasureTheory/Section_1_1_2.lean
+++ b/Analysis/MeasureTheory/Section_1_1_2.lean
@@ -297,21 +297,29 @@ theorem IsElementary.isBounded {d:ℕ} {E: Set (EuclideanSpace' d)} (hE: IsEleme
 
 /-- Every elementary set is Jordan measurable. -/
 theorem IsElementary.jordanMeasurable {d:ℕ} {E: Set (EuclideanSpace' d)} (hE: IsElementary E) : JordanMeasurable E := by
-  sorry
+  refine ⟨hE.isBounded, le_antisymm (Jordan_inner_le_outer hE.isBounded) ?_⟩
+  -- outer ≤ measure ≤ inner, taking `E` itself as the enclosing and the enclosed set
+  exact (Jordan_outer_le hE (Set.Subset.refl E)).trans
+    (le_Jordan_inner hE (Set.Subset.refl E) hE.isBounded)
 
 /-- The Jordan measure of an elementary set equals its elementary measure. -/
 theorem JordanMeasurable.mes_of_elementary {d:ℕ} {E: Set (EuclideanSpace' d)} (hE: IsElementary E) : hE.jordanMeasurable.measure = hE.measure := by
-  sorry
+  refine le_antisymm ?_ (le_Jordan_inner hE (Set.Subset.refl E) hE.isBounded)
+  rw [JordanMeasurable.eq_outer hE.jordanMeasurable]
+  exact Jordan_outer_le hE (Set.Subset.refl E)
 
 /-- The empty set is Jordan measurable. -/
-theorem JordanMeasurable.empty (d:ℕ) : JordanMeasurable (∅: Set (EuclideanSpace' d)) := by
-  sorry
+theorem JordanMeasurable.empty (d:ℕ) : JordanMeasurable (∅: Set (EuclideanSpace' d)) :=
+  IsElementary.jordanMeasurable (IsElementary.empty d)
 
 /-- The empty set has Jordan measure zero. -/
 @[simp]
 theorem JordanMeasurable.mes_of_empty (d:ℕ) : (JordanMeasurable.empty d).measure = 0 := by
-  sorry
+  have h := JordanMeasurable.mes_of_elementary (IsElementary.empty d)
+  rwa [IsElementary.measure_of_empty] at h
 
+
+/-- Exercise 1.1.6 (i) (Boolean closure) -/
 theorem JordanMeasurable.union {d:ℕ} {E F : Set (EuclideanSpace' d)}
   (hE: JordanMeasurable E) (hF: JordanMeasurable F) : JordanMeasurable (E ∪ F) := by
   -- Since $E$ and $F$ are both Jordan measurable, they are bounded.

--- a/Analysis/MeasureTheory/Section_1_1_2.lean
+++ b/Analysis/MeasureTheory/Section_1_1_2.lean
@@ -143,7 +143,18 @@ theorem Jordan_inner_le_outer {d:ℕ} {E: Set (EuclideanSpace' d)} (hE: Bornolog
 
 /-- Elementary measure of a subset is a lower bound for inner Jordan measure. -/
 theorem le_Jordan_inner {d:ℕ} {E A: Set (EuclideanSpace' d)}
-  (hA: IsElementary A) (hAE: A ⊆ E) : hA.measure ≤ Jordan_inner_measure A := by
+  (hA: IsElementary A) (hAE: A ⊆ E) (hE: Bornology.IsBounded E) :
+  hA.measure ≤ Jordan_inner_measure E := by
+  -- `hA.measure` is one of the numbers the supremum ranges over, and the whole
+  -- family is bounded above by the measure of an elementary set containing `E`.
+  obtain ⟨C, hC, hEC⟩ := IsElementary.contains_bounded hE
+  refine le_csSup ⟨hC.measure, ?_⟩ ⟨A, hA, hAE, rfl⟩
+  rintro m ⟨B, hB, hBE, rfl⟩
+  exact IsElementary.measure_mono hB hC (hBE.trans hEC)
+
+/-- The elementary measure of a set is a lower bound for its own inner Jordan measure. -/
+theorem le_Jordan_inner_self {d:ℕ} {A: Set (EuclideanSpace' d)}
+  (hA: IsElementary A) : hA.measure ≤ Jordan_inner_measure A := by
   -- Strategy:
   -- 1. Unfold definition: Jordan_inner_measure A = sSup { m | ∃ B, IsElementary B, B ⊆ A ∧ m = hB.measure }
   -- 2. Show hA.measure is in this set: use A itself (A ⊆ A, and hA.measure = hA.measure)
@@ -165,7 +176,16 @@ theorem le_Jordan_inner {d:ℕ} {E A: Set (EuclideanSpace' d)}
 
 /-- Elementary measure of a superset is an upper bound for outer Jordan measure. -/
 theorem Jordan_outer_le {d:ℕ} {E A: Set (EuclideanSpace' d)}
-  (hA: IsElementary A) (hAE: E ⊆ A) : Jordan_outer_measure A ≤ hA.measure := by
+  (hA: IsElementary A) (hAE: E ⊆ A) : Jordan_outer_measure E ≤ hA.measure := by
+  -- `hA.measure` is one of the numbers the infimum ranges over, and they are all
+  -- non-negative.
+  refine csInf_le ⟨0, ?_⟩ ⟨A, hA, hAE, rfl⟩
+  rintro m ⟨B, hB, -, rfl⟩
+  exact IsElementary.measure_nonneg hB
+
+/-- The elementary measure of a set is an upper bound for its own outer Jordan measure. -/
+theorem Jordan_outer_le_self {d:ℕ} {A: Set (EuclideanSpace' d)}
+  (hA: IsElementary A) : Jordan_outer_measure A ≤ hA.measure := by
   -- Strategy:
   -- 1. Unfold definition: Jordan_outer_measure A = sInf { m | ∃ B, IsElementary B, A ⊆ B ∧ m = hB.measure }
   -- 2. Show hA.measure is in this set: use A itself (A ⊆ A, and hA.measure = hA.measure)

--- a/Analysis/MeasureTheory/Section_1_2_1.lean
+++ b/Analysis/MeasureTheory/Section_1_2_1.lean
@@ -2562,15 +2562,6 @@ lemma Box.shrink_to_closed {d:ℕ} (B: Box d) (hB: B.toSet.Nonempty) (δ: ℝ) (
       simp only [B', BoundedInterval.toSet, Set.mem_Icc, le_refl, and_self]
 
 namespace IsElementary
-/-- Elementary sets are bounded (finite union of bounded boxes) -/
-lemma isBounded {d:ℕ} {E: Set (EuclideanSpace' d)} (hE: IsElementary E) :
-    Bornology.IsBounded E := by
-  obtain ⟨S, hS_eq⟩ := hE
-  rw [hS_eq]
-  rw [Bornology.isBounded_biUnion_finset]
-  intro B _
-  exact Box.isBounded B
-
 /-- Elementary measure of empty set is zero (handles proof term mismatch) -/
 lemma measure_of_empty_eq {d : ℕ} {E : Set (EuclideanSpace' d)}
     (hE : IsElementary E) (hempty : E = ∅) : hE.measure = 0 := by


### PR DESCRIPTION
Four `sorry`s in `Analysis/MeasureTheory/Section_1_1_2.lean` — `IsElementary.jordanMeasurable`, `JordanMeasurable.mes_of_elementary`, `JordanMeasurable.empty`, `JordanMeasurable.mes_of_empty`.

The interesting part is the first commit, which is a statement fix rather than a proof. `le_Jordan_inner` and `Jordan_outer_le` each take a hypothesis relating `A` to `E` and then state a bound about `A` alone:

```lean
theorem le_Jordan_inner (hA: IsElementary A) (hAE: A ⊆ E) : hA.measure ≤ Jordan_inner_measure A
theorem Jordan_outer_le  (hA: IsElementary A) (hAE: E ⊆ A) : Jordan_outer_measure A ≤ hA.measure
```

`hAE` is unused in both, and neither says anything about `E` — so neither can be used for what the names suggest, sandwiching the measures of a set between the elementary sets inside and outside it. Restated about `E`; the inner one needs `E` bounded, since otherwise the supremum ranges over an unbounded family. The old statements survive as `le_Jordan_inner_self` / `Jordan_outer_le_self` (the `A = E` case), which is what the existing call sites in Section_1_2_0 and Section_1_2_1 use.

With that, the four proofs are short: outer ≤ elementary measure ≤ inner, and inner ≤ outer.

The one supporting fact needed is that an elementary set is bounded. Section_1_2_1 already had `IsElementary.isBounded`, a thousand lines into a later chapter where nothing earlier could reach it, so the last commit moves the fact to where elementary sets are introduced and deletes the copy.

`lake build Analysis.MeasureTheory.Section_1_1_2 Analysis.MeasureTheory.Section_1_2_0 Analysis.MeasureTheory.Section_1_2_1` → `Build completed successfully (3286 jobs).`, no warnings; `sorry` count in Section_1_1_2 drops from 43 to 39.